### PR TITLE
docs(perf-review): add dagre, d3-force, svgo candidate reviews

### DIFF
--- a/docs/perf-review/d3-force.md
+++ b/docs/perf-review/d3-force.md
@@ -1,0 +1,102 @@
+# Candidate review: `d3-force`
+
+> **Status:** GO (als neues Paket `@amigo-labs/force-layout`, kein Drop-in) · **Predicted:** 🟡 Yellow leaning 🟢 Green · **Reviewed:** 2026-04-20
+
+## Verdict
+
+`d3-force` ist eine **N-Body-Simulation** auf Graph-Nodes — Quad-Tree-basierte many-body repulsion + Feder-Forces für Edges, iterativ über Ticks. Pure Math auf Float-Arrays, keine DOM-Dependency. Shape ist Green für mittlere/große Graphen, aber **Tick-Callback-Semantik** ist die Falle: der idiomatische Use (`simulation.on('tick', draw)`) ruft JS 300× pro Simulation — exakt die `chart.js`-Animation-Falle. Als Batch-API (`simulate(nodes, edges, iterations) → finalPositions`) ist es Green; als Tick-Mirror ist es Black.
+
+## JS package
+
+- **npm:** [`d3-force`](https://www.npmjs.com/package/d3-force) (~2 M/Woche standalone) + via `d3`-bundle (~5 M/Woche)
+- **Exports:** `forceSimulation(nodes)`, `forceManyBody()`, `forceLink(edges)`, `forceCenter()`, `forceCollide()`, `forceX()`, `forceY()`, `simulation.tick()`, `.on('tick'|'end', cb)`, `.restart()`, `.alpha()`
+- **Typical input:** Nodes mit `{id, x?, y?, vx?, vy?}` + Edges mit `{source, target, distance?}`
+- **Typical output:** In-place mutation der Nodes mit `x, y, vx, vy` nach N Ticks
+- **Realistic median use-case:** Force-directed Graph-Darstellung in Browsern (ObservableHQ, Kumu, Gephi-Web) — 50–500 Nodes, 60–300 Ticks bis Konvergenz, animiert per Tick-Callback
+
+## Rust replacement
+
+- **Candidate crates:** `fdg` (force-directed-graph, aktiv, MIT, Quadtree + Barnes-Hut), `fdg-sim` (Kernkomponente), alternativ direkter Port auf `petgraph` + custom Barnes-Hut
+- **Maintenance:** `fdg` aktiv, letzte Commits Q4 2025
+- **Gotchas:** d3's spezifische Force-Kombination (Link-Distance + many-body + collision) ist stabil-abgestimmt; Rust-Parity braucht identische Parameter-Semantik. Fixed-Nodes (pinned) müssen unterstützt werden.
+
+## BACKLOG check
+
+Kein Eintrag. Kein `docs/packages.json`-Entry. Erster Force-Simulation-Kandidat.
+
+## FFI-overhead prediction
+
+| Factor | Assessment |
+|---|---|
+| Per-call work | Tick: O((V+E) log V) mit Barnes-Hut. 100 Nodes × 300 Ticks ≈ 30–80 ms JS. 500 Nodes × 300 Ticks ≈ 500 ms–2 s. Substantiell. |
+| Input size | Nodes-Array 50–500 × ~40 B + Edges ~60–800 × ~20 B = 2–30 KB. Ein Crossing. |
+| Output size | Positions flach, ~16 B × V. ≤10 KB für Median. `Buffer`/Float64Array flach. |
+| Stateful potential | **Hoch.** Simulation-State (Quadtree-Budget, Alpha-Decay) gehört in NAPI-Klasse — Caller kann mehrere `tick(n)`-Calls machen ohne Setup neu aufzubauen. |
+| Batch realism | Ein `simulate(iterations)` liefert Final-Positions; Tick-by-Tick ist der animierte Pfad. Server-Side (SSR-Graphen, Layout-Precompute) ist Batch-natürlich. |
+| FFI-share | Batch-simulate: <1% FFI auf Median (30 ms Rust, 200 ns Crossings). Tick-Mirror (`tick()` × 300 mit JS-Callback): 300 × ~300 ns = 90 µs Overhead bei 30 ms Work = 0.3%. Akzeptabel — aber Callback-Pattern bleibt API-hygienisch unsauber. |
+
+## Classification reasoning
+
+Drei Pfade:
+
+1. **Batch `simulate(nodes, edges, iterations) → positions`** — 🟢 Green. One-Shot-Compute. Passt zu SSR, statischen Graph-Previews, CI-Layout-Precompute, Mermaid-Force-Renderern.
+2. **Stateful `ForceSimulation`-Klasse mit `.tick(n)`** — 🟡 Yellow. User ruft `.tick(1)` × 300 in RAF-Loop für Animation. 300 FFI-Crossings sind tolerabel (BASELINE), aber jeder Tick verlangt Positions-Transfer zurück nach JS. Bei 500 Nodes = 8 KB × 300 Crossings = ~2.5 MB/Simulation durchgeschaufelt. Messbar aber nicht Killer.
+3. **Tick-Callback `.on('tick', cb)` mit User-JS pro Tick** — 🔴 Red/Black. `chart.js`-Animation-Falle reinkarniert. Nicht anbieten.
+
+Für den Median-Server-Side-Use-Case (Layout-Precompute, Graph-Export) ist Pfad 1 ausreichend und liefert Green. Für Browser-interaktive Animation (d3-forces Haupt-Use-Case) bleibt JS-Baseline optimal — kein Port-Wert. Also: Paket addressiert den **Server-Side-Pfad** explizit, Browser-User bleiben auf d3-force.
+
+**Shape-Match:** wie `commonmark`/`pdfkit-batch` (spec-in, result-out, substantielle Compute). **Nicht** wie `chart.js` (keine Plugin-Callbacks im v1-API).
+
+**Benchmark-Gap-Flag:** Kleiner Graph (20 Nodes × 100 Ticks) muss ≥1× treffen sonst Yellow-Downgrade. d3's Quadtree ist hochoptimiert in V8 — der Rust-Gewinn könnte auf kleinen Graphen unter 1.5× liegen.
+
+## If GO — proposed port
+
+- **Crate-name:** `@amigo-labs/force-layout`
+- **API sketch:**
+  ```ts
+  type ForceNode = { id: string; x?: number; y?: number; fx?: number; fy?: number };
+  type ForceLink = { source: string; target: string; distance?: number; strength?: number };
+  type ForceOptions = {
+    manyBodyStrength?: number;   // default: -30
+    linkDistance?: number;       // default: 30
+    centerX?: number; centerY?: number;
+    collideRadius?: number;
+    alphaMin?: number;           // default: 0.001
+    alphaDecay?: number;         // default: 0.0228 (→ ~300 Ticks)
+    velocityDecay?: number;      // default: 0.4
+  };
+
+  export function simulate(
+    nodes: ForceNode[],
+    links: ForceLink[],
+    options?: ForceOptions & { iterations?: number }
+  ): Array<{ id: string; x: number; y: number }>;
+
+  export class ForceSimulation {
+    constructor(nodes: ForceNode[], links: ForceLink[], options?: ForceOptions);
+    tick(n?: number): void;                 // advance n ticks (default: 1)
+    positions(): Array<{ id: string; x: number; y: number }>;
+    setNodes(nodes: ForceNode[]): void;
+    setLinks(links: ForceLink[]): void;
+  }
+  ```
+  Kein `.on('tick', cb)`-Callback. Browser-Animationen bleiben bei d3.
+- **Must-have benchmark scenarios:**
+  - **Tiny (20/30):** 20 Nodes, 30 Edges, 100 Ticks. Green-Gate: ≥ 1×.
+  - **Median (100/150):** **Entscheider** — 100 Nodes, 150 Edges, bis Konvergenz (~300 Ticks). Green-Gate: ≥ 2×.
+  - **Large (500/800):** 500/800, 300 Ticks. Green-Gate: ≥ 3×.
+  - **Tick-API (100/150, 300 × tick(1)):** misst Stateful-Class-Pfad mit JS-Loop. Yellow akzeptabel, Red-Warnung bei < 1.5×.
+- **Green gate:** alle Batch-Szenarien + ≥2× Median.
+- **Risks:**
+  - **V8-Optimum:** d3's ManyBodyForce ist V8-JIT-freundlich — kleine Graphen könnten unter 2× liegen, weil die Rust-Pipeline pro Tick vergleichsweise wenig Arbeit hat.
+  - **Force-Parity:** Exakte Reproduktion der d3-Force-Kombination ist nicht Ziel; Layout-Qualität "gleichwertig" reicht. Pixel-Regression-Tests werden brechen.
+  - **Positions-Marshaling:** Float64Array/`Buffer` statt `{id, x, y}[]` könnte den Output-Overhead halbieren — v2-Optimierung falls Yellow.
+  - **Baseline-Gap:** `docs/BASELINE.md` deckt nicht "Array of 500 Number-Objekte". Vor Port-Start `nodeArrayEcho`-Case im `_ffi-bench` ergänzen.
+
+## If NO-GO — BACKLOG entry
+
+```markdown
+- **d3-force** (~2M/Woche standalone). N-Body-Force-Simulation. Shape-Green für Server-Side-Batch, aber Measurement ergab <2× auf dem Median-Case (100 Nodes × 300 Ticks), weil d3's Quadtree in V8 bereits JIT-optimal läuft. Eingefroren bis messbarer Hebel (SIMD-Quadtree?) oder Median-Graph wächst. Siehe `docs/perf-review/d3-force.md`.
+```
+
+Section: **FFI overhead > gain** oder **Parity too expensive**.

--- a/docs/perf-review/dagre.md
+++ b/docs/perf-review/dagre.md
@@ -1,0 +1,152 @@
+# Candidate review: `dagre` / `@dagrejs/dagre`
+
+> **Status:** GO (als neues Paket `@amigo-labs/graph-layout`, kein Drop-in) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-20
+
+## Verdict
+
+`dagre` ist ein reiner **Algorithmus** — Sugiyama-Style Layered-Layout für gerichtete Graphen — **ohne** DOM, Canvas, Events oder Plugin-Callbacks. Input: Graph-Topologie + Node-Größen. Output: Koordinaten. Das ist exakt die `commonmark` / `pdfkit`-neu Green-Shape: Bytes-in / Bytes-out, substantielle Compute pro Call, keine Callback-Boundary. Der einzige Fallstrick ist die Drop-in-Versuchung: die graphlib-Chain-API (`g.setNode(...); g.setEdge(...); dagre.layout(g)`) mit dutzenden `setNode`-Crossings pro Layout wäre die `xml`/`pdfkit-chain`-Falle. Als `layout(spec)`-Paket mit einem Call pro Graph ist es Green.
+
+## JS package
+
+- **npm:** [`dagre`](https://www.npmjs.com/package/dagre) (original, seit 2020 unmaintained) + [`@dagrejs/dagre`](https://www.npmjs.com/package/@dagrejs/dagre) (aktiver Fork, Major-Consumer-Empfehlung)
+- **Downloads:** `dagre` ~1.5 M/Woche + `@dagrejs/dagre` ~1.3 M/Woche ≈ **~2.8 M/Woche kombiniert** (Q1 2026)
+- **Exports / API surface:** `graphlib.Graph` (Node-Klasse, stateful), `layout(graph, opts?)`, `acyclic`, `normalize`, `rank`, `order`, `position` als Einzel-Phasen-Exports
+- **Typical input:** Graph-Objekt mit `setNode(id, {width, height, label, rank?})` + `setEdge(v, w, {weight?, minlen?, labelpos?})` + Graph-Optionen (`rankdir`, `nodesep`, `ranksep`, `marginx`, `marginy`)
+- **Typical output:** Der gleiche Graph, **in-place mutiert** — jeder Node bekommt `.x`, `.y`; jede Edge bekommt `.points: [{x, y}, …]` + Routing; Graph selbst bekommt `.width`, `.height`
+- **Realistic median use-case:** **Mermaid-Flowcharts** (~20–200 Nodes, neuer Layout pro Edit), **ReactFlow-Editoren** (~10–500 Nodes, Re-Layout auf User-Action), **Cytoscape/joint.js-Dashboards**. Graphen sind meist 20–300 Nodes, 30–500 Edges. Re-Layout passiert **häufig** (pro User-Keystroke in manchen Editoren), aber immer als ein `layout()`-Call — nicht in Hot-Loops aufgerufen
+
+## Rust replacement
+
+- **Candidate crate(s):**
+  - `layout` / `layout-rs` (nadavrot/layout auf crates.io) — **primär**. Sugiyama-Layered-Layout, aktiv gepflegt, MIT, pure-Rust, renderfähig zu SVG aber Koordinaten-Output ist direkt zugänglich. Keine native Dependencies, WASM-tauglich.
+  - `petgraph` — für Graph-Primitive (DAG-Check, SCC, topological sort) als Baustein
+  - `rust-sugiyama` (weniger bekannt, kleinerer Scope) — sekundär
+  - Custom-Port: Der Sugiyama-Algorithmus aus `dagre/lib/` ist gut dokumentiert (~3000 Zeilen JS, davon ~1500 hot). Direkte Portierung mit `petgraph`-Backend ist tractable
+- **Maintenance / license:** `layout-rs` MIT, aktiv, letzte Commits Q1 2026. `petgraph` ist Standard-Crate des Ökosystems. Kein Supply-Chain-Risiko.
+- **Known gotchas / divergences:**
+  - Pixel-Parity mit `dagre` **kein Ziel** — Sugiyama hat viele valide Lösungen pro Graph, jeder Implementer wählt marginal anders
+  - Edge-Routing: `dagre`'s Spline-Heuristik (via `graphlib-dot` indirekt) ist proprietär; `layout-rs` routet direkt. Konsumenten wie Mermaid akzeptieren das, weil sie die Points ohnehin durch ihre eigene Spline-Library schieben
+  - `ranker: 'network-simplex' | 'tight-tree' | 'longest-path'` — drei Ranker-Algorithmen in dagre. v1 kann auf `network-simplex` (der default) begrenzt sein; die anderen als Fast-Follow
+  - Label-Nodes: `dagre` fügt implizit Dummy-Nodes für Kanten-Labels ein. Muss repliziert werden, sonst kollidieren Labels mit Edges
+
+## BACKLOG check
+
+Kein `dagre`-Eintrag in `BACKLOG.md`. Keine Graph-Layout- oder Visualisierungs-Bibliothek bisher bewertet (nur `chart.js` → Black). Kein Eintrag in `docs/packages.json`. Dieses Review ist der erste Kandidat in der Graph-Algorithmen-Kategorie und legt die Vorlage für `d3-force`, `cytoscape-layouts`, `elkjs` etc.
+
+## FFI-overhead prediction
+
+| Factor | Assessment |
+|---|---|
+| Per-call algorithmic work | **Substantiell für den Median-Case.** 100 Nodes / 150 Edges: ~2–10 ms in dagre JS (abhängig von Ranker). 500 Nodes / 800 Edges: ~50–200 ms. Rust-Port sollte 2–5× darunter liegen. Kein Trivial-Compute-Risiko. |
+| Input size distribution | Graph-Spec als JSON/Array ~2–50 KB für den Median. Batch-Pass (ein Call mit `{nodes, edges}`) kollabiert die 150+ `setNode`/`setEdge` Crossings der graphlib-API auf **ein** Crossing. |
+| Output size distribution | Positions-Array ~100 × 16 B (x/y doubles) + Edge-Points ~200 × 4 × 16 B = ~15 KB für Median-Graph. `Buffer`/Typed-Array-Return oder einfaches JS-Objekt — `docs/BASELINE.md` sagt beides ist flach <200 ns bis ~1 MB. |
+| Reusable setup (stateful potential) | **Mittel.** Graph-Konfiguration (`rankdir`, `ranksep`, etc.) könnte in einer `GraphLayouter`-Klasse gecached werden. Größerer Hebel: bei Re-Layout auf User-Edit **mutiert** der User den Graph; wenn er eine NAPI-Klasse hält, könnte ein diff-basiertes Re-Layout später Punkte holen (Fast-Follow, nicht v1). |
+| Batch-usage realism | **Mittel-niedrig.** Ein User-Edit = ein `layout()`-Call. Mermaid-Server (z.B. Docusaurus-Build) rendert aber hunderte Diagramme pro Build — `layoutMany(specs: LayoutSpec[])` ist für diese Use-Cases der Hebel. |
+| FFI-share estimate vs. Rust work | Drop-in Chain-API (`setNode` × 150 + `layout()`): 150 Crossings × 180 ns = ~27 µs FFI bei ~5 ms Rust-Compute = **<1% FFI** — tolerabel, aber unnötig. Batch-Spec-API: <0.5% FFI. Beide sind Green-tauglich aus FFI-Sicht; Präferenz für Batch-API aus API-Hygiene-Gründen (kein Stateful-Object über FFI-Grenze mit Mutations-Semantik). |
+
+## Classification reasoning
+
+Dagre ist einer der **saubersten** Green-Shapes im JS-Ökosystem, gerade weil es keinen der drei `chart.js`-Blocker hat:
+
+1. **Runtime-Symmetrie.** Dagre läuft identisch in Browser und Node — reiner Algorithmus, keine DOM-Dependencies. `@amigo-labs/graph-layout` erreicht den Node-Consumer-Pfad (Mermaid-Server, Docusaurus-Build, CI-Graph-Rendering, reactflow-SSR) ohne Runtime-Mismatch. Browser-Consumer bleiben auf JS, das ist OK — sie haben nie eine native Option.
+
+2. **Keine native Konkurrenz.** Anders als `chart.js` (wo `node-canvas` → Skia das Feld hielt) hat Graph-Layout **keinen** nativen JS-Konkurrenten. Dagre ist pure JS, ELK ist Java (via GWT zu JS), alle anderen Layouter sind ebenfalls pure JS. Rust-Port misst gegen echte JS-Baseline.
+
+3. **Keine Callback-Surface.** Dagre hat keine Plugins, keine Tooltip-Formatter, keine Animationen. Der einzige Callback im API ist `nodeOrder` (optional, selten genutzt). v1 kann ihn weglassen.
+
+Zusätzlich: der Algorithmus ist **compute-bound**, nicht memory-bound — Crossing-Reduction ist der typische Hot-Path und das ist pure Integer-Arithmetik auf Rank-/Order-Arrays. Rust hat hier nachmessbare Gewinne (kein GC-Druck auf den inneren Loops, Fixed-Size-Arrays statt V8-Arrays, kein Hashmap-Lookup für Node-IDs wenn man auf `usize`-Indices geht).
+
+**Shape-Matching:**
+- ✅ Wie `commonmark` (Bytes-in-spec, Bytes-out-result, substantielle Compute)
+- ✅ Wie `pdfkit` (neues Paket, nicht Drop-in; Spec→Output; stateful-class optional)
+- ✅ Wie `sanitize-html` (AST-Transformation mit Parser + Algorithmus + Serializer)
+- ❌ **Nicht** wie `chartjs` (keine Browser-Runtime, keine Native-Konkurrenz, keine Callbacks)
+- ❌ **Nicht** wie `deep-equal`/`levenshtein` (kein Short-Input-Hot-Loop)
+
+**Benchmark-Gap-Flag:** Die Green-Prediction ist algorithmisch fundiert aber unmeasured. Vor Shipping müssen die vier Szenarien unten gemessen werden. Kleinster Graph (10 Nodes) muss mindestens `1×` treffen — darunter kippt es auf Yellow. Ranker-Wahl ist Faktor: `network-simplex` ist der schwerste Pfad in dagre und damit der beste Gewinn-Kandidat; `longest-path` ist trivial und bringt kaum Rust-Gewinn.
+
+## If GO — proposed port
+
+- **Recommended crate-name:** `@amigo-labs/graph-layout` (nicht `@amigo-labs/dagre` — explizit nicht Drop-in, und öffnet Tür für weitere Layouter-Algorithmen als Fast-Follow: `force`, `elk-lite`, `hierarchical`)
+- **Primary API sketch:**
+  ```ts
+  type NodeSpec = {
+    id: string;
+    width: number;
+    height: number;
+    label?: string;
+    rank?: number;        // optional pre-assigned rank
+  };
+  type EdgeSpec = {
+    from: string;
+    to: string;
+    weight?: number;
+    minlen?: number;
+    label?: string;
+    labelWidth?: number;
+    labelHeight?: number;
+  };
+  type LayoutOptions = {
+    rankdir?: 'TB' | 'BT' | 'LR' | 'RL';  // default: 'TB'
+    ranker?: 'network-simplex' | 'tight-tree' | 'longest-path';
+    nodesep?: number;    // px between siblings
+    ranksep?: number;    // px between ranks
+    edgesep?: number;
+    marginx?: number;
+    marginy?: number;
+    acyclicer?: 'greedy' | null;
+  };
+  type NodeResult = { id: string; x: number; y: number; width: number; height: number };
+  type EdgeResult = {
+    from: string;
+    to: string;
+    points: Array<{ x: number; y: number }>;
+    labelX?: number;
+    labelY?: number;
+  };
+  type LayoutResult = {
+    nodes: NodeResult[];
+    edges: EdgeResult[];
+    width: number;
+    height: number;
+  };
+
+  export function layout(
+    nodes: NodeSpec[],
+    edges: EdgeSpec[],
+    options?: LayoutOptions
+  ): LayoutResult;
+
+  export function layoutMany(
+    specs: Array<{ nodes: NodeSpec[]; edges: EdgeSpec[]; options?: LayoutOptions }>
+  ): LayoutResult[];
+
+  export class GraphLayouter {
+    constructor(options?: LayoutOptions);   // Options einmal setzen, viele layouts
+    layout(nodes: NodeSpec[], edges: EdgeSpec[]): LayoutResult;
+  }
+  ```
+  **Explizit nicht** `graphlib.Graph`-kompatibel. Keine stateful Mutation über die FFI-Grenze, kein `g.node(id).x = ...`.
+- **Must-have benchmark scenarios:**
+  - **Tiny (10/12):** 10 Nodes, 12 Edges — Mermaid-Minimal-Flowchart. Misst ob FFI-Overhead den Win auffrisst. Green-Gate: ≥ 1×.
+  - **Small (50/75):** typischer README-Flowchart. Green-Gate: ≥ 1.5×.
+  - **Median (100/150):** **der eigentliche Bench-Entscheider** — ReactFlow-Editor mit mittlerer Komplexität. Green-Gate: ≥ 2×.
+  - **Large (500/800):** CI/CD-DAG, Monorepo-Dep-Graph. Green-Gate: ≥ 3×.
+  - **Ranker-Matrix:** alle drei Szenarien × {`network-simplex`, `longest-path`} getrennt messen. `network-simplex` ist der Gewinn-Driver.
+- **Acceptance thresholds (Green gate):** alle oben + `layoutMany(100 × Median-Graph)` ≥ 3× dagre-Schleife (misst Batch-FFI-Amortisation). Ein Szenario unter dem Gate → Yellow, Review nach einem Sprint.
+- **Risks:**
+  - **Parity-Tail:** dagre hat 10 Jahre Edge-Cases (self-loops, multi-edges, disconnected components, rank-constraints, compound-nodes). v1-Scope muss explizit ausgewiesen sein: **einfache gerichtete Graphen, keine Compound-Nodes, keine Multi-Edges**. Das schließt ~95% des Mermaid/ReactFlow-Traffics ein.
+  - **Output-Divergenz:** Positionen werden sich von dagre unterscheiden (auch schon zwischen `dagre` und `@dagrejs/dagre` gibt es Drift). Consumer müssen wissen: das Paket berechnet *ein gutes* Layout, nicht *dagre's* Layout. Mermaid-User die Pixel-Regression-Tests gegen dagre-Output haben, werden sie neu baseliine müssen.
+  - **Layout-rs-Maturity:** Falls `layout-rs` nicht alle drei Ranker hat oder Edge-Routing schwach ist, muss der Sugiyama-Pipeline custom implementiert werden. Das ist ~2000 Zeilen Rust statt ~300. Vor Port-Start muss verifiziert werden.
+  - **Benchmark-Realismus:** Der Median-Fall ist "User klickt, Layout neu" — also eine Single-Call-Latenz, nicht Throughput. Green ist erst dann Green, wenn die Single-Call-Latenz auch bei 100-Node-Graphen klar unter dem JS-Baseline liegt (inklusive First-Call-Cold-Start — keine Regex-Compile-o.ä. Kaltstart-Falle).
+  - **`_ffi-bench`-Baseline-Nuance:** `docs/BASELINE.md` deckt `echoBuffer`, nicht "JSON-Objekt mit 500 Nodes". Input-Marshaling-Kosten für tiefe Node-Arrays sind qualitativ geschätzt, nicht gemessen. Vor Port-Start einen `nodeArrayEcho(n)`-Case zum `_ffi-bench`-Crate ergänzen.
+
+## If NO-GO — BACKLOG entry
+
+Nicht einschlägig — Prediction ist Green. Falls das Review-Ergebnis nach Messung aber Yellow oder Red würde (z.B. wenn `layout-rs` auf kleinen Graphen langsamer ist als dagre-JS weil JS' JIT die einfachen Integer-Loops schon optimal übersetzt), wäre die BACKLOG-Einordnung:
+
+```markdown
+- **dagre / @dagrejs/dagre** (~2.8M/Woche kombiniert). Graph-Layout-Algorithmus (Sugiyama-layered). Shape-technisch Green — aber Measurement ergab <1.5× Gewinn auf dem Median-Case (100/150 Graph), weil V8 den Crossing-Reduction-Hotloop bereits gut JIT'd. Port eingefroren bis a) messbar schnellerer Rust-Sugiyama-Ansatz gefunden (SIMD für Rank-Arrays?), b) Median-Case sich zu größeren Graphen verschiebt. Siehe `docs/perf-review/dagre.md`.
+```
+
+Section in `BACKLOG.md`: **FFI overhead > gain** (falls klein-Graph-Problem) oder **Parity too expensive** (falls Sugiyama-Varianten-Tail zu lang wird).

--- a/docs/perf-review/svgo.md
+++ b/docs/perf-review/svgo.md
@@ -1,0 +1,128 @@
+# Candidate review: `svgo`
+
+> **Status:** GO (Drop-in-orientiert mit Scope-Begrenzung) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-20
+
+## Verdict
+
+`svgo` ist ein **SVG-Optimizer**: Parser → AST-Plugin-Pipeline → Serializer. Shape ist identisch zum bereits Green-shipped `sanitize-html` (und zu `commonmark`): Bytes-in / Bytes-out, substantielle Compute pro Byte, keine Callback-Grenze wenn die Plugin-Liste als statisches Config-Objekt (nicht als JS-Callbacks) übergeben wird. Rust hat bereits einen aktiv entwickelten und gegen `svgo` gebenchmarkten Konkurrenten: **`oxvg`** (Oxc-Team). Die Entscheidung ist hier nicht "ist Rust schnell genug", sondern "können wir oxvg/usvg sauber NAPI-wrappen mit genug Plugin-Parity".
+
+## JS package
+
+- **npm:** [`svgo`](https://www.npmjs.com/package/svgo) (~10 M/Woche, Q1 2026)
+- **Exports:** `optimize(svgString, config?) → { data, info }`, Plugin-Registry (`preset-default` mit ~30 Plugins, custom Plugins möglich), CLI
+- **Typical input:** SVG-String 0.5–500 KB (Icons: ~1–5 KB; Illustrations: 10–100 KB; exportierter Chart-Output oder Figma-SVG: bis MBs)
+- **Typical output:** minifizierter SVG-String, meist 30–70% kleiner als Input
+- **Realistic median use-case:** **Build-Time-Optimierung** von Icon-Sets und statischen SVG-Assets in Webpack/Vite/Rollup-Pipelines; **Runtime-Optimierung** in CMS/Editor-Uploads. Typisch: 100–10.000 SVGs pro Build, jedes 1–20 KB
+
+## Rust replacement
+
+- **Candidate crate(s):**
+  - **`oxvg`** (primär) — vom Oxc-Team (Bun/Oxlint), aktiv gepflegt, MIT, benchmarkt explizit gegen svgo, >30 Plugin-Parity als Ziel. Q1 2026 noch pre-1.0 aber produktiv gereift.
+  - `usvg` (sekundär, Baseline) — von resvg-Team, parst SVG → intermediate representation, fokussiert auf Rendering nicht Optimization. Nicht drop-in-tauglich, aber hochwertiger SVG-Parser falls oxvg-Parser nicht reicht.
+  - `svgcleaner` (obsolet, archiviert 2020) — nicht verwenden
+- **Maintenance / license:** `oxvg` MIT, aktiv, monatliche Releases. Supply-Chain-Risiko niedrig (Oxc-Ökosystem, gleicher Vendor wie Oxlint).
+- **Known gotchas / divergences:**
+  - Plugin-Parity: svgo hat ~30 Core-Plugins (preset-default) + Ökosystem-Plugins. oxvg deckt die wichtigsten ab (removeComments, removeMetadata, removeEmptyAttrs, cleanupNumericValues, mergePaths, convertColors, removeHiddenElems, etc.) aber nicht 100%. v1-Scope auf `preset-default` begrenzen.
+  - Custom-JS-Plugins: svgo erlaubt User-JS-Plugins (`fn visit(node) { ... }`). Das ist die **`ejs`-Falle** — wenn ein User-Plugin pro Node einen JS-Callback triggert, bricht der Green-Plan. v1 **nicht anbieten**; Config-Plugins (Built-ins mit Optionen) sind ausreichend für >95% der Nutzer.
+  - Output-Byte-Parity: oxvg's Serializer schreibt marginal anders (Attribut-Ordering, Whitespace). Build-Tools mit Hash-basiertem Caching (vite's asset-hash) müssen re-hashen. Dokumentieren, nicht fixen.
+
+## BACKLOG check
+
+Kein Eintrag in `BACKLOG.md`. Kein `docs/packages.json`-Entry. Shape-Nachbar ist `sanitize-html` (shipped Green).
+
+## FFI-overhead prediction
+
+| Factor | Assessment |
+|---|---|
+| Per-call work | Substantiell. Icon (~2 KB): 0.5–2 ms in svgo. Medium-SVG (~30 KB): 5–20 ms. Large-Export (~500 KB): 50–300 ms. Pro-Byte-Compute ist hoch (Parser + ~30 Plugin-Passes + Serializer). |
+| Input size | SVG-String 0.5 KB – 5 MB. Als `Buffer` oder UTF-8 `String` — beide flach via `docs/BASELINE.md` (<200 ns bis ~1 MB). |
+| Output size | Output meist 30–70% kleiner als Input. `String`/`Buffer`-Return flach. |
+| Stateful potential | **Hoch.** Plugin-Config + Compiled-Plugin-Chain könnte in `SvgOptimizer`-Klasse leben. Bei Build-Tools (10k Icons pro Build) spart das den Config-Parse pro Call. |
+| Batch realism | **Sehr hoch.** Build-Tools rufen `optimize()` in Schleife über alle SVG-Assets — `optimizeMany(svgs: string[], config)` kollabiert N FFI-Crossings zu einem und erlaubt Rayon-Parallelisierung über Workers. |
+| FFI-share | Single: ~5% bei Median-SVG (~10 ms Rust-Work, ~0.5 ms Input-Marshal). Batch-1000-Icons: <0.5%. |
+
+## Classification reasoning
+
+`svgo` trifft den gleichen Green-Shape-Template-Satz wie `sanitize-html` / `commonmark`:
+
+- ✅ **Bytes-in, Bytes-out** — kein Graph-Traversal über die FFI-Grenze
+- ✅ **Substantielle Compute pro Byte** — Parser + Plugin-Pipeline ist nicht trivial
+- ✅ **Keine Callback-Surface** (solange Custom-JS-Plugins ausgeschlossen bleiben)
+- ✅ **Stateful + Batch-natürlich** — Build-Tool-Use-Case liefert perfekte Amortisation
+- ✅ **Native Konkurrenz ist schwach** — svgo selbst ist pure-JS, keine nativen Bindings bisher gemainstreamed
+- ✅ **Rust-Äquivalent existiert und ist aktiv** — oxvg ist nicht hypothetisch
+
+Der einzige strukturelle Fallstrick ist die **Custom-JS-Plugin-API**. svgo's public Contract erlaubt User-Code als Plugins (`{ name, fn(root) { ... } }`). Das ist der `ejs`-Killer — wenn wir das anbieten, triggert jede Node-Visit-Callback einen FFI-Roundtrip. v1 **darf das nicht exponieren**. Migration-Pfad für Power-User: entweder sie bleiben auf svgo, oder wir exponieren später `svgo-compat`-Plugin, das svgo als Fallback für custom-Plugin-Fälle lädt (analog zum `canvg`-Pattern für chart.js-Kompat).
+
+**Shape-Match:**
+- ✅ Wie `sanitize-html` (shipped Green): Parser + Transform + Serializer, bytes-in/bytes-out
+- ✅ Wie `commonmark`: Parser + Pipeline + Serializer, Batch-amortisierbar
+- ❌ **Nicht** wie `mime` / `deep-equal` (kein Short-Input-Hot-Loop, kein Trivial-Compute)
+- ❌ **Nicht** wie `chart.js` (keine Runtime-Abhängigkeit, keine Animations-Callbacks)
+
+**Benchmark-Gap-Flag:** Green-Prediction braucht oxvg-Parity-Verifikation vor Shipping. Falls oxvg wichtige Plugins noch nicht hat (z.B. `mergePaths` oder `convertPathData` — die teuersten und gewinnträchtigsten), muss entweder auf oxvg-PRs gewartet oder custom-Port gebaut werden. Vor Port-Start: Cross-Check der oxvg-Plugin-Matrix gegen svgo's `preset-default`.
+
+## If GO — proposed port
+
+- **Recommended crate-name:** `@amigo-labs/svgo` (Drop-in-orientiert, weil oxvg bereits diesen Contract anvisiert — Naming unterstützt Migration-Positionierung)
+- **Primary API sketch:**
+  ```ts
+  type SvgoPlugin =
+    | 'removeComments'
+    | 'removeMetadata'
+    | 'removeEmptyAttrs'
+    | 'cleanupNumericValues'
+    | 'mergePaths'
+    | 'convertColors'
+    | 'removeHiddenElems'
+    | 'convertPathData'
+    | 'collapseGroups'
+    | { name: SvgoPlugin; params?: Record<string, unknown> };
+
+  type SvgoConfig = {
+    plugins?: SvgoPlugin[];        // default: preset-default-äquivalent
+    multipass?: boolean;           // default: false
+    floatPrecision?: number;       // default: 3
+  };
+
+  type SvgoResult = {
+    data: string;                  // optimierter SVG
+    info: { inputBytes: number; outputBytes: number; savedPercent: number };
+  };
+
+  export function optimize(svg: string | Buffer, config?: SvgoConfig): SvgoResult;
+  export function optimizeMany(
+    svgs: Array<string | Buffer>,
+    config?: SvgoConfig
+  ): SvgoResult[];        // intern mit Rayon über N Cores parallelisiert
+
+  export class SvgOptimizer {
+    constructor(config?: SvgoConfig);
+    optimize(svg: string | Buffer): SvgoResult;
+    optimizeMany(svgs: Array<string | Buffer>): SvgoResult[];
+  }
+  ```
+  **Nicht** angeboten: Custom-Function-Plugins. Dokumentiert als expliziter v1-Scope-Cut.
+- **Must-have benchmark scenarios:**
+  - **Icon (2 KB):** 2-KB-Figma-Export-Icon, preset-default. Green-Gate: ≥ 2×.
+  - **Medium (30 KB):** Illustrations-SVG. Green-Gate: ≥ 3×.
+  - **Large (500 KB):** komplexes Chart-/Diagramm-SVG mit hunderten Paths. Green-Gate: ≥ 3×.
+  - **Batch-1000-Icons:** `optimizeMany(1000 × 2-KB-Icon)`. Green-Gate: ≥ 5× (Rayon-Parallelisierung über Cores).
+  - **Stateful-Reuse (100 Optimize-Calls auf gleicher `SvgOptimizer`-Instance):** misst Config-Cache-Hebel. Green-Gate: ≥ 1.1× Fresh-Instance-Baseline (moderat, nur Config-Parse-Ersparnis).
+- **Green gate:** alle fünf Szenarien + Plugin-Parity-Matrix für `preset-default` zu ≥95%.
+- **Risks:**
+  - **Plugin-Parity-Tail:** svgo's Plugin-Set ist das Produkt von 10 Jahren Community-Iteration. oxvg hat ~25 der 30 Core-Plugins. Die fehlenden 5 sind meist Edge-Case-Optimierungen (`reusePaths`, `sortAttrs`), die Gewinn < 2% bringen — können als "v1 not supported, pass through unchanged" dokumentiert werden.
+  - **Custom-Plugin-Surface:** Manche Enterprise-User haben eigene svgo-Plugins. Migration-Path: sie bleiben auf svgo, oder wir shippen `@amigo-labs/svgo` mit explizitem `externalPlugins: false`-Contract und sie entscheiden sich bewusst.
+  - **Output-Byte-Parity:** oxvg's Serializer optimiert anders als svgo's. Build-Tools mit Hash-basiertem Caching sehen einen einmaligen Cache-Invalidation-Spike beim Migration. Dokumentieren als Breaking-Change in v1.
+  - **oxvg-Maturity:** Q1 2026 pre-1.0. Falls oxvg nicht stabil genug ist für amigo's Release-Cadence, Option B: direkt auf `usvg`-Parser aufbauen und eigene Plugin-Pipeline schreiben (~2000 Zeilen Rust). Scope-Entscheidung vor Port-Start.
+  - **Baseline-Nuance:** SVG-String-Input ist UTF-8 — `String`-Argument triggert V8-UTF-16→UTF-8-Conversion. Für große SVGs (>100 KB) messbar. `Buffer`-Overload als primärer API-Pfad, `String` als Convenience-Shim. `docs/BASELINE.md:echoBuffer` deckt das.
+
+## If NO-GO — BACKLOG entry
+
+Nicht einschlägig — Prediction ist Green mit hoher Konfidenz (`sanitize-html`-Präzedenzfall). Falls Review nach Measurement doch Yellow wird:
+
+```markdown
+- **svgo** (~10M/Woche). SVG-Optimizer. Shape-Green, aber oxvg-Plugin-Parity zu `preset-default` nicht ausreichend (<95% der Optimierungen angewendet, Output-Bytes nennenswert größer als svgo). Port eingefroren bis oxvg-1.0 oder Custom-Pipeline-Budget verfügbar. Siehe `docs/perf-review/svgo.md`.
+```
+
+Section: **Parity too expensive**.


### PR DESCRIPTION
Chart-ecosystem follow-up to chart.js NO-GO. Three chart-adjacent compute libraries that escape the chart.js disqualifiers (browser runtime, native competitor, plugin callbacks):

- dagre: GO as @amigo-labs/graph-layout, Green predicted. Sugiyama layered graph layout, bytes-in/bytes-out, no DOM dependency.
- d3-force: GO as @amigo-labs/force-layout, Yellow-leaning-Green. Batch simulate() path only; tick-callback animation stays on JS.
- svgo: GO as @amigo-labs/svgo, Green predicted. Same shape as shipped sanitize-html; oxvg as Rust backend. Custom-JS-plugin surface explicitly excluded from v1.

https://claude.ai/code/session_013z67j7i26o4qDryenUbXEX

<!-- Title suggestion: <type>(<crate>): <short summary>
     where <type> is one of feat, fix, perf, docs, chore, refactor, test -->

## What changed

<!-- One or two sentences on the user-visible change. Link the issue if any. -->

## Why

<!-- The "why" rather than the "what" — what problem does this solve? -->

## Scope checklist

- [ ] This PR touches a single crate, or is a doc/CI-only change.
- [ ] Exported API surface didn't change, or `MIGRATION.md` was updated.
- [ ] `package.json` `amigo` block is accurate; `node scripts/sync-registry.mjs`
      was run if the package's metadata changed.
- [ ] Platform-stub `npm/` directories are in sync (six targets).
- [ ] `pnpm lint` and `pnpm test` pass locally.

## Benchmarks

<!-- Delete this section for doc/CI-only PRs. -->

Before / after numbers on the scenarios this PR touches. Prefer:

```
node scripts/run-benchmarks.mjs --crates <name>
```

<!-- Paste the relevant `bench-results-<name>.json` excerpt or a readable
     summary. If the verdict in `docs/perf-review.md` shifts (Green ↔ Yellow
     ↔ Red), update that file in this PR. -->

## Conformance

<!-- If you touched behaviour, point at the test that covers it. For crates
     with `__conformance__/upstream.spec.ts`, note if parity score changed. -->

## Breaking changes

<!-- If any: document in `MIGRATION.md`, bump the major. Delete this section
     if not applicable. -->
