### PR TITLE
fix: replace corepack with direct pnpm install in Docker musl build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           image: ${{ matrix.docker }}
           options: '--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build'
           run: |
-            corepack enable
+            npm install -g pnpm@10
             pnpm --filter @amigo-labs/${{ needs.resolve.outputs.crate }} run build --target ${{ matrix.target }}
 
       - name: Build (Native)


### PR DESCRIPTION
The napi-rs Docker image (lts-alpine) ships Node.js 18 with an outdated corepack that fails signature verification for newer pnpm versions. Installing pnpm directly via npm bypasses this issue.

https://claude.ai/code/session_01XNpMRZUXJWtup5pbXqH1nz