### PR TITLE
fix: provide libgcc_s linker script for musl cdylib builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,3 @@ linker = "aarch64-linux-gnu-gcc"
 
 [target.x86_64-unknown-linux-musl]
 linker = "musl-gcc"
-rustflags = ["-C", "link-arg=-static-libgcc"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
+          # Rust explicitly passes -lgcc_s when linking cdylib targets, but the
+          # musl toolchain only ships the static libgcc.a. Create a linker script
+          # that redirects -lgcc_s to the static archive.
+          sudo sh -c 'echo "GROUP ( libgcc.a )" > /usr/lib/x86_64-linux-musl/libgcc_s.so'
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           cd crates/${{ needs.resolve.outputs.crate }}
-          npm version ${{ needs.resolve.outputs.version }} --no-git-tag-version
+          npm version ${{ needs.resolve.outputs.version }} --no-git-tag-version --allow-same-version
 
       - uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
The previous -static-libgcc approach didn't work because Rust explicitly injects -lgcc_s into the linker command, bypassing GCC driver flags.

Instead, create a linker script at /usr/lib/x86_64-linux-musl/libgcc_s.so that redirects to the static libgcc.a. When the linker encounters -lgcc_s, it finds this script and resolves it to the static archive, avoiding the missing libgcc_s.so.1 error.

https://claude.ai/code/session_01BqYMKXpNiUaCXmhLFEL6yJ