### PR TITLE
feat(skill): add rust-check for single-package perf-review

### DIFF
--- a/.claude/skills/rust-check/SKILL.md
+++ b/.claude/skills/rust-check/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: rust-check
+description: Evaluate a single package against the amigo-native perf-review framework and decide keep-great-or-kill. Takes one package name (argument or prompted) and auto-detects the mode — an existing `crates/*` entry gets a measurement-based Green/Yellow/Red/Black classification with a Phase-C optimization plan or a Phase-D deprecation path, while an unknown npm name gets a candidate assessment with FFI-overhead heuristics, a BACKLOG check, a scan for a usable Rust crate, and a go/no-go prediction. Output is a single decision doc at `docs/perf-review/<pkg>.md`; the skill never touches crate source, benchmarks, docs/packages.json, or BACKLOG.md. Use when deciding whether to port a new npm package, when a released crate looks weak in BENCHMARKS.md, before deprecating or archiving a package, or for the quarterly re-review of already-shipped crates.
+---
+
+# rust-check
+
+Evaluate **one** package against the amigo-native perf-review framework. Every `@amigo-labs/*` crate must be measurably faster, smaller, or safer than its JS original — this skill turns that principle into a repeatable, unsentimental decision for one package at a time.
+
+## When to use
+
+- Considering a new npm package to port (candidate mode)
+- A released crate under-performs vs. its BENCHMARKS.md promise (review mode)
+- Before deprecating or archiving a package (review mode → Phase-D plan)
+- Quarterly re-review cycle — V8 moves, Rust crates improve, the calculus changes
+
+## Two hard rules
+
+Keep these visible while writing the review. They are the whole point.
+
+1. **"Fast at all costs" does not count.** Synthetic-benchmark wins without a realistic median use-case are disqualifying. Always state the real use-case explicitly in the report — if the bench file only covers cherry-picked large inputs, flag it as a benchmark gap and downgrade one tier until the gap is closed.
+2. **No sunk-cost.** The classification thresholds do not care how long the crate took to build. A Red is a Red.
+
+## Classification thresholds
+
+| Label | Criteria |
+|---|---|
+| 🟢 Green | ≥2× speedup at medium/large inputs AND ≥1× at the smallest realistic input; parity high. |
+| 🟡 Yellow | ≥2× at large but <1× at small, or ~1.5× across the board, or bundle/startup cost eats the gain for short-lived processes. |
+| 🔴 Red | <1.5× even at large, or slower than JS at the median real use-case, or parity not maintainable at acceptable cost. |
+| ⚫ Black | Scope error — shape is structurally bad for NAPI (many tiny String ops in a hot path, lookup-style workloads). No input size rescues it. |
+
+## Workflow
+
+### Step 1 — Resolve the package name
+
+If the user passed a name, use it. Otherwise `AskUserQuestion`: "Which package should I evaluate?". Accept `foo`, `@amigo-labs/foo`, and scoped npm names (`lodash.clonedeep`).
+
+### Step 2 — Detect the mode
+
+```bash
+node .claude/skills/rust-check/scripts/detect-mode.mjs <name>
+```
+
+Outputs a JSON object on stdout. Key fields:
+
+- `mode`: `"existing"` or `"candidate"`
+- `cratePath`, `libRs`, `cargoToml`, `benchFile`, `readme`, `jsCompetitors` — only on existing
+- `benchmarksMdSection` — the `### <name>` block from `BENCHMARKS.md` if present
+- `backlogEntry` — matching line in `BACKLOG.md` if present
+- `packagesJsonEntry` — registry entry if present (has advertised `speedup`)
+- `baselineExists` — whether `docs/BASELINE.md` (FFI-overhead baseline) has been captured
+- `existingReview` — whether `docs/perf-review/<pkg>.md` already exists (re-review)
+- `reportPath` — where to write the output
+
+Branch on `mode`.
+
+### Step 3a — Review mode (existing crate)
+
+Collect evidence read-only (no edits, no bench runs):
+
+1. `libRs` — read exported `#[napi]` signatures. Note: `String` vs `&str`, `Vec<T>` vs `Buffer`, whether any state is kept, async boundaries.
+2. `benchFile` — what input sizes are covered? Which JS competitor packages? Are the small/medium/large buckets all present?
+3. `benchmarksMdSection` — copy verbatim into the report's Evidence section. **Do not invent numbers.** If a size is missing, list it under "Benchmark gaps".
+4. `cargoToml` — which Rust crate is wrapped, which features, release profile overrides.
+5. `packagesJsonEntry.speedup` — compare to the actual BENCHMARKS.md numbers. A mismatch is a red flag for the report.
+6. `baselineExists` — if `false`, note that FFI-overhead estimates for the optimization plan are qualitative, not quantitative. Recommend creating the `_ffi-bench` crate as a follow-up.
+
+Ask the user one short question if the realistic median use-case isn't obvious from the README: "What's the real-world call pattern — size, frequency, batched or not?" Don't guess. The whole review turns on this.
+
+Apply the classification thresholds. Then walk the Phase-C levers for the chosen template table:
+
+- **C.1 Input-type**: Does the signature take owned `String`/`Vec<T>` where `&str`/`&[T]` would do? Could a `Buffer` overload bypass UTF-8 validation?
+- **C.2 Output-type**: Is a new allocation returned where a borrow, `Buffer`, or typed array would suffice?
+- **C.3 Batch**: Is the call shape loop-friendly? Is there already a `fooMany` / iterator API? Target: <10% per-item overhead vs. the algorithm cost.
+- **C.4 Stateful**: Is there a per-call setup cost (regex compile, schema parse, key load) that could live in a NAPI class? Rule of thumb: >20% of per-call time as setup → class API wins.
+- **C.5 Parallel**: Embarrassingly parallel over large inputs? Rayon makes sense only above an empirically-determined threshold — note the threshold as "TBD" if unmeasured.
+- **C.6 Algorithm**: Is there a faster Rust crate (SIMD, streaming, zero-copy)? Examples from the plan: `strsim` → `triple_accel`, `miniz_oxide` → `zlib-rs`, `serde_json` → `simd-json`.
+- **C.7 Allocator**: Many small allocations → arena (`bumpalo`). Caller-provided output buffer for fill-in-place APIs.
+- **C.8 Bundle-size**: Check `lto`, `codegen-units`, `strip`, `panic = "abort"`. Default features off unless used.
+
+Mark each lever `applicable` / `not applicable` / `already done` with a concrete reason sourced from the code, not a guess.
+
+Write the action plan based on the classification:
+
+- **Green** — short polish list only (missing bucket in benches, maybe a batch API, README tightening).
+- **Yellow** — prioritized C-lever list with explicit targets and the expected classification-upgrade path. Budget: one focused optimization sprint. If it stays Yellow after, reclassify to Red.
+- **Red** — Phase-D deprecation path: (a) `deprecated` field in `package.json`, (b) README warning, (c) `MIGRATION.md` pointing to the recommended JS alternative, (d) 3-month deprecation window, (e) eventual move to `archived/`. Draft the `docs/post-mortems/<pkg>.md` outline.
+- **Black** — archival plan and BACKLOG note under the appropriate rejection category.
+
+Render the `templates/existing-review.md` template and write to `reportPath`.
+
+### Step 3b — Candidate mode (npm package, not yet ported)
+
+1. **Backlog check** — if `backlogEntry` is non-null, quote it to the user and ask whether to continue anyway. If they decline, stop.
+2. **Evidence gathering** — use `WebFetch` / `WebSearch` if helpful:
+   - npm registry for the JS package (downloads, main exports, install footprint)
+   - crates.io for a suitable Rust replacement (recent release, license, maintenance)
+   - Ask the user if which JS package is meant is ambiguous (e.g. `yaml` could mean `js-yaml` or `yaml`).
+3. **FFI-overhead prediction** — fill the template table using the API signature:
+   - Typical input/output sizes. Small strings (<100 bytes) called in a hot loop → FFI-trap warning.
+   - Per-call algorithmic work. Trivial (hashmap lookup, string concat, regex over 20 chars) → likely Red/Black. Substantial (crypto, compression, parsing large documents) → candidate for Green.
+   - Stateful potential. Reusable setup (key, schema, regex) is a big lever.
+   - Batch realism. If callers normally loop, require a batch API in the design.
+4. **Pattern-match to the post-mortem heuristics**:
+   - **FFI-trap shape** (mime, dotenv, cosmiconfig, shallow clone/equal): tiny-work-per-call, output is a small primitive. Predict Red or Black.
+   - **Green shape** (jwt, inflate, sanitize-html, encoding): bytes-in / bytes-out, substantial compute, streaming friendly.
+   - **Unclear** (file-type-style magic-bytes, xxhash for small buffers): predict Yellow and note the benchmark scenarios that would decide it.
+5. **Go / No-Go recommendation**:
+   - **GO** → fill the "If GO" section: recommended crate name, API sketch (TS signature), must-have benchmark scenarios (small/medium/large, realistic median), Green-gate threshold, risks.
+   - **NO-GO** → fill the "If NO-GO" section: draft `BACKLOG.md` entry under the right category (Parity too expensive / Scope too large / FFI overhead > gain / Needs a JS engine / Deprecated).
+
+Render the `templates/candidate-review.md` template and write to `reportPath`.
+
+### Step 4 — Summary
+
+One or two sentences in chat: the classification (or GO/NO-GO), the single most important driver, and the report path. The user decides what happens next — this skill does not implement optimizations, deprecations, or BACKLOG edits.
+
+## What the skill must not do
+
+- Never modify `crates/*`, `scripts/*`, `docs/packages.json`, `BACKLOG.md`, `BENCHMARKS.md`, or `README.md`.
+- Never run `vitest bench` as a side effect — benchmarks are expensive and the user owns that decision. Use numbers from `BENCHMARKS.md` only. If data is missing, say so.
+- Never invent speedup numbers. "Bench gap" is a valid classification input — an unmeasured small-input bucket for a package that only bench-covers large inputs is itself a Yellow downgrade signal.
+- Never commit. The user reviews the report and chooses follow-up.
+
+## Files this skill writes
+
+Exactly one: `docs/perf-review/<pkg>.md`. Re-reviews overwrite. Git history preserves prior versions.
+
+## Extending
+
+New classification levers (e.g. security reviews, supply-chain concerns) can be added to the Phase-C table in `templates/existing-review.md` and documented in the workflow. Keep `detect-mode.mjs` read-only and side-effect-free.

--- a/.claude/skills/rust-check/SKILL.md
+++ b/.claude/skills/rust-check/SKILL.md
@@ -85,7 +85,7 @@ Write the action plan based on the classification:
 
 - **Green** — short polish list only (missing bucket in benches, maybe a batch API, README tightening).
 - **Yellow** — prioritized C-lever list with explicit targets and the expected classification-upgrade path. Budget: one focused optimization sprint. If it stays Yellow after, reclassify to Red.
-- **Red** — Phase-D deprecation path: (a) `deprecated` field in `package.json`, (b) README warning, (c) `MIGRATION.md` pointing to the recommended JS alternative, (d) 3-month deprecation window, (e) eventual move to `archived/`. Draft the `docs/post-mortems/<pkg>.md` outline.
+- **Red** — Phase-D deprecation path: (a) run `npm deprecate <pkg>@"*" "<migration message>"` so the registry flags installs, (b) README warning at the top of the crate, (c) `MIGRATION.md` pointing to the recommended JS alternative, (d) 3-month deprecation window, (e) eventual move to `archived/`. Draft the `docs/post-mortems/<pkg>.md` outline.
 - **Black** — archival plan and BACKLOG note under the appropriate rejection category.
 
 Render the `templates/existing-review.md` template and write to `reportPath`.

--- a/.claude/skills/rust-check/scripts/detect-mode.mjs
+++ b/.claude/skills/rust-check/scripts/detect-mode.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * rust-check — resolve one package name to an evaluation mode plus the
+ * evidence Claude needs to fill out docs/perf-review/<pkg>.md.
+ *
+ * Usage (from monorepo root):
+ *   node .claude/skills/rust-check/scripts/detect-mode.mjs <name>
+ *
+ * Output: single JSON object on stdout. Non-zero exit only on missing arg
+ * or when cwd is not the monorepo root.
+ *
+ * Read-only. No network, no subprocess.
+ */
+
+import { readdirSync, existsSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = process.cwd()
+const CRATES_DIR = join(ROOT, 'crates')
+const BENCHMARKS_MD = join(ROOT, 'BENCHMARKS.md')
+const BACKLOG_MD = join(ROOT, 'BACKLOG.md')
+const PACKAGES_JSON = join(ROOT, 'docs', 'packages.json')
+const BASELINE_MD = join(ROOT, 'docs', 'BASELINE.md')
+const PERF_REVIEW_DIR = join(ROOT, 'docs', 'perf-review')
+
+function die(msg) {
+  console.error(`[rust-check] ${msg}`)
+  process.exit(2)
+}
+
+const rawArg = process.argv[2]
+if (!rawArg) {
+  die('missing package name. Usage: detect-mode.mjs <name>')
+}
+
+if (!existsSync(CRATES_DIR)) {
+  die(`crates/ not found in ${ROOT}. Run from the monorepo root.`)
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+function readText(path) {
+  try {
+    return readFileSync(path, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+function isDir(p) {
+  try { return statSync(p).isDirectory() } catch { return false }
+}
+
+function normalize(raw) {
+  // strip scope (@amigo-labs/foo → foo, @scope/foo → foo) and whitespace
+  let name = raw.trim()
+  if (name.startsWith('@')) {
+    const slash = name.indexOf('/')
+    if (slash !== -1) name = name.slice(slash + 1)
+  }
+  return name
+}
+
+function listCrates() {
+  return readdirSync(CRATES_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith('_'))
+    .map((e) => e.name)
+    .sort()
+}
+
+function extractBenchmarksSection(md, crateName) {
+  if (!md) return null
+  // Sections are `### <crateName>` until the next `### ` or end of file.
+  const marker = `### ${crateName}`
+  const start = md.indexOf(marker)
+  if (start === -1) return null
+  const rest = md.slice(start)
+  const nextHeading = rest.search(/\n### /)
+  return nextHeading === -1 ? rest.trim() : rest.slice(0, nextHeading).trim()
+}
+
+function findBacklogMention(md, name) {
+  if (!md) return null
+  // Look for a bullet line mentioning the bare name (word-boundary, case-sensitive).
+  const pattern = new RegExp(`^-\\s+\\*\\*${escapeRegex(name)}\\*\\*.*$`, 'mi')
+  const match = md.match(pattern)
+  return match ? match[0] : null
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const name = normalize(rawArg)
+const crates = listCrates()
+const cratePath = crates.includes(name) ? join('crates', name) : null
+const mode = cratePath ? 'existing' : 'candidate'
+
+const packagesJson = readJson(PACKAGES_JSON)
+const packagesJsonEntry = packagesJson?.packages?.find?.((p) => p.name === name) ?? null
+
+const benchmarksMdSection = extractBenchmarksSection(readText(BENCHMARKS_MD), name)
+const backlogEntry = findBacklogMention(readText(BACKLOG_MD), name)
+const existingReview = existsSync(join(PERF_REVIEW_DIR, `${name}.md`))
+const baselineExists = existsSync(BASELINE_MD)
+
+let evidence = {}
+if (mode === 'existing') {
+  const cratePkg = readJson(join(ROOT, cratePath, 'package.json'))
+  evidence = {
+    cratePath,
+    libRs: join(cratePath, 'src', 'lib.rs'),
+    cargoToml: join(cratePath, 'Cargo.toml'),
+    readme: join(cratePath, 'README.md'),
+    benchFile: join(cratePath, '__bench__', 'index.bench.ts'),
+    conformanceDir: join(cratePath, '__conformance__'),
+    npmPackage: cratePkg?.name ?? `@amigo-labs/${name}`,
+    version: cratePkg?.version ?? null,
+    jsCompetitors: Object.keys(cratePkg?.devDependencies ?? {}).filter(
+      (d) => !d.startsWith('@amigo-labs/') && !d.startsWith('@napi-rs/') && d !== 'vitest' && d !== 'fast-check' && d !== 'typescript' && d !== 'tsx' && d !== '@types/node',
+    ),
+  }
+}
+
+const result = {
+  mode,
+  name,
+  inputRaw: rawArg,
+  packagesJsonEntry,
+  benchmarksMdSection,
+  backlogEntry,
+  baselineExists,
+  existingReview,
+  reportPath: `docs/perf-review/${name}.md`,
+  ...evidence,
+}
+
+process.stdout.write(JSON.stringify(result, null, 2) + '\n')

--- a/.claude/skills/rust-check/scripts/detect-mode.mjs
+++ b/.claude/skills/rust-check/scripts/detect-mode.mjs
@@ -12,7 +12,7 @@
  * Read-only. No network, no subprocess.
  */
 
-import { readdirSync, existsSync, readFileSync, statSync } from 'node:fs'
+import { readdirSync, existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 const ROOT = process.cwd()
@@ -53,18 +53,41 @@ function readText(path) {
   }
 }
 
-function isDir(p) {
-  try { return statSync(p).isDirectory() } catch { return false }
+function normalize(raw) {
+  // Strip only the internal @amigo-labs/ scope so existing crates resolve by
+  // their folder name. Keep every other npm scope intact — collapsing
+  // @scope/foo → foo would collide with unrelated packages and point
+  // reportPath/BACKLOG lookups at the wrong entity.
+  const trimmed = raw.trim()
+  const internalScope = '@amigo-labs/'
+  if (trimmed.startsWith(internalScope)) return trimmed.slice(internalScope.length)
+  return trimmed
 }
 
-function normalize(raw) {
-  // strip scope (@amigo-labs/foo → foo, @scope/foo → foo) and whitespace
-  let name = raw.trim()
-  if (name.startsWith('@')) {
-    const slash = name.indexOf('/')
-    if (slash !== -1) name = name.slice(slash + 1)
+function assertSafeName(name) {
+  // Allow npm-valid characters only; this is the identity string AND the
+  // substring used to derive reportPath, so anything path-ish is rejected.
+  // Scoped names like `@scope/pkg` are valid and get a safe filename below.
+  if (!name) die('empty package name after normalization')
+  if (name.includes('..') || name.includes('\\') || name.includes('\0')) {
+    die(`refusing unsafe package name: ${JSON.stringify(name)}`)
   }
-  return name
+  if (name.startsWith('.') || name.startsWith('/') || name.endsWith('/')) {
+    die(`refusing unsafe package name: ${JSON.stringify(name)}`)
+  }
+  // npm allows exactly one `/` (scope separator). More than one is invalid
+  // and would collapse into directory segments in reportPath.
+  const slashes = (name.match(/\//g) ?? []).length
+  if (slashes > 1) die(`refusing unsafe package name: ${JSON.stringify(name)}`)
+  if (slashes === 1 && !name.startsWith('@')) {
+    die(`refusing unsafe package name: ${JSON.stringify(name)}`)
+  }
+}
+
+function safeFilename(name) {
+  // Flatten a scoped npm name (@scope/pkg) to a single filename segment so
+  // reportPath is always a direct child of docs/perf-review/.
+  return name.replace(/^@/, '').replace(/\//g, '__')
 }
 
 function listCrates() {
@@ -87,7 +110,9 @@ function extractBenchmarksSection(md, crateName) {
 
 function findBacklogMention(md, name) {
   if (!md) return null
-  // Look for a bullet line mentioning the bare name (word-boundary, case-sensitive).
+  // Match a markdown bullet line whose bolded label is the package name.
+  // Multiline (`m`) anchors ^/$ per line; case-insensitive (`i`) so
+  // "Deep-Equal" still matches "deep-equal".
   const pattern = new RegExp(`^-\\s+\\*\\*${escapeRegex(name)}\\*\\*.*$`, 'mi')
   const match = md.match(pattern)
   return match ? match[0] : null
@@ -98,16 +123,19 @@ function escapeRegex(s) {
 }
 
 const name = normalize(rawArg)
+assertSafeName(name)
 const crates = listCrates()
 const cratePath = crates.includes(name) ? join('crates', name) : null
 const mode = cratePath ? 'existing' : 'candidate'
+
+const reportFilename = `${safeFilename(name)}.md`
 
 const packagesJson = readJson(PACKAGES_JSON)
 const packagesJsonEntry = packagesJson?.packages?.find?.((p) => p.name === name) ?? null
 
 const benchmarksMdSection = extractBenchmarksSection(readText(BENCHMARKS_MD), name)
 const backlogEntry = findBacklogMention(readText(BACKLOG_MD), name)
-const existingReview = existsSync(join(PERF_REVIEW_DIR, `${name}.md`))
+const existingReview = existsSync(join(PERF_REVIEW_DIR, reportFilename))
 const baselineExists = existsSync(BASELINE_MD)
 
 let evidence = {}
@@ -123,7 +151,14 @@ if (mode === 'existing') {
     npmPackage: cratePkg?.name ?? `@amigo-labs/${name}`,
     version: cratePkg?.version ?? null,
     jsCompetitors: Object.keys(cratePkg?.devDependencies ?? {}).filter(
-      (d) => !d.startsWith('@amigo-labs/') && !d.startsWith('@napi-rs/') && d !== 'vitest' && d !== 'fast-check' && d !== 'typescript' && d !== 'tsx' && d !== '@types/node',
+      (d) =>
+        !d.startsWith('@amigo-labs/') &&
+        !d.startsWith('@napi-rs/') &&
+        !d.startsWith('@types/') &&
+        d !== 'vitest' &&
+        d !== 'fast-check' &&
+        d !== 'typescript' &&
+        d !== 'tsx',
     ),
   }
 }
@@ -137,7 +172,7 @@ const result = {
   backlogEntry,
   baselineExists,
   existingReview,
-  reportPath: `docs/perf-review/${name}.md`,
+  reportPath: `docs/perf-review/${reportFilename}`,
   ...evidence,
 }
 

--- a/.claude/skills/rust-check/templates/candidate-review.md
+++ b/.claude/skills/rust-check/templates/candidate-review.md
@@ -1,0 +1,63 @@
+# Candidate review: `{{NAME}}`
+
+> **Status:** {{RECOMMENDATION}} · **Predicted:** {{CLASSIFICATION}} · **Reviewed:** {{DATE}}
+
+## Verdict
+
+{{ONE_SENTENCE_VERDICT}}
+
+## JS package
+
+- **npm:** {{NPM_PACKAGE}}
+- **Downloads:** {{NPM_DOWNLOADS}}
+- **Exports / API surface:** {{JS_API_SURFACE}}
+- **Typical input:** {{TYPICAL_INPUT}}
+- **Typical output:** {{TYPICAL_OUTPUT}}
+- **Realistic median use-case:** {{MEDIAN_USE_CASE}}
+
+## Rust replacement
+
+- **Candidate crate(s):** {{RUST_CRATES}}
+- **Maintenance / license:** {{RUST_MAINTENANCE}}
+- **Known gotchas / divergences:** {{RUST_CAVEATS}}
+
+## BACKLOG check
+
+{{BACKLOG_NOTE}}
+
+## FFI-overhead prediction
+
+| Factor | Assessment |
+|---|---|
+| Per-call algorithmic work | {{ALGO_WORK}} |
+| Input size distribution | {{INPUT_DISTRIBUTION}} |
+| Output size distribution | {{OUTPUT_DISTRIBUTION}} |
+| Reusable setup (stateful potential) | {{STATEFUL_POTENTIAL}} |
+| Batch-usage realism | {{BATCH_REALISM}} |
+| FFI-share estimate vs. Rust work | {{FFI_SHARE_ESTIMATE}} |
+
+## Classification reasoning
+
+{{RATIONALE_PROSE}}
+
+Reference patterns from the post-mortem: a shape that resembles `nanoid` / `mime` / `deep-equal` (small input, trivial per-call work, FFI dominates) trends Red/Black. A shape that resembles `jwt` / `inflate` / `sanitize-html` (substantial compute, bytes-in/bytes-out, streaming) trends Green.
+
+## If GO — proposed port
+
+- **Recommended crate-name:** `@amigo-labs/{{CRATE_NAME}}`
+- **Primary API sketch:**
+  ```ts
+  {{API_SKETCH}}
+  ```
+- **Must-have benchmark scenarios:**
+  {{REQUIRED_BENCHMARKS}}
+- **Acceptance thresholds (Green gate):** {{GREEN_GATE}}
+- **Risks:** {{RISKS}}
+
+## If NO-GO — BACKLOG entry
+
+```markdown
+{{BACKLOG_SNIPPET}}
+```
+
+Section in `BACKLOG.md`: **{{BACKLOG_SECTION}}**

--- a/.claude/skills/rust-check/templates/existing-review.md
+++ b/.claude/skills/rust-check/templates/existing-review.md
@@ -1,0 +1,62 @@
+# Perf-Review: `@amigo-labs/{{NAME}}`
+
+> **Status:** {{CLASSIFICATION}} · **Reviewed:** {{DATE}} · **Version:** {{VERSION}}
+
+## Verdict
+
+{{ONE_SENTENCE_VERDICT}}
+
+## Classification rationale
+
+{{RATIONALE_PROSE}}
+
+## Evidence
+
+### Measured speedup (from BENCHMARKS.md)
+
+{{BENCHMARKS_TABLE}}
+
+### Realistic use-case
+
+{{USE_CASE_NARRATIVE}}
+
+### Benchmark gaps
+
+{{BENCHMARK_GAPS}}
+
+### API surface
+
+{{API_SIGNATURE_NOTES}}
+
+### Bundle / binary size
+
+{{SIZE_NOTES}}
+
+### FFI-overhead baseline
+
+{{BASELINE_NOTES}}
+
+## Phase-C optimization checklist
+
+| # | Lever | Applicable | Notes |
+|---|---|---|---|
+| C.1 | Input-type minimization (`String` → `&str`, `Vec<T>` → `&[T]`, Buffer-overload) | {{C1_STATUS}} | {{C1_NOTES}} |
+| C.2 | Output-type minimization (`String` → `&str`, `Vec<T>` → Buffer) | {{C2_STATUS}} | {{C2_NOTES}} |
+| C.3 | Batch API | {{C3_STATUS}} | {{C3_NOTES}} |
+| C.4 | Stateful API (reusable setup via NAPI class) | {{C4_STATUS}} | {{C4_NOTES}} |
+| C.5 | Parallelization (rayon over large inputs) | {{C5_STATUS}} | {{C5_NOTES}} |
+| C.6 | Algorithm swap (SIMD variant, streaming parser, etc.) | {{C6_STATUS}} | {{C6_NOTES}} |
+| C.7 | Allocator tuning (arena, caller-provided output buffer) | {{C7_STATUS}} | {{C7_NOTES}} |
+| C.8 | Bundle-size (LTO, features, panic=abort, strip) | {{C8_STATUS}} | {{C8_NOTES}} |
+
+## Action plan
+
+{{ACTION_PLAN}}
+
+## References
+
+- Crate: `{{CRATE_PATH}}`
+- Bench: `{{BENCH_FILE}}`
+- Lib: `{{LIB_RS}}`
+- Cargo: `{{CARGO_TOML}}`
+- `docs/packages.json` speedup field: `{{ADVERTISED_SPEEDUP}}`


### PR DESCRIPTION
New skill at .claude/skills/rust-check/ that evaluates one package at a
time against the perf post-mortem framework. Auto-detects mode:

- existing crates/* entry → Green/Yellow/Red/Black classification from
  BENCHMARKS.md + Phase-C lever checklist + action plan (polish /
  optimize-sprint / deprecate / archive).
- unknown npm name → candidate assessment with FFI-overhead heuristics,
  BACKLOG check, Rust-crate scan, go/no-go prediction.

Read-only: writes only docs/perf-review/<pkg>.md, never touches crate
source, benchmarks, docs/packages.json, or BACKLOG.md.

Parts:
- SKILL.md — workflow, thresholds, two hard rules ("fast at all costs"
  doesn't count; no sunk-cost).
- scripts/detect-mode.mjs — resolves name (handles @amigo-labs/ scope),
  emits JSON with cratePath, benchmarksMdSection, backlogEntry, etc.
- templates/existing-review.md, templates/candidate-review.md —
  skeletons Claude fills in.

https://claude.ai/code/session_012gwST7rdmQ4xKboSvcb1Uf