### PR TITLE
fix(docs): render benchmark charts for all 15 crates

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -97,14 +97,9 @@ function formatBytes(bytes) {
   if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(0) + ' KB';
   return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
 }
-function detectCrate(name) {
-  const l = name.toLowerCase();
-  if (l.includes('slugify')) return 'slugify';
-  if (l.includes('argon2')) return 'argon2';
-  if (l.includes('xxh')) return 'xxhash';
-  if (l.includes('sanitize')) return 'sanitize-html';
-  if (l.includes('csv')) return 'csv';
-  return 'other';
+function suiteCrate(suite) {
+  const m = suite.file?.match(/^crates\/([^/]+)\//);
+  return m ? m[1] : null;
 }
 
 // --- boot ---
@@ -431,7 +426,7 @@ function renderBench(pkg) {
     host.innerHTML = '<div style="color:var(--text-tertiary);font-size:.75rem">No benchmark data available.</div>';
     return;
   }
-  const suites = state.data.benchmarks.suites.filter(s => detectCrate(s.name) === pkg.name);
+  const suites = state.data.benchmarks.suites.filter(s => suiteCrate(s) === pkg.name);
   if (!suites.length) {
     host.innerHTML = '<div style="color:var(--text-tertiary);font-size:.75rem">No benchmarks for this package yet.</div>';
     return;
@@ -441,7 +436,7 @@ function renderBench(pkg) {
     const entries = suite.entries.filter(e => e.hz > 0);
     if (!entries.length) continue;
     const maxHz = Math.max(...entries.map(e => e.hz));
-    const scenario = suite.name.split(' - ').slice(1).join(' - ') || suite.name;
+    const scenario = suite.name.replace(/^[^\s]+\s+[-—]\s+/, '') || suite.name;
     html += `<div class="slab-col-sub">${scenario}</div>`;
     const sorted = [...entries].sort((a, b) => b.hz - a.hz);
     for (const entry of sorted) {

--- a/docs/app.js
+++ b/docs/app.js
@@ -14,10 +14,17 @@ const state = {
 // parses strings like "3-7x faster", "1.4-2.5× faster", returns max value
 function parseMaxSpeedup(s) {
   if (!s) return 0;
-  const matches = s.match(/(\d+(?:\.\d+)?)/g);
-  if (!matches) return 0;
-  const nums = matches.map(Number);
-  return Math.max(...nums);
+  let best = -Infinity;
+  for (const part of s.split('/')) {
+    const nums = part.match(/(\d+(?:\.\d+)?)/g);
+    if (!nums) continue;
+    const n = Math.max(...nums.map(Number));
+    const dir = /slower/i.test(part) ? -1 : /faster/i.test(part) ? 1 : 0;
+    if (dir === 0) continue;
+    const v = dir * n;
+    if (v > best) best = v;
+  }
+  return best === -Infinity ? 0 : best;
 }
 
 // returns how much smaller amigo is vs. the largest competitor for this pkg

--- a/docs/packages.json
+++ b/docs/packages.json
@@ -145,7 +145,7 @@
       "name": "xml",
       "title": "XML",
       "description": "SAX-style XML parser via quick-xml.",
-      "speedup": "1.7–2.8× slower",
+      "speedup": "2.8× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/xml",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/xml",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/xml/README.md"

--- a/docs/packages.json
+++ b/docs/packages.json
@@ -55,7 +55,7 @@
       "name": "slugify",
       "title": "Slugify",
       "description": "Unicode-aware slugification. Wraps deunicode + unicode-normalization.",
-      "speedup": "3–7× faster",
+      "speedup": "2.7–4.7× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/slugify",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/slugify",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/slugify/README.md"
@@ -64,7 +64,7 @@
       "name": "argon2",
       "title": "Argon2",
       "description": "Argon2id password hashing with sync + async API.",
-      "speedup": "1.4–2.5× faster",
+      "speedup": "1.35× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/argon2",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/argon2",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/argon2/README.md"
@@ -73,7 +73,7 @@
       "name": "xxhash",
       "title": "XXHash",
       "description": "XXH32, XXH64, and XXH3 with batch + streaming support.",
-      "speedup": "1.3–2.6× faster",
+      "speedup": "up to 2.7× faster / 5.7× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/xxhash",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/xxhash",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/xxhash/README.md"
@@ -82,7 +82,7 @@
       "name": "sanitize-html",
       "title": "Sanitize HTML",
       "description": "HTML sanitization via Mozilla's ammonia engine.",
-      "speedup": "1.6–2× faster",
+      "speedup": "1.71–2× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/sanitize-html",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/sanitize-html",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/sanitize-html/README.md"
@@ -91,7 +91,7 @@
       "name": "csv",
       "title": "CSV",
       "description": "CSV parsing and serialization via BurntSushi's csv crate.",
-      "speedup": "1.4–3.5× faster",
+      "speedup": "1.08–1.27× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/csv",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/csv",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/csv/README.md"
@@ -100,7 +100,7 @@
       "name": "file-type",
       "title": "File Type",
       "description": "Magic-byte file-type detection via the Rust infer crate.",
-      "speedup": "TBD",
+      "speedup": "25–993× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/file-type",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/file-type",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/file-type/README.md"
@@ -109,7 +109,7 @@
       "name": "inflate",
       "title": "Inflate",
       "description": "zlib deflate/inflate/gzip powered by flate2 + zlib-rs.",
-      "speedup": "TBD",
+      "speedup": "up to 12× faster / 1.32× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/inflate",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/inflate",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/inflate/README.md"
@@ -118,7 +118,7 @@
       "name": "levenshtein",
       "title": "Levenshtein",
       "description": "Edit distance via triple_accel (SIMD) with a strsim fallback.",
-      "speedup": "TBD",
+      "speedup": "7.5× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/levenshtein",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/levenshtein",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/levenshtein/README.md"
@@ -127,7 +127,7 @@
       "name": "nanoid",
       "title": "NanoID",
       "description": "Crypto-safe URL-friendly ID generator via the nanoid Rust crate.",
-      "speedup": "TBD",
+      "speedup": "1.14–4.6× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/nanoid",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/nanoid",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/nanoid/README.md"
@@ -136,7 +136,7 @@
       "name": "encoding",
       "title": "Encoding",
       "description": "Character encoding conversion powered by Mozilla's encoding_rs.",
-      "speedup": "TBD",
+      "speedup": "1.59–28× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/encoding",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/encoding",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/encoding/README.md"
@@ -145,7 +145,7 @@
       "name": "xml",
       "title": "XML",
       "description": "SAX-style XML parser via quick-xml.",
-      "speedup": "TBD",
+      "speedup": "1.7–2.8× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/xml",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/xml",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/xml/README.md"
@@ -154,7 +154,7 @@
       "name": "deep-equal",
       "title": "Deep Equal",
       "description": "Deep structural equality for JSON-safe values.",
-      "speedup": "TBD",
+      "speedup": "up to 1.39× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/deep-equal",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/deep-equal",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/deep-equal/README.md"
@@ -163,7 +163,7 @@
       "name": "deepmerge",
       "title": "Deepmerge",
       "description": "Recursive object merge for JSON-safe values.",
-      "speedup": "TBD",
+      "speedup": "2.9–6× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/deepmerge",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/deepmerge",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/deepmerge/README.md"
@@ -172,7 +172,7 @@
       "name": "jwt",
       "title": "JWT",
       "description": "JWT sign, verify, and decode via the jsonwebtoken Rust crate.",
-      "speedup": "TBD",
+      "speedup": "1.65–7.7× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/jwt",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/jwt",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/jwt/README.md"
@@ -181,7 +181,7 @@
       "name": "zip",
       "title": "ZIP",
       "description": "ZIP archive read/write via the zip Rust crate.",
-      "speedup": "TBD",
+      "speedup": "up to 11× faster / 2.1× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/zip",
       "sourceUrl": "https://github.com/amigo-labs/amigo-native/tree/main/crates/zip",
       "readmeUrl": "https://github.com/amigo-labs/amigo-native/blob/main/crates/zip/README.md"

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -60,6 +60,7 @@ a:hover { color: var(--text-primary); }
 .app {
   display: grid;
   grid-template-rows: auto auto 1fr auto;
+  grid-template-columns: minmax(0, 1fr);
   height: 100vh;
   max-width: 1200px;
   margin: 0 auto;
@@ -132,7 +133,7 @@ a:hover { color: var(--text-primary); }
 
 /* DASHBOARD */
 .dashboard {
-  display: grid; grid-template-columns: 260px 1fr;
+  display: grid; grid-template-columns: 260px minmax(0, 1fr);
   gap: 24px; padding: 24px 0;
   overflow: hidden; min-height: 0;
 }
@@ -255,6 +256,8 @@ a:hover { color: var(--text-primary); }
   padding: 6px 12px; border-radius: 6px;
   background: var(--accent-dim); color: var(--accent);
   white-space: nowrap;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 .slab-desc {
   color: var(--text-secondary);
@@ -382,7 +385,7 @@ a:hover { color: var(--text-primary); }
 }
 
 @media (max-width: 900px) {
-  body { overflow: auto; }
+  body { overflow-x: hidden; overflow-y: auto; }
   .app { height: auto; min-height: 100vh; padding: 0 16px; }
 
   .hero { flex-wrap: wrap; gap: 12px; padding: 16px 0 12px; }
@@ -397,7 +400,7 @@ a:hover { color: var(--text-primary); }
   .marquee-item { font-size: 0.65rem; }
 
   .dashboard {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     overflow: visible; padding: 16px 0;
     gap: 16px;
   }
@@ -429,7 +432,7 @@ a:hover { color: var(--text-primary); }
   .slab { padding: 18px; overflow-x: hidden; overflow-y: visible; border-radius: 12px; min-width: 0; max-width: 100%; }
   .slab-head { gap: 10px; flex-wrap: wrap; max-width: 100%; }
   .slab-name { font-size: 1.05rem; overflow-wrap: anywhere; word-break: break-all; min-width: 0; flex: 1 1 auto; }
-  .slab-speedup { font-size: 0.68rem; padding: 4px 8px; flex: 0 0 auto; }
+  .slab-speedup { font-size: 0.68rem; padding: 4px 8px; flex: 0 1 auto; white-space: normal; }
   .slab-desc { font-size: 0.95rem; margin: 12px 0 18px; }
 
   .slab-install {

--- a/scripts/generate-report.mjs
+++ b/scripts/generate-report.mjs
@@ -326,15 +326,31 @@ function formatRatio(x) {
   return Math.round(x).toString()
 }
 
+function entryVariant(name) {
+  const i = name.indexOf(' ')
+  return i === -1 ? '' : name.slice(i + 1)
+}
+
 function computeSpeedupString(suites) {
   const ratios = []
   for (const suite of suites) {
-    const amigo = suite.entries.find((e) => e.name.includes('@amigo') && e.hz > 0)
+    const amigoEntries = suite.entries.filter((e) => e.name.includes('@amigo') && e.hz > 0)
     const competitors = suite.entries.filter((e) => !e.name.includes('@amigo') && e.hz > 0)
-    if (!amigo || !competitors.length) continue
-    // fastest competitor per suite → most conservative claim
-    const bestHz = Math.max(...competitors.map((e) => e.hz))
-    ratios.push(amigo.hz / bestHz)
+    if (!amigoEntries.length || !competitors.length) continue
+    // Variant-match only when a suite has multiple amigo variants (e.g. encoding
+    // small/100KB/10MB): otherwise the variant suffix encodes library qualifiers
+    // (`slugify (npm)`, `file-type (upstream async)`) and strict matching would
+    // discard the legitimate 1-vs-1 comparison.
+    const variantMatch = new Set(amigoEntries.map((e) => entryVariant(e.name))).size > 1
+    for (const amigo of amigoEntries) {
+      const pool = variantMatch
+        ? competitors.filter((e) => entryVariant(e.name) === entryVariant(amigo.name))
+        : competitors
+      if (!pool.length) continue
+      // fastest competitor in pool → most conservative claim
+      const bestHz = Math.max(...pool.map((e) => e.hz))
+      ratios.push(amigo.hz / bestHz)
+    }
   }
   if (!ratios.length) return 'TBD'
   const min = Math.min(...ratios)

--- a/scripts/generate-report.mjs
+++ b/scripts/generate-report.mjs
@@ -317,3 +317,61 @@ const docsDir = join(root, 'docs')
 const docsPath = join(docsDir, 'data.json')
 writeFileSync(docsPath, JSON.stringify(docsData, null, 2))
 console.log(`Written to ${docsPath}`)
+
+// --- Refresh docs/packages.json speedup strings ---
+
+function formatRatio(x) {
+  if (x < 2) return x.toFixed(2).replace(/\.?0+$/, '')
+  if (x < 10) return x.toFixed(1).replace(/\.0$/, '')
+  return Math.round(x).toString()
+}
+
+function computeSpeedupString(suites) {
+  const ratios = []
+  for (const suite of suites) {
+    const amigo = suite.entries.find((e) => e.name.includes('@amigo') && e.hz > 0)
+    const competitors = suite.entries.filter((e) => !e.name.includes('@amigo') && e.hz > 0)
+    if (!amigo || !competitors.length) continue
+    // fastest competitor per suite → most conservative claim
+    const bestHz = Math.max(...competitors.map((e) => e.hz))
+    ratios.push(amigo.hz / bestHz)
+  }
+  if (!ratios.length) return 'TBD'
+  const min = Math.min(...ratios)
+  const max = Math.max(...ratios)
+  if (min >= 1.05) {
+    const lo = formatRatio(min)
+    const hi = formatRatio(max)
+    return lo === hi ? `${lo}× faster` : `${lo}–${hi}× faster`
+  }
+  if (max <= 0.95) {
+    const lo = formatRatio(1 / max)
+    const hi = formatRatio(1 / min)
+    return lo === hi ? `${lo}× slower` : `${lo}–${hi}× slower`
+  }
+  // Mixed: show best win and worst regression
+  const winners = ratios.filter((r) => r >= 1.05)
+  const losers = ratios.filter((r) => r <= 0.95)
+  const parts = []
+  if (winners.length) parts.push(`up to ${formatRatio(Math.max(...winners))}× faster`)
+  if (losers.length) parts.push(`${formatRatio(1 / Math.min(...losers))}× slower`)
+  return parts.length ? parts.join(' / ') : '~equal'
+}
+
+const packagesPath = join(docsDir, 'packages.json')
+if (benchData?.suites?.length && existsSync(packagesPath)) {
+  const packagesData = JSON.parse(readFileSync(packagesPath, 'utf-8'))
+  const suitesByCrate = new Map()
+  for (const suite of benchData.suites) {
+    const m = suite.file?.match(/^crates\/([^/]+)\//)
+    if (!m) continue
+    if (!suitesByCrate.has(m[1])) suitesByCrate.set(m[1], [])
+    suitesByCrate.get(m[1]).push(suite)
+  }
+  for (const pkg of packagesData.packages ?? []) {
+    const suites = suitesByCrate.get(pkg.name)
+    if (suites?.length) pkg.speedup = computeSpeedupString(suites)
+  }
+  writeFileSync(packagesPath, JSON.stringify(packagesData, null, 2) + '\n')
+  console.log(`Updated speedup strings in ${packagesPath}`)
+}


### PR DESCRIPTION
Dashboard showed "No benchmarks for this package yet." for 10 of 15
packages because detectCrate() only mapped suites for slugify, argon2,
xxhash, sanitize-html, and csv. Switch to suiteCrate() which derives the
crate name from suite.file (crates/<name>/__bench__/...), so every
package in packages.json automatically gets its suites rendered.

Also broaden the scenario-label stripper to handle both " - " and " — "
prefixes — 10 of the crates use an em-dash in their bench names and
would otherwise render with a redundant "crate — " prefix.

https://claude.ai/code/session_01Ki9JLxfd7fNfwEjB3LAdWP