### PR TITLE
fix: statically link libgcc for musl target to fix build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,4 @@ linker = "aarch64-linux-gnu-gcc"
 
 [target.x86_64-unknown-linux-musl]
 linker = "musl-gcc"
+rustflags = ["-C", "link-arg=-static-libgcc"]


### PR DESCRIPTION
The musl build fails with "cannot find libgcc_s.so.1" because Rust tries to dynamically link libgcc_s when building a cdylib. Pass -static-libgcc to musl-gcc so it links libgcc statically instead.

https://claude.ai/code/session_01BqYMKXpNiUaCXmhLFEL6yJ