### PR TITLE
ci: build NAPI binaries once and share via artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cargo-test
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -30,13 +33,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cargo-test
       - run: cargo test --workspace
 
-  test-node:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: napi-build
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -45,6 +54,33 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build all crates
         run: pnpm -r run build
+      - name: Upload NAPI binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: napi-binaries
+          path: |
+            crates/*/*.node
+            crates/*/index.js
+            crates/*/index.d.ts
+          retention-days: 1
+          if-no-files-found: error
+
+  test-node:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Download NAPI binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: napi-binaries
+          path: crates/
       - name: Test all crates
         run: pnpm -r run test
       - name: Parity tests
@@ -52,18 +88,20 @@ jobs:
 
   test-conformance:
     runs-on: ubuntu-latest
-    needs: test-node
+    needs: build
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Build all crates
-        run: pnpm -r run build
+      - name: Download NAPI binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: napi-binaries
+          path: crates/
       - name: Run conformance suite
         run: pnpm -r run test:conformance
 
@@ -77,15 +115,17 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: dtolnay/rust-toolchain@stable
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Build all crates
-        run: pnpm -r run build
+      - name: Download NAPI binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: napi-binaries
+          path: crates/
       - name: Run benchmarks and generate report
         run: pnpm bench:report
       - name: Commit BENCHMARKS.md and docs/data.json


### PR DESCRIPTION
Previously the Rust/NAPI build ran three times (test-node,
test-conformance, benchmark) and test-conformance waited sequentially
behind test-node. Now a dedicated build job produces the .node binaries
plus generated index.js/index.d.ts, uploads them as an artifact, and the
downstream jobs download instead of rebuilding. Adds Swatinem/rust-cache
to lint, test-rust, and build so cargo compilation is cached between
runs.

https://claude.ai/code/session_01KtoxhFaqa7pofDn9JdoU6h