### PR TITLE
fix: replace outdated Docker musl build with native musl-tools

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,6 @@
-# Cross-compile linker config
-# Required for cross-compiling to aarch64 on x86_64 runners
+# Cross-compile linker config for CI
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+[target.x86_64-unknown-linux-musl]
+linker = "musl-gcc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
             host: ubuntu-latest
           - target: x86_64-unknown-linux-musl
             host: ubuntu-latest
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           - target: aarch64-unknown-linux-gnu
             host: ubuntu-latest
           - target: x86_64-apple-darwin
@@ -79,24 +78,19 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
+      - name: Install cross-compilation tools (aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
-      - name: Build (Docker)
-        if: matrix.docker
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ matrix.docker }}
-          options: '--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build'
-          run: |
-            npm install -g pnpm@10
-            pnpm --filter @amigo-labs/${{ needs.resolve.outputs.crate }} run build --target ${{ matrix.target }}
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
 
-      - name: Build (Native)
-        if: ${{ !matrix.docker }}
+      - name: Build
         shell: bash
         run: pnpm --filter @amigo-labs/${{ needs.resolve.outputs.crate }} run build --target ${{ matrix.target }}
 


### PR DESCRIPTION
The napi-rs Docker image (lts-alpine) ships Node 18 which is incompatible with current dependencies (styleText requires Node 20+). Replace with native musl-tools on the Ubuntu runner, which uses the same Node 24 as all other build targets.

https://claude.ai/code/session_01XNpMRZUXJWtup5pbXqH1nz