### PR TITLE
docs: translate FFI overhead baseline to English

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Language
+
+All repository content — documentation, code comments, commit messages, PR
+descriptions, and perf-review / post-mortem documents — must be written in
+**English**. This applies to every file under `docs/`, every crate
+`README.md`, `BACKLOG.md`, `CONTRIBUTING.md`, and all source-code comments.
+
+Non-English strings are only allowed when they are deliberate test fixtures
+for Unicode handling (e.g. `"Schöne Grüße"` in a slugify test, `"café"` in
+an encoding test). Those are data, not prose, and should stay as-is.
+
+When adding new documentation or translating existing content, keep the
+tone and formatting consistent with the surrounding English text.

--- a/docs/BASELINE.md
+++ b/docs/BASELINE.md
@@ -1,111 +1,110 @@
-# FFI-Overhead-Baseline
+# FFI Overhead Baseline
 
-> Was kostet ein `@amigo-labs/*`-Call, bevor irgendeine eigentliche
-> Arbeit passiert? Diese Zahlen sind der Referenzwert für jede andere
-> Perf-Diskussion in diesem Repo. Ein Package das pro Call weniger
-> echtes Work macht als diese Tabelle zeigt, kann die Alternative in JS
-> strukturell nicht schlagen — egal wie schnell der Rust-Code selbst
-> ist.
+> What does an `@amigo-labs/*` call cost before any actual work
+> happens? These numbers are the reference point for every other
+> perf discussion in this repo. A package that does less real work
+> per call than this table shows cannot structurally beat the JS
+> alternative — no matter how fast the Rust code itself is.
 
-## Messaufbau
+## Measurement Setup
 
-- Crate: `crates/_ffi-bench/` (nicht publiziert, `publish = false`)
-- Harness: `vitest bench` (`npm run bench` im Crate)
-- Release-Profil: `lto = true, codegen-units = 1, strip = "symbols", panic = "abort"`
-- Node: v22.22.2 auf linux/x64 (glibc)
+- Crate: `crates/_ffi-bench/` (not published, `publish = false`)
+- Harness: `vitest bench` (`npm run bench` inside the crate)
+- Release profile: `lto = true, codegen-units = 1, strip = "symbols", panic = "abort"`
+- Node: v22.22.2 on linux/x64 (glibc)
 
-Alle fünf Primitive machen pro Call **keine** eigentliche Arbeit — sie
-messen nur, was die N-API-Grenze an Fixkosten produziert.
+All five primitives perform **no** actual work per call — they only
+measure the fixed costs produced by the N-API boundary.
 
-## Messung
+## Measurements
 
 | Primitive | Ops/s | Per-Call | Interpretation |
 |---|---:|---:|---|
-| `noop()` | 9,15 M | **109 ns** | Der **harte Floor**. Jeder NAPI-Call zahlt das, Punkt. |
-| `echoString(s) → String`, 10 B | 4,28 M | ~234 ns | +125 ns: zwei Mini-UTF-16/UTF-8-Konvertierungen. |
-| `echoString` 1 KB | 1,28 M | ~780 ns | +670 ns ≈ 0,6 ns/byte Mehrkosten. |
-| `echoString` 100 KB | 28,8 k | ~34,7 µs | ~0,35 ns/byte, skaliert praktisch linear. |
-| `echoBuffer(b) → Buffer`, 1 KB | 5,56 M | ~180 ns | Nur +70 ns auf noop. |
-| `echoBuffer` 100 KB | 5,75 M | ~174 ns | **Flat**. |
-| `echoBuffer` 10 MB | 5,58 M | ~179 ns | **Flat auch bei 10 MB** — Buffer ist eine V8-Handle, kein memcpy. |
-| `sumArray(xs: Vec<u32>)`, 10 Elemente | 1,44 M | ~694 ns | ~58 ns pro u32 oben auf den Fixkosten. |
-| `sumArray` 1000 Elemente | 23,0 k | ~43,4 µs | **~43 ns pro u32** für Array-Marshalling. |
-| `sumArray` 100 000 Elemente | 233 | ~4,29 ms | ~43 ns pro u32 — skaliert linear. |
+| `noop()` | 9.15 M | **109 ns** | The **hard floor**. Every NAPI call pays this, period. |
+| `echoString(s) → String`, 10 B | 4.28 M | ~234 ns | +125 ns: two tiny UTF-16/UTF-8 conversions. |
+| `echoString` 1 KB | 1.28 M | ~780 ns | +670 ns ≈ 0.6 ns/byte of extra cost. |
+| `echoString` 100 KB | 28.8 k | ~34.7 µs | ~0.35 ns/byte, scales essentially linearly. |
+| `echoBuffer(b) → Buffer`, 1 KB | 5.56 M | ~180 ns | Only +70 ns on top of noop. |
+| `echoBuffer` 100 KB | 5.75 M | ~174 ns | **Flat**. |
+| `echoBuffer` 10 MB | 5.58 M | ~179 ns | **Flat even at 10 MB** — a Buffer is a V8 handle, not a memcpy. |
+| `sumArray(xs: Vec<u32>)`, 10 elements | 1.44 M | ~694 ns | ~58 ns per u32 on top of the fixed costs. |
+| `sumArray` 1000 elements | 23.0 k | ~43.4 µs | **~43 ns per u32** for array marshalling. |
+| `sumArray` 100,000 elements | 233 | ~4.29 ms | ~43 ns per u32 — scales linearly. |
 
-## Was das heißt
+## What This Means
 
-### 1. Der Floor ist 109 ns
+### 1. The Floor is 109 ns
 
-Für jedes Package im Repo gilt: **eine Rust-Funktion, die gerufen und
-ein Ergebnis zurückgibt, kostet mindestens 109 ns**. Wenn die JS-
-Alternative für denselben Input < 109 ns braucht — zum Beispiel weil
-sie nur auf einem vorberechneten Buffer arbeitet — hat Rust keine
-Chance. Bei `nanoid` war genau das der Befund: nanoid@5 braucht ~260
-ns pro Call; ein Rust-Binding kostete ~1500 ns (siehe Phase B unten
-für die Messung). Deswegen wurde `nanoid` auf pure-JS umgestellt.
+For every package in the repo: **a Rust function that gets called
+and returns a result costs at least 109 ns**. If the JS alternative
+needs < 109 ns for the same input — for example because it only
+operates on a precomputed buffer — Rust has no chance. With
+`nanoid` that was exactly the finding: nanoid@5 takes ~260 ns per
+call; a Rust binding cost ~1500 ns (see Phase B below for the
+measurement). That's why `nanoid` was switched to pure JS.
 
-### 2. Strings kosten je 100 KB etwa 35 µs
+### 2. Strings Cost About 35 µs per 100 KB
 
-Jedes `fn foo(s: String) -> String` zahlt an beiden Enden der FFI die
-UTF-16 ↔ UTF-8-Konvertierung. Bei großen Texten frisst das genug
-Zeit, dass jeder Algorithmus der weniger als ~0,5 ns/byte echten
-Compute macht, vom Konvertieren selbst überholt wird. Beobachtung:
-`encoding`'s UTF-8-encode-10MB war vor dem Fix 2,1× langsamer als
-`iconv-lite`, weil wir 10 MB zweimal durch den FFI-Konvertierer
-schickten (Input + Output) und noch einen `.into_owned()` obendrauf.
+Every `fn foo(s: String) -> String` pays the UTF-16 ↔ UTF-8
+conversion at both ends of the FFI. For large texts that eats up
+enough time that any algorithm doing less than ~0.5 ns/byte of real
+compute is overtaken by the conversion itself. Observation:
+`encoding`'s UTF-8-encode-10MB was 2.1× slower than `iconv-lite`
+before the fix, because we were sending 10 MB through the FFI
+converter twice (input + output) with an extra `.into_owned()` on
+top.
 
-**Faustregel:** Wenn der Rust-Code pro Byte weniger macht als ~1 ns
-echten Compute, entweder
-- den String-Input durch einen `Buffer`-Input ersetzen (Zero-Copy,
-  Caller hält die Bytes), oder
-- das Package in pure JS neu schreiben (wie `nanoid`), oder
-- erst gar nicht portieren.
+**Rule of thumb:** If the Rust code does less than ~1 ns per byte of
+real compute, either
+- replace the string input with a `Buffer` input (zero-copy, the
+  caller owns the bytes), or
+- rewrite the package in pure JS (like `nanoid`), or
+- don't port it in the first place.
 
-### 3. Buffer ist essentiell flat — das ist die schnelle Lane
+### 3. Buffers Are Essentially Flat — That's the Fast Lane
 
-`echoBuffer` ist **flach auf ~180 ns von 1 KB bis 10 MB**. Das ist der
-entscheidende Unterschied: N-API-Buffer sind V8-Handles, die beim
-Crossing nur eine Referenz hin und her reichen — keine Kopie. **10 MB
-kosten exakt so viel wie 1 KB**: 180 ns.
+`echoBuffer` is **flat at ~180 ns from 1 KB to 10 MB**. That's the
+decisive difference: N-API buffers are V8 handles that only pass a
+reference back and forth when crossing — no copy. **10 MB costs
+exactly as much as 1 KB**: 180 ns.
 
-Konsequenz für jedes neue Package: **Bytes-in-Bytes-out ist immer der
-billigste Pfad.** Wenn der Output eines Algorithmus ein Binärblob ist
-(Hash, komprimierte Daten, Bildpixel, UTF-8-Bytes), zurückgeben als
-`Buffer`, niemals als `String` oder `Vec<u8>`.
+Consequence for every new package: **bytes-in-bytes-out is always
+the cheapest path.** If the output of an algorithm is a binary blob
+(hash, compressed data, image pixels, UTF-8 bytes), return it as a
+`Buffer`, never as a `String` or `Vec<u8>`.
 
-### 4. `Vec<T>`-Arrays sind teuer — 43 ns pro Element
+### 4. `Vec<T>` Arrays Are Expensive — 43 ns per Element
 
-`sumArray(Vec<u32>)` kostet ~43 ns pro Element. Ein Array von 1000
-u32 frisst 43 µs an reinem Marshalling — **das gleiche Datenvolumen
-als Buffer reingereicht kostet 180 ns**. Faktor **240× teurer**.
+`sumArray(Vec<u32>)` costs ~43 ns per element. An array of 1000
+u32s eats 43 µs of pure marshalling — **the same data volume passed
+in as a Buffer costs 180 ns**. Factor **240× more expensive**.
 
-Konsequenz: wenn eine Package-Funktion eine Liste von Zahlen oder
-Bytes verarbeitet, soll sie `Buffer` bzw. `Uint8Array` annehmen, nie
-`Vec<T>` von Primitives. Für u16/u32/f64 entsprechend `TypedArray`.
+Consequence: if a package function processes a list of numbers or
+bytes, it should accept a `Buffer` or `Uint8Array`, never `Vec<T>`
+of primitives. For u16/u32/f64 use the corresponding `TypedArray`.
 
-Beispiel aus dem Repo: `xxhash batch 1000 × 64 bytes` war 4,8 bis 5,7×
-langsamer als xxhash-wasm. Vermutung (zu verifizieren): Die Batch-API
-gibt Hashes als `Vec<BigInt>` zurück. Das sind 1000 BigInt-
-Konstruktionen + Array-Marshalling = ein großer Teil der Laufzeit. Ein
-zurückgegebener `Buffer` (1000 × 8 Bytes = 8 KB) wäre ~180 ns
-konstant.
+Example from the repo: `xxhash batch 1000 × 64 bytes` was 4.8 to
+5.7× slower than xxhash-wasm. Hypothesis (to be verified): the
+batch API returns hashes as `Vec<BigInt>`. That's 1000 BigInt
+constructions + array marshalling = a large chunk of the runtime.
+A returned `Buffer` (1000 × 8 bytes = 8 KB) would be ~180 ns flat.
 
-### 5. Was kriegt man für diese Fixkosten "zurück"?
+### 5. What Do You Get "Back" for These Fixed Costs?
 
-Damit ein Rust-Port sich lohnt, muss die Differenz zwischen
-**(Rust-Work + FFI-Overhead)** und **(JS-Work)** signifikant werden.
-Daumenregel:
+For a Rust port to pay off, the difference between **(Rust work +
+FFI overhead)** and **(JS work)** has to become significant. Rule
+of thumb:
 
-- JS-Work < 1 µs pro Call → Rust-Port lohnt sich nur mit Batch-API
-  oder wenn der Rust-Algorithmus dramatisch (10×+) schneller ist.
-- JS-Work 1–10 µs → 2× Speedup realistisch, wenn Rust-Algorithmus
-  messbar schneller ist und die FFI keine Vec-Marshalling-Falle hat.
-- JS-Work > 10 µs → FFI-Overhead unter 10 %, voller Rust-Gewinn
-  geht durch.
+- JS work < 1 µs per call → a Rust port only pays off with a batch
+  API or if the Rust algorithm is dramatically (10×+) faster.
+- JS work 1–10 µs → a 2× speedup is realistic if the Rust algorithm
+  is measurably faster and the FFI has no Vec-marshalling trap.
+- JS work > 10 µs → FFI overhead is under 10%, the full Rust win
+  comes through.
 
-Diese Zahlen hängen an deiner Hardware + Node-Version, aber die
-Größenordnungen bleiben stabil. Aktualisieren, wenn sich die Toolchain
-ändert (Node-Major-Bump, V8-Major-Bump, napi-rs-Major-Bump).
+These numbers depend on your hardware + Node version, but the
+orders of magnitude stay stable. Update them when the toolchain
+changes (Node major bump, V8 major bump, napi-rs major bump).
 
 ## Reproducing
 

--- a/docs/perf-review.md
+++ b/docs/perf-review.md
@@ -1,122 +1,122 @@
-# Perf-Review
+# Perf review
 
-> Ehrliche Klassifizierung der 16 publizierten `@amigo-labs/*`-Packages
-> gegen ihre jeweiligen JS-Alternativen. Entscheidungsgrundlage:
-> `npm run bench` Zahlen aus `bench-results.json` (gemessen
-> 2026-04-18, Node v22.22.2 linux/x64) und der FFI-Overhead-Baseline in
-> `docs/BASELINE.md` (noop = 109 ns, echoString 100KB = 34,7 µs, Buffer
-> echo konstant ~180 ns).
+> Honest classification of the 16 published `@amigo-labs/*` packages
+> against their respective JS alternatives. Basis for the decision:
+> `npm run bench` numbers from `bench-results.json` (measured
+> 2026-04-18, Node v22.22.2 linux/x64) and the FFI overhead baseline in
+> `docs/BASELINE.md` (noop = 109 ns, echoString 100KB = 34.7 µs, Buffer
+> echo constant ~180 ns).
 
-## Verdikt-Legende
+## Verdict legend
 
-- 🟢 **Green** — mindestens 2× schneller als bestes JS-Alternative auf
-  mittleren/großen Inputs, nie langsamer als 1× auf realistischem
-  Minimum. Package hat klare Daseinsberechtigung.
-- 🟡 **Yellow** — gemischte Ergebnisse oder nur grenzwertig schneller.
-  Ein Optimierungs-Sprint (Phase C) entscheidet über Upgrade zu Green
-  oder Downgrade zu Red.
-- 🔴 **Red** — verliert meistens oder auf realistischem Median gegen
-  JS-Alternative. Kandidat zum Deprecaten (Phase D) außer ein
-  radikaler Rewrite bringt messbare Wende.
-- ⚫ **Black** — strukturell falsche Entscheidung. NAPI kann den
-  Use-Case nicht gewinnen.
+- 🟢 **Green** — at least 2× faster than the best JS alternative on
+  medium/large inputs, never slower than 1× on the realistic
+  minimum. The package has a clear reason to exist.
+- 🟡 **Yellow** — mixed results or only marginally faster.
+  An optimization sprint (Phase C) decides upgrade to Green
+  or downgrade to Red.
+- 🔴 **Red** — loses on the realistic median against the JS
+  alternative most of the time. Candidate for deprecation (Phase D) unless a
+  radical rewrite produces a measurable turnaround.
+- ⚫ **Black** — structurally the wrong call. NAPI cannot win the
+  use-case.
 
-## Nach-Sprint-Stand (Phase C/D abgeschlossen)
+## Post-sprint state (Phase C/D complete)
 
-Nach den Optimierungs-Sprints und dem Deprecation-Sweep:
+After the optimization sprints and the deprecation sweep:
 
-| Package | Verdikt | Post-Sprint-Range | Was passiert ist |
+| Package | Verdict | Post-sprint range | What happened |
 |---|---|---|---|
-| **slugify** | 🟢 | 3,0× – 6,0× | unverändert — war bereits Green |
-| **deepmerge** | 🟢 | 3,3× – 5,9× | unverändert |
-| **file-type** | 🟢 | 16× – 1265× | unverändert |
-| **jwt** | 🟢 | 1,4× – 4,8× | unverändert |
-| **sanitize-html** | 🟢 | 1,44× – 3,94× | unverändert |
-| **csv** | 🟢 | **1,43× – 1,77×** alle Größen | `parse()` routet jetzt durch `parseToJson + JSON.parse`. Von Red→Green auf allen drei Größen. (Commit `ecf8408`) |
-| **zip** | 🟢 | 2,66× – 3,7× | `extractAll()` hinzugefügt. Letzte Regression (0,56×) → 2,66× gegen adm-zip. (Commit `16c74ed`) |
-| **xxhash** | 🟢 | Large-Buffer 1,2×–2,5×, Batch **2,44× – 4,00×** | `*Batch(Vec<Buffer>)→Vec<T>` gelöscht, durch `*Many(Buffer, chunkSize)→Buffer` ersetzt. 0,17× → 4,00× auf dem schlimmsten Batch-Szenario. (Commit `4c6fb50`) |
-| **encoding** | 🟢 | latin1 decode **14,8×**, UTF-8 an Parität, shift_jis **1,17×** | Shift_JIS nach encoding_rs-Upgrade jetzt über iconv-lite (961 vs 821 hz auf 100 KB, siehe `docs/data.json`). Status von Yellow → Green. |
-| **commonmark** | 🟢 | 3,5× – 8,1× vs `marked` / `markdown-it` | Neuer Port auf `pulldown-cmark` — explizit CommonMark+GFM spec-strict statt `marked`-Drop-in. Green über alle Größen (small bis large). |
-| **jose** | 🟢 | 1,62× – 6,97× | Rescope: `generateRsaKeyPair` aus Public-API entfernt (2,6× langsamer als panva/jose). Shipped surface — Ed25519 keygen + JWK-Thumbprint — alle net-positiv. (Commit `12cf84e`) |
-| **tiktoken** | 🟢 | 2,22× – 23,4× vs `js-tiktoken` + `tiktoken`-WASM | BPE-Tokenizer via `tiktoken-rs`, Singleton-NAPI-Class. Gegen `gpt-tokenizer` (LRU-Merge-Cache in JS) strukturell 0,3×–0,5× — Positionierung als pure-JS/WASM-Killer, nicht gpt-tokenizer-Killer. (Commit `2b49284`) |
-| **inflate** | 🟡 | deflate 4,1×–6,4×, inflate 0,46×–0,49× | Direct-Decompress-API + pre-alloc auf 1,7× des alten Inflate-Stands. zlib-rs selbst limitiert hier; Backend-Wechsel aufgeschoben. (Commit `32d7dfa`) |
-| **argon2** | 🟡 | 1,37× | CPU-bound, Optimierungs-Ceiling erreicht. Keep as-is. |
-| **bcrypt** | 🟡 | 1,10×–1,42× vs `bcrypt`-npm, 1,37×–1,56× vs `bcryptjs` | Phase-C: pure-Rust Blowfish-Backend durch vendored Solar-Designer `crypt_blowfish` C-Source ersetzt. Red→Yellow; 2× Green-Gate strukturell nicht erreichbar (identischer Algorithmus in beiden Konkurrenten). (Commit `53db550`) |
-| **nanoid** | 🟡→Green-ish | 1,03× – 1,08× über nanoid@5 | Bereits pure-JS seit `794396b`. Schlägt nanoid@5 überall knapp; 0,8× vs `crypto.randomUUID` (erwartbar: weniger Work pro ID). |
-| **deep-equal** | 🗄️ **ARCHIVED** | 0,96× – 1,30× | Archived 2026-04-19. Re-review bestätigte Red, kein FFI-Hebel denkbar. Post-Mortem in `docs/post-mortems/deep-equal.md`, Review in `docs/perf-review/deep-equal.md`. |
-| **levenshtein** | 🗄️ **ARCHIVED** | 0,13× – 1,10× | Archived 2026-04-19 nach Phase-C-Spike (`distanceU16`) — Gate ≥1,5× bei 10k chars verfehlt (6,7× langsamer als fast-levenshtein). Siehe `docs/perf-review/levenshtein.md` und `docs/post-mortems/levenshtein.md`. |
-| **xml** | 🗄️ **ARCHIVED** | parseXml 0,44× – 0,68× / parseXmlToJson 0,72× – 1,55× | Archived 2026-04-19 (never published). Re-review mit `parseXmlToJson` verliert 100 KB-Median und 10 MB; 10 MB ist JSON.parse-gebunden. `archived/xml/` + `docs/perf-review/xml.md`. |
+| **slugify** | 🟢 | 3.0× – 6.0× | unchanged — was already Green |
+| **deepmerge** | 🟢 | 3.3× – 5.9× | unchanged |
+| **file-type** | 🟢 | 16× – 1265× | unchanged |
+| **jwt** | 🟢 | 1.4× – 4.8× | unchanged |
+| **sanitize-html** | 🟢 | 1.44× – 3.94× | unchanged |
+| **csv** | 🟢 | **1.43× – 1.77×** across sizes | `parse()` now routes through `parseToJson + JSON.parse`. Red→Green on all three sizes. (Commit `ecf8408`) |
+| **zip** | 🟢 | 2.66× – 3.7× | `extractAll()` added. Last regression (0.56×) → 2.66× against adm-zip. (Commit `16c74ed`) |
+| **xxhash** | 🟢 | large-buffer 1.2×–2.5×, batch **2.44× – 4.00×** | `*Batch(Vec<Buffer>)→Vec<T>` deleted, replaced by `*Many(Buffer, chunkSize)→Buffer`. 0.17× → 4.00× on the worst batch scenario. (Commit `4c6fb50`) |
+| **encoding** | 🟢 | latin1 decode **14.8×**, UTF-8 at parity, shift_jis **1.17×** | Shift_JIS now ahead of iconv-lite after the encoding_rs upgrade (961 vs 821 hz at 100 KB, see `docs/data.json`). Status Yellow → Green. |
+| **commonmark** | 🟢 | 3.5× – 8.1× vs `marked` / `markdown-it` | New port on `pulldown-cmark` — explicitly CommonMark+GFM spec-strict instead of a `marked` drop-in. Green across all sizes (small to large). |
+| **jose** | 🟢 | 1.62× – 6.97× | Rescope: `generateRsaKeyPair` removed from the public API (2.6× slower than panva/jose). Shipped surface — Ed25519 keygen + JWK thumbprint — all net-positive. (Commit `12cf84e`) |
+| **tiktoken** | 🟢 | 2.22× – 23.4× vs `js-tiktoken` + `tiktoken` WASM | BPE tokenizer via `tiktoken-rs`, singleton NAPI class. Against `gpt-tokenizer` (LRU merge cache in JS) structurally 0.3×–0.5× — positioned as a pure-JS/WASM killer, not a gpt-tokenizer killer. (Commit `2b49284`) |
+| **inflate** | 🟡 | deflate 4.1×–6.4×, inflate 0.46×–0.49× | Direct-decompress API + pre-alloc lifts it to 1.7× of the old inflate state. zlib-rs itself limits us here; backend swap deferred. (Commit `32d7dfa`) |
+| **argon2** | 🟡 | 1.37× | CPU-bound, optimization ceiling reached. Keep as-is. |
+| **bcrypt** | 🟡 | 1.10×–1.42× vs `bcrypt`-npm, 1.37×–1.56× vs `bcryptjs` | Phase C: pure-Rust Blowfish backend replaced with vendored Solar Designer `crypt_blowfish` C source. Red→Yellow; 2× Green gate structurally unreachable (identical algorithm in both competitors). (Commit `53db550`) |
+| **nanoid** | 🟡→Green-ish | 1.03× – 1.08× over nanoid@5 | Already pure JS since `794396b`. Edges past nanoid@5 everywhere; 0.8× vs `crypto.randomUUID` (expected: less work per ID). |
+| **deep-equal** | 🗄️ **ARCHIVED** | 0.96× – 1.30× | Archived 2026-04-19. Re-review confirmed Red, no conceivable FFI lever. Post-mortem in `docs/post-mortems/deep-equal.md`, review in `docs/perf-review/deep-equal.md`. |
+| **levenshtein** | 🗄️ **ARCHIVED** | 0.13× – 1.10× | Archived 2026-04-19 after the Phase C spike (`distanceU16`) — gate ≥1.5× at 10k chars missed (6.7× slower than fast-levenshtein). See `docs/perf-review/levenshtein.md` and `docs/post-mortems/levenshtein.md`. |
+| **xml** | 🗄️ **ARCHIVED** | parseXml 0.44× – 0.68× / parseXmlToJson 0.72× – 1.55× | Archived 2026-04-19 (never published). Re-review with `parseXmlToJson` loses the 100 KB median and the 10 MB; 10 MB is JSON.parse-bound. `archived/xml/` + `docs/perf-review/xml.md`. |
 
-**Net (Stand nach den 4 post-Sprint-Shipments bcrypt / commonmark / jose / tiktoken):** 5 Green → **12 Green** + 1 faktisch-Green (nanoid). 7 Yellow → **3 Yellow** (argon2, inflate, bcrypt — alle drei algorithmisch/Backend-limitiert, 2× Gate strukturell nicht erreichbar). 3 Red → 3 Deprecated (3-Monats-Window). Portfolio-Total: 16 shipped.
+**Net (state after the 4 post-sprint shipments bcrypt / commonmark / jose / tiktoken):** 5 Green → **12 Green** + 1 effectively Green (nanoid). 7 Yellow → **3 Yellow** (argon2, inflate, bcrypt — all three algorithmically/backend-limited, 2× gate structurally unreachable). 3 Red → 3 Deprecated (3-month window). Portfolio total: 16 shipped.
 
-**Update 2026-04-19 (Perf-Sprint)**: encoding von Yellow → Green nach shift_jis Re-Messung (1,17× statt 0,65×). Inflate bleibt Yellow mit laufendem Backend-Spike (`docs/perf-review/inflate-backend-spike.md`); zusätzlich `decompress_bulk` ohne Zero-Init-Output-Buffer (erwartet +5–15 % auf 10 MB Inflate). Neue additive APIs im Portfolio: `renderFast`/`renderBytesFast` — jeweils Option-Unmarshalling-frei für FFI-floor-dominierte Cases. file-type async bounded copy auf 4 KB Prefix (vorher: voller Buffer).
+**Update 2026-04-19 (perf sprint)**: encoding moved Yellow → Green after the shift_jis re-measurement (1.17× instead of 0.65×). Inflate stays Yellow with an ongoing backend spike (`docs/perf-review/inflate-backend-spike.md`); additionally `decompress_bulk` without a zero-init output buffer (expected +5–15% on 10 MB inflate). New additive APIs in the portfolio: `renderFast`/`renderBytesFast` — each option-unmarshalling-free for FFI-floor-dominated cases. file-type async bounded copy to a 4 KB prefix (previously: full buffer).
 
-Die 8-Green-Packages sind alle netto-schneller-als-JS auf jedem gemessenen Szenario. Das ist die Qualitätsgarantie für das Portfolio: keine Footguns mehr, keine "works well for X but slow for Y"-Überraschungen in den Green-Packages.
+The 8 Green packages are all net-faster-than-JS on every measured scenario. That's the quality guarantee for the portfolio: no more footguns, no more "works well for X but slow for Y" surprises in the Green packages.
 
-## Ursprüngliche Klassifizierung (pre-Sprint)
+## Original classification (pre-sprint)
 
-Dieser Abschnitt dokumentiert die Post-Phase-A-Baseline. Verdikte oben unter "Nach-Sprint-Stand" sind aktuell.
+This section documents the post-phase-A baseline. Verdicts above under "Post-sprint state" are current.
 
-## Ergebnis-Übersicht
+## Result overview
 
-| Package | Verdikt | Range (amigo vs best JS) | Kommentar |
+| Package | Verdict | Range (amigo vs best JS) | Comment |
 |---|---|---|---|
-| **slugify** | 🟢 | **3,0× – 6,0×** | Unicode-normalize + transliterate ist echtes Work, FFI-Overhead klein relativ zu. Keep as-is. |
-| **deepmerge** | 🟢 | **3,3× – 5,9×** | Object-Merging-Allokationen in Rust meaningful schneller als in JS. |
-| **file-type** | 🟢 | **16× – 1265×** | Upstream ist async API die für synchron blockieren muss; unser sync-Path ist trivial. |
-| **jwt** | 🟢 | **1,4× – 4,8×** | Alle 6 Szenarien (HS256/RS256/ES256 sign/verify) schneller. Crypto ist Compute-bound. |
-| **sanitize-html** | 🟢 | **1,44× – 3,94×** | Small-case 1,44× ist grenzwertig aber nicht unter 1; scaled sauber auf 3,94× bei 100 KB. Hybrid-Engine (Tokenizer + Strict-Fallback) bereits implementiert. |
-| **argon2** | 🟡 | 1,37× (einziges Szenario) | Schwach oberhalb Parität. Noch keine RS256-/ES256-Style-Variationen gebenched. **Sprint**: zweite Config messen; evtl. Batch-API. |
-| **csv** | 🟡 | `parseToJson` 1,59× – 1,78× ✓; plain `parse` **0,71× – 1,08×** ✗ | Zwei Entry-Points mit wildly unterschiedlicher Perf. Plain-`parse` verliert auf großen Inputs gegen `papaparse`. **Sprint**: `parse` entweder fixen oder deprecaten zugunsten von `parseToJson`. |
-| **encoding** | 🟡 | latin1 decode 10MB **14,7×** ✓; shift_jis decode 0,65× ✗ | Mixed. UTF-8 / UTF-16LE / Latin-1 laufen alle über V8-Fast-Paths (Parität bis sehr schnell). Shift_JIS + CJK-Familie geht durch Rust und verliert. **Sprint**: Profilieren wo Shift_JIS-Decoder Zeit frisst. Wenn nicht fixbar → Shift_JIS aus der Package-Surface raus oder Black-dokumentieren. |
-| **inflate** | 🟡 | deflate 100KB-10MB **4,1× – 6,4×** ✓; inflate 100KB-10MB **0,29× – 0,40×** ✗ | Completely mixed: Kompression (deflate) dramatisch schneller, Dekompression (inflate) dramatisch langsamer als `node:zlib`. Das ist **im selben Package** — inkohärent für User. **Sprint**: Untersuchen warum inflate so viel schlechter ist als node:zlib (derselbe zlib-rs-Backend sollte gleich sein). Vermutung: Output-Buffer-Alloc-Strategie oder fehlendes Streaming. |
-| **nanoid** | 🟡 | 0,76× – 1,10× | Bereits von Rust auf pure-JS umgestellt (`794396b`). Kann strukturell nicht besser werden als nanoid@5 weil beide gegen dieselbe `crypto.getRandomValues`/`randomFillSync`-Primitive laufen. An Parität; 0,76×-Abstand zu `crypto.randomUUID` bei batch ist erwartbar (randomUUID ist weniger Work pro ID). **Sprint-Ziel**: Entscheiden ob das Package überhaupt noch notwendig ist (→ ggf. Black). |
-| **xxhash** | 🟡 | xxh3 1MB **2,54×** ✓; batch 1000×64B **0,15× – 0,32×** ✗ | Große-Buffer ist echter Gewinn; Batch-API ist katastrophal (5-6× langsamer als xxhash-wasm-loop). Das ist das **klassische Array-Marshalling-Antipattern** aus `docs/BASELINE.md`: `Vec<BigInt>` auszugeben kostet 43 ns pro Element allein für den FFI-Transport. **Sprint**: Batch-API muss Ergebnisse als `Buffer` (8KB für 1000 × u64) zurückgeben. |
-| **zip** | 🟡 | 4 von 5 Szenarien Green (2,8× – 3,7×); extract-all 0,56× ✗ | Ein Einzel-Ausreißer (extract 100 kleine Files). **Sprint**: Profilieren warum adm-zip bei vielen kleinen Files gewinnt; Per-Entry-Allokations-Muster vermutlich. |
-| **deep-equal** | 🔴 | 0,96× – 1,30× | Niemals meaningful schneller. `fast-deep-equal` ist winziges pures JS das V8 perfekt JITtet. Deep-equal-Arbeit pro Call ist unter 1 µs (flat 7-key: 500 ns) → FFI-Floor von 109 ns frisst 20 % des Budgets, Rust-Gewinn zu klein. **Kill** oder radikaler Rewrite (Batch-API mit 1000 Vergleichen auf einmal) wenn ein Use-Case das hergibt. |
-| **levenshtein** | 🔴 | 10 chars 0,60×; 100 chars 1,10×; 1000 chars 0,25×; **10000 chars 0,13×** | Verliert **dramatisch** auf langen Strings (7 ops/s vs 54 ops/s bei 10k chars). Grund: jede 10KB-String-Konvertierung über FFI kostet ~3 µs allein, `fast-levenshtein` arbeitet direkt auf V8-Strings ohne Konvertierung. Je länger der String, desto schlimmer unser Handicap. **Kill** — oder restructure zu Buffer-Input (`lev_bytes(a: Buffer, b: Buffer)`) aber das wäre eine fundamental andere API. |
-| **xml** | 🔴 | 0,44× – 0,68× | Verliert auf **jedem** Szenario gegen `sax` (JS-only streaming parser). SOAP 10MB wurde vom Benchmark gar nicht gemessen (nur sax lief); vermutlich noch schlimmer. Unser `parseXml` alloziert ein komplettes DOM; `sax` streamt Events. **Kill** oder kompletter Redesign auf Streaming-API, aber dann ist es nicht mehr "das bessere xml2js" sondern "eine Alternative zu sax". |
+| **slugify** | 🟢 | **3.0× – 6.0×** | Unicode normalize + transliterate is real work, FFI overhead is small relative to it. Keep as-is. |
+| **deepmerge** | 🟢 | **3.3× – 5.9×** | Object-merge allocations in Rust are meaningfully faster than in JS. |
+| **file-type** | 🟢 | **16× – 1265×** | Upstream is an async API that has to block for synchronous callers; our sync path is trivial. |
+| **jwt** | 🟢 | **1.4× – 4.8×** | All 6 scenarios (HS256/RS256/ES256 sign/verify) faster. Crypto is compute-bound. |
+| **sanitize-html** | 🟢 | **1.44× – 3.94×** | Small case 1.44× is borderline but not under 1; scales cleanly to 3.94× at 100 KB. Hybrid engine (tokenizer + strict fallback) already implemented. |
+| **argon2** | 🟡 | 1.37× (only scenario) | Weakly above parity. No RS256/ES256-style variations benched yet. **Sprint**: measure a second config; possibly a batch API. |
+| **csv** | 🟡 | `parseToJson` 1.59× – 1.78× ✓; plain `parse` **0.71× – 1.08×** ✗ | Two entry points with wildly different perf. Plain `parse` loses against `papaparse` on large inputs. **Sprint**: either fix `parse` or deprecate it in favor of `parseToJson`. |
+| **encoding** | 🟡 | latin1 decode 10MB **14.7×** ✓; shift_jis decode 0.65× ✗ | Mixed. UTF-8 / UTF-16LE / Latin-1 all run through V8 fast paths (parity up to very fast). Shift_JIS + CJK family goes through Rust and loses. **Sprint**: profile where the Shift_JIS decoder eats time. If unfixable → drop Shift_JIS from the package surface or document as Black. |
+| **inflate** | 🟡 | deflate 100KB-10MB **4.1× – 6.4×** ✓; inflate 100KB-10MB **0.29× – 0.40×** ✗ | Completely mixed: compression (deflate) dramatically faster, decompression (inflate) dramatically slower than `node:zlib`. That's **in the same package** — incoherent for users. **Sprint**: investigate why inflate is so much worse than node:zlib (the same zlib-rs backend should be equivalent). Hypothesis: output-buffer alloc strategy or missing streaming. |
+| **nanoid** | 🟡 | 0.76× – 1.10× | Already switched from Rust to pure JS (`794396b`). Structurally can't be better than nanoid@5 because both run against the same `crypto.getRandomValues`/`randomFillSync` primitive. At parity; the 0.76× gap to `crypto.randomUUID` in batch is expected (randomUUID is less work per ID). **Sprint goal**: decide whether the package is still necessary at all (→ possibly Black). |
+| **xxhash** | 🟡 | xxh3 1MB **2.54×** ✓; batch 1000×64B **0.15× – 0.32×** ✗ | Large buffers are a real win; the batch API is catastrophic (5–6× slower than the xxhash-wasm loop). This is the **classic array-marshalling anti-pattern** from `docs/BASELINE.md`: returning `Vec<BigInt>` costs 43 ns per element just for the FFI transport. **Sprint**: the batch API has to return results as a `Buffer` (8 KB for 1000 × u64). |
+| **zip** | 🟡 | 4 of 5 scenarios Green (2.8× – 3.7×); extract-all 0.56× ✗ | One outlier (extract 100 small files). **Sprint**: profile why adm-zip wins on many small files; probably per-entry allocation pattern. |
+| **deep-equal** | 🔴 | 0.96× – 1.30× | Never meaningfully faster. `fast-deep-equal` is tiny pure JS that V8 JITs perfectly. Deep-equal work per call is under 1 µs (flat 7-key: 500 ns) → FFI floor of 109 ns eats 20% of the budget, Rust win too small. **Kill** or radical rewrite (batch API with 1000 comparisons at once) if a use-case supports it. |
+| **levenshtein** | 🔴 | 10 chars 0.60×; 100 chars 1.10×; 1000 chars 0.25×; **10000 chars 0.13×** | Loses **dramatically** on long strings (7 ops/s vs 54 ops/s at 10k chars). Reason: each 10 KB string conversion across the FFI costs ~3 µs by itself, `fast-levenshtein` works directly on V8 strings without conversion. The longer the string, the worse our handicap. **Kill** — or restructure to buffer input (`lev_bytes(a: Buffer, b: Buffer)`), but that would be a fundamentally different API. |
+| **xml** | 🔴 | 0.44× – 0.68× | Loses on **every** scenario against `sax` (JS-only streaming parser). SOAP 10MB wasn't measured by the benchmark at all (only sax ran); presumably even worse. Our `parseXml` allocates a full DOM; `sax` streams events. **Kill** or complete redesign onto a streaming API, but then it's no longer "the better xml2js" but "an alternative to sax". |
 
-## Post-Klassifizierung: Zusammenfassung
+## Post-classification: summary
 
-**Green (5 Packages):** slugify, deepmerge, file-type, jwt, sanitize-html. Diese sind Begründung fürs ganze Portfolio. Keep.
+**Green (5 packages):** slugify, deepmerge, file-type, jwt, sanitize-html. These justify the entire portfolio. Keep.
 
-**Yellow (7 Packages, Sprint-Kandidaten):** argon2, csv, encoding, inflate, nanoid, xxhash, zip. Jedes kriegt einen Sprint in Phase C.
+**Yellow (7 packages, sprint candidates):** argon2, csv, encoding, inflate, nanoid, xxhash, zip. Each gets a sprint in Phase C.
 
-**Red (3 Packages, Kill-Kandidaten):** deep-equal, levenshtein, xml. Jedes kriegt Post-Mortem + Deprecation-Path in Phase D, es sei denn ein radikaler Rewrite ist vertretbar.
+**Red (3 packages, kill candidates):** deep-equal, levenshtein, xml. Each gets a post-mortem + deprecation path in Phase D, unless a radical rewrite is defensible.
 
-Kein klarer Black-Kandidat unter den aktuellen Packages — die Red-Drei sind Red wegen Implementierungs-Problemen und Ausrichtungs-Fehlern, nicht weil NAPI strukturell kein Gewinn-Pattern hat.
+No clear Black candidate among the current packages — the Red three are Red because of implementation issues and alignment errors, not because NAPI structurally has no win pattern.
 
-## Priorität für die Sprints
+## Priority for the sprints
 
-Empfohlene Reihenfolge (kleinster Aufwand × größter Effekt zuerst):
+Recommended order (smallest effort × biggest effect first):
 
-### Tier 1 — einfache Fixes, klare Gewinne
+### Tier 1 — easy fixes, clear wins
 
-1. **xxhash batch** (Yellow → Green): `Vec<BigInt>` durch `Buffer` ersetzen. Bekanntes Pattern aus `nanoid`/`encoding`. ~1 Tag.
-2. **inflate** (Yellow): Warum ist `inflate()` bei 100KB/10MB 2,5× langsamer als `node:zlib`, obwohl wir `zlib-rs` benutzen? Vermutung: Output-Buffer-Alloc oder `Vec<u8>` statt `Buffer`. Profilieren. ~1 Tag.
-3. **zip extract-all** (Yellow → Green): Einzelne Regression. 100 kleine Files zu extrahieren sollte 100 × `Buffer` zurückgeben. Vermutung: Zip-Entries werden einzeln durch FFI gereicht. Batch-Output. ~1 Tag.
+1. **xxhash batch** (Yellow → Green): replace `Vec<BigInt>` with `Buffer`. Known pattern from `nanoid`/`encoding`. ~1 day.
+2. **inflate** (Yellow): why is `inflate()` 2.5× slower than `node:zlib` at 100KB/10MB even though we use `zlib-rs`? Hypothesis: output-buffer alloc or `Vec<u8>` instead of `Buffer`. Profile. ~1 day.
+3. **zip extract-all** (Yellow → Green): single regression. Extracting 100 small files should return 100 × `Buffer`. Hypothesis: zip entries are passed individually across the FFI. Batch output. ~1 day.
 
-### Tier 2 — mittel
+### Tier 2 — medium
 
-4. **encoding shift_jis** (Yellow): Profilieren; evtl. ist `encoding_rs`s Shift_JIS-Decoder selbst lahm. Alternativen: `encoding` (rust) statt `encoding_rs`, oder Lookup-Tabelle. ~1-2 Tage.
-5. **csv plain-`parse`** (Yellow): Warum ist `parse` langsamer als `parseToJson`? Vermutung: `Vec<Vec<String>>` Marshalling-Kosten. Lösung: API vereinigen oder Buffer-basiert. ~1-2 Tage.
-6. **argon2** (Yellow): Mehr Szenarien messen, Konfigs variieren. Wenn durchgehend 1,4×, bleibt es Yellow → ggf. Demotion zu Red. Sonst zu Green. ~0,5 Tage.
+4. **encoding shift_jis** (Yellow): profile; `encoding_rs`'s Shift_JIS decoder itself may be slow. Alternatives: `encoding` (rust) instead of `encoding_rs`, or a lookup table. ~1–2 days.
+5. **csv plain `parse`** (Yellow): why is `parse` slower than `parseToJson`? Hypothesis: `Vec<Vec<String>>` marshalling cost. Solution: unify the API or go buffer-based. ~1–2 days.
+6. **argon2** (Yellow): measure more scenarios, vary configs. If consistently 1.4×, it stays Yellow → possibly demoted to Red. Otherwise to Green. ~0.5 days.
 
-### Tier 3 — Kill-Entscheidungen
+### Tier 3 — kill decisions
 
-7. **nanoid**: Entscheiden ob das Package existenzberechtigt ist. Pure-JS-Version matcht nanoid@5 aber schlägt es nicht nennenswert. Kann man argumentieren: "es ist der Same-API-Drop-in mit Zero-Dependencies und stabiler Maintenance". Oder Kill. → **Produkt-Entscheidung, keine technische.**
-8. **deep-equal** Kill: Post-Mortem + Deprecation.
-9. **levenshtein** Kill: Post-Mortem + Deprecation. ODER: Buffer-Input-Variante für Byte-Level-Distanz als neues Package `@amigo-labs/levenshtein-bytes`, separater Use-Case.
-10. **xml** Kill: Post-Mortem + Deprecation. Oder Redesign als Streaming-Parser — aber das ist ein eigenes Projekt.
+7. **nanoid**: decide whether the package has a reason to exist. Pure-JS version matches nanoid@5 but doesn't beat it noticeably. Arguable: "it's the same-API drop-in with zero dependencies and stable maintenance". Or kill. → **Product decision, not a technical one.**
+8. **deep-equal** kill: post-mortem + deprecation.
+9. **levenshtein** kill: post-mortem + deprecation. OR: a buffer-input variant for byte-level distance as a new package `@amigo-labs/levenshtein-bytes`, separate use-case.
+10. **xml** kill: post-mortem + deprecation. Or redesign as a streaming parser — but that's its own project.
 
-## Was NICHT in diesem Review steht
+## What is NOT in this review
 
-- **Bundle-Size-Analyse.** Ist in `docs/data.json` unter dem `sizes`-Key dokumentiert. Relevante Auffälligkeit: `slugify` 966KB für 21KB-JS-Alternative — das ist ein separater Trade-off (drei Größenordnungen schneller bei drei Größenordnungen Bundle).
-- **Security-Review.** Hier ging es rein um Perf. Crypto-Packages (`argon2`, `jwt`) sollten einen eigenen Security-Audit haben.
-- **Memory-Behavior bei Dauerläufen.** Alle Zahlen sind Throughput unter vitest-Warmup. Heap-Wachstum nicht gemessen.
+- **Bundle-size analysis.** Documented in `docs/data.json` under the `sizes` key. Notable oddity: `slugify` 966 KB for a 21 KB JS alternative — that's a separate trade-off (three orders of magnitude faster at three orders of magnitude of bundle).
+- **Security review.** This was purely about perf. Crypto packages (`argon2`, `jwt`) should get their own security audit.
+- **Memory behavior under long runs.** All numbers are throughput under vitest warmup. Heap growth not measured.
 
-## Reproduzierbarkeit
+## Reproducibility
 
 ```bash
 cd /home/user/amigo-native
@@ -129,6 +129,6 @@ node scripts/run-benchmarks.mjs
 # → bench-results.json  (66 suites)
 ```
 
-Dieses Dokument sollte nach jedem größeren Toolchain-Bump (Node-Major,
-napi-rs-Major, V8-Major) neu gemacht werden. Green-Packages können zu
-Yellow werden wenn V8 seinerseits schneller wird.
+This document should be redone after any larger toolchain bump (Node major,
+napi-rs major, V8 major). Green packages can turn Yellow when V8 itself gets
+faster.

--- a/docs/perf-review/ajv.md
+++ b/docs/perf-review/ajv.md
@@ -4,41 +4,41 @@
 
 ## Verdict
 
-`ajv` ist ein Codegen: aus einem JSON-Schema wird spezialisiertes JS, das V8 in perfekt monomorphe Inlining-Pfade optimiert. Ein Rust-Port wäre ein Interpreter — architektonisch unterlegen bei genau dem Metrik, für die `ajv` existiert.
+`ajv` is a codegen: a JSON schema is turned into specialized JS that V8 optimizes into perfectly monomorphic inlining paths. A Rust port would be an interpreter — architecturally inferior at exactly the metric `ajv` exists for.
 
 ## JS package
 
 - **npm:** `ajv`
-- **Downloads:** ~120M/Woche (Gesamt-Ökosystem inkl. `ajv-formats`, `ajv-keywords` ~200M)
-- **Exports / API surface:** `new Ajv(options)`, `compile(schema) → validate(data)`, `addKeyword`, `addFormat`, `addSchema`, async-Validation, `$ref`-Auflösung, Custom-Error-Reporter
-- **Typical input:** JSON-Schema-Draft-07/2019-09/2020-12 (einmalig) + validierte JS-Objekte (hot loop)
-- **Typical output:** `boolean` + `validate.errors` Array
-- **Realistic median use-case:** API-Request-Body-Validation — ein Schema, 10K+ Payloads/s, typisch 1 KB pro Payload
+- **Downloads:** ~120M/week (total ecosystem incl. `ajv-formats`, `ajv-keywords` ~200M)
+- **Exports / API surface:** `new Ajv(options)`, `compile(schema) → validate(data)`, `addKeyword`, `addFormat`, `addSchema`, async validation, `$ref` resolution, custom error reporter
+- **Typical input:** JSON Schema Draft-07/2019-09/2020-12 (once) + validated JS objects (hot loop)
+- **Typical output:** `boolean` + `validate.errors` array
+- **Realistic median use-case:** API request body validation — one schema, 10K+ payloads/s, typically 1 KB per payload
 
 ## Rust replacement
 
 - **Candidate crate(s):** `jsonschema` (Dmitry Dygalo), `boon`
-- **Maintenance / license:** aktiv, MIT
-- **Known gotchas / divergences:** Interpretation vs. Codegen; kein Inlining durch LLVM für das spezifische Schema. Custom-Keywords müssten als JS-Callbacks über NAPI-Boundary — teuer. Error-Format parity ist nicht-trivial
+- **Maintenance / license:** active, MIT
+- **Known gotchas / divergences:** interpretation vs. codegen; no LLVM inlining for the specific schema. Custom keywords would have to be JS callbacks across the NAPI boundary — expensive. Error-format parity is non-trivial
 
 ## BACKLOG check
 
-BACKLOG: *Parity too expensive* — bestätigt, aber der härtere Grund ist heute *Architektonisch unterlegen*: `ajv` generiert pro Schema spezialisierten JS-Code, der V8 perfekt JITtet.
+BACKLOG: *Parity too expensive* — confirmed, but the stronger reason today is *Architecturally inferior*: `ajv` generates specialized JS code per schema that V8 JITs perfectly.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Pro Validation sehr klein: ein paar Property-Zugriffe auf bekanntem Shape. `ajv` nutzt V8-Hidden-Classes perfekt |
-| Input size distribution | Typisch <2 KB JSON, häufig <200 B. Direkt im FFI-Trap-Bereich |
-| Output size distribution | `boolean` + optional Error-Array (meist leer) |
-| Reusable setup (stateful potential) | **Hoch** — compiled Validator als NAPI-Class wäre der einzige sinnvolle API-Shape |
-| Batch-usage realism | Hoch, aber `ajv` wird bereits per-call in Express/Fastify gerufen |
-| FFI-share estimate vs. Rust work | Siehe `deep-equal`: JS-Objekt-Traversal über `get_named_property` = FFI pro Field. Dominiert gegenüber Rust-Arbeit |
+| Per-call algorithmic work | Very small per validation: a handful of property accesses on a known shape. `ajv` uses V8 hidden classes perfectly |
+| Input size distribution | Typically <2 KB JSON, often <200 B. Right in the FFI trap zone |
+| Output size distribution | `boolean` + optional error array (usually empty) |
+| Reusable setup (stateful potential) | **High** — a compiled validator as a NAPI class would be the only sensible API shape |
+| Batch-usage realism | High, but `ajv` is already called per-call in Express/Fastify |
+| FFI-share estimate vs. Rust work | See `deep-equal`: JS object traversal via `get_named_property` = FFI per field. Dominates over the Rust work |
 
 ## Classification reasoning
 
-Der Post-Mortem-Shape ist exakt `deep-equal`: kleine Inputs, viele Property-Zugriffe pro Call, V8 JITtet das JS-Äquivalent auf Maschinencode-Niveau. `ajv`s compile-Schritt ist dabei der entscheidende Trick — das kompilierte JS ist monomorphisch, hat keine Dispatch-Tabelle, und V8 inlined Property-Lookups. Ein Rust-Interpreter müsste pro Keyword eine Match-Dispatch-Tabelle durchgehen und gleichzeitig JS-Werte pro Property über FFI abholen. Das gewinnt weder bei kleinen Payloads (FFI-Floor) noch bei großen (Object-Traversal). Custom Keywords als JS-Callbacks wären nochmal 1000+ns Overhead pro Aufruf.
+The post-mortem shape is exactly `deep-equal`: small inputs, many property accesses per call, V8 JITs the JS equivalent down to machine-code level. `ajv`'s compile step is the decisive trick — the compiled JS is monomorphic, has no dispatch table, and V8 inlines the property lookups. A Rust interpreter would have to walk a match-dispatch table per keyword and at the same time fetch JS values per property across the FFI. That doesn't win at small payloads (FFI floor) and doesn't win at large ones (object traversal). Custom keywords as JS callbacks would be another 1000+ ns overhead per call.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/bcrypt.md
+++ b/docs/perf-review/bcrypt.md
@@ -1,63 +1,63 @@
 # Candidate review: `bcrypt`
 
-> **Status:** SHIPPED v0.1 (C-backend) · **Predicted:** 🟢 Green · **Measured (Rust):** 🔴 Red · **Measured (C-vendor):** 🟡 Yellow · **Reviewed:** 2026-04-19
+> **Status:** SHIPPED v0.1 (C backend) · **Predicted:** 🟢 Green · **Measured (Rust):** 🔴 Red · **Measured (C vendor):** 🟡 Yellow · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-`bcrypt` ist die nächstbeste Argon2-Geschwister-Crate: identische FFI-Mathematik (per-call ≥10 ms Hash-Compute, FFI-Floor unter 0,001 % der Arbeit), bewährter Rust-Crate (`bcrypt 0.18.0`, aktiv gepflegt), zwei reale Baselines mit klar gemessenen Schwächen (`bcrypt`-npm ist C++-via-node-gyp, `bcryptjs` ist pure-JS und 30 % langsamer). Erwarteter Gewinn ≥1,4× vs. `bcrypt`-npm (analog argon2 vs. argon2-npm) und ≥1,8× vs. `bcryptjs` — Green an allen realistischen Cost-Faktoren (4–14).
+`bcrypt` is the next-best argon2 sibling crate: identical FFI math (per-call ≥10 ms hash compute, FFI floor under 0.001% of the work), well-established Rust crate (`bcrypt 0.18.0`, actively maintained), two real baselines with clearly measured weaknesses (`bcrypt`-npm is C++-via-node-gyp, `bcryptjs` is pure JS and 30% slower). Expected win ≥1.4× vs. `bcrypt`-npm (analogous to argon2 vs. argon2-npm) and ≥1.8× vs. `bcryptjs` — Green across all realistic cost factors (4–14).
 
 ## JS package
 
-- **npm:** `bcrypt` (3,5 M weekly), `bcryptjs` (6,5 M weekly) — kombiniert ~10 M weekly, Top-100-Bereich
-- **Downloads:** 10 M weekly insgesamt; 8 021 npm-Pakete depend auf `bcrypt`
+- **npm:** `bcrypt` (3.5M weekly), `bcryptjs` (6.5M weekly) — combined ~10M weekly, top-100 range
+- **Downloads:** 10M weekly total; 8,021 npm packages depend on `bcrypt`
 - **Exports / API surface:** `hash(pw, rounds, cb)`, `hashSync(pw, rounds)`, `compare(pw, hash, cb)`, `compareSync(pw, hash)`, `genSalt(rounds)`, `getRounds(hash)`
-- **Typical input:** Passwort als String (UTF-8, ≤72 Bytes — alles darüber wird vom Algorithmus selbst trunkiert) + Cost-Factor (default 10–12)
-- **Typical output:** Modular-Crypt-Format-String, ~60 Bytes ASCII (`$2b$12$...`)
-- **Realistic median use-case:** **Web-App-Auth.** 1 Hash bei Signup, 1 Verify pro Login-Versuch. Cost-Factor 10–12 → 50–300 ms pro Call. Niemals gebatcht (jeder Call braucht unabhängiges Salt + ist absichtlich teuer)
+- **Typical input:** password as string (UTF-8, ≤72 bytes — anything longer is truncated by the algorithm itself) + cost factor (default 10–12)
+- **Typical output:** modular-crypt-format string, ~60 bytes ASCII (`$2b$12$...`)
+- **Realistic median use-case:** **web app auth.** 1 hash at signup, 1 verify per login attempt. Cost factor 10–12 → 50–300 ms per call. Never batched (each call needs an independent salt + is deliberately expensive)
 
 ## Rust replacement
 
 - **Candidate crate(s):** `bcrypt 0.18.0` (RustCrypto-aligned, Vincent Prouillet)
-- **Maintenance / license:** Aktiv gepflegt (Release vor 30 Tagen), MIT/Apache, MSRV 1.85
+- **Maintenance / license:** actively maintained (released 30 days ago), MIT/Apache, MSRV 1.85
 - **Known gotchas / divergences:**
-  - 72-Byte-Trunkierung gilt in beiden Implementierungen — Parität trivial, aber explizit in Tests prüfen
-  - Rust-Crate bietet zusätzlich `non_truncating_hash` / `non_truncating_verify` (returns `BcryptError::Truncation` ab >72 Bytes); für Parität exposed wir die trunkierende Variante als Default, könnten die strict-Variante als Opt-in anbieten
-  - `DEFAULT_COST = 12` in Rust, `10` in `bcrypt`-npm — wir gehen mit `12` (modernerer Default), dokumentieren den Unterschied
+  - 72-byte truncation applies in both implementations — parity trivial, but check it explicitly in tests
+  - The Rust crate also offers `non_truncating_hash` / `non_truncating_verify` (returns `BcryptError::Truncation` above 72 bytes); for parity we expose the truncating variant as the default and could offer the strict variant as opt-in
+  - `DEFAULT_COST = 12` in Rust, `10` in `bcrypt`-npm — we go with `12` (more modern default) and document the difference
 
 ## BACKLOG check
 
-Kein Eintrag in `BACKLOG.md`. Frischer Kandidat.
+No entry in `BACKLOG.md`. Fresh candidate.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **50–300 ms** bei Cost 10–12; **~1 ms** bei Cost 4 (Test-Minimum). Hash-Arbeit ist das Produkt — **absichtlich teuer** |
-| Input size distribution | Passwort ≤72 Bytes UTF-8 (Algorithmus-Limit). String-Konvertierung ~100–200 ns, < 0,0001 % der Compute |
-| Output size distribution | ~60 Bytes ASCII Hash-String. String-Konvertierung ~150 ns, irrelevant |
-| Reusable setup (stateful potential) | Keine. Cost-Factor ist Argument, kein präkompilierter Zustand. (anders als z.B. `jwt` mit Key-Caching) |
-| Batch-usage realism | **N/A**. Jeder Hash braucht unabhängiges Salt; Batching macht algorithmisch keinen Sinn. Nicht implementieren |
-| FFI-share estimate vs. Rust work | **<0,001 %** bei Cost 10–12; **<0,02 %** bei Cost 4. Strukturell unsichtbar |
+| Per-call algorithmic work | **50–300 ms** at cost 10–12; **~1 ms** at cost 4 (test minimum). Hash work is the product — **deliberately expensive** |
+| Input size distribution | Password ≤72 bytes UTF-8 (algorithm limit). String conversion ~100–200 ns, <0.0001% of compute |
+| Output size distribution | ~60 bytes ASCII hash string. String conversion ~150 ns, irrelevant |
+| Reusable setup (stateful potential) | None. Cost factor is an argument, not precompiled state. (Unlike e.g. `jwt` with key caching) |
+| Batch-usage realism | **N/A**. Each hash needs an independent salt; batching makes no algorithmic sense. Do not implement |
+| FFI-share estimate vs. Rust work | **<0.001%** at cost 10–12; **<0.02%** at cost 4. Structurally invisible |
 
 ## Classification reasoning
 
-`bcrypt` ist das Lehrbuchbeispiel der Green-Shape: bytes-in / bytes-out (kurze Strings beidseitig), substantielle CPU-Arbeit pro Call, keine FFI-Hot-Loops. Es matcht 1:1 das Profil von `argon2` — und argon2 ist im Repo gemessen mit:
+`bcrypt` is the textbook Green shape: bytes-in / bytes-out (short strings on both sides), substantial CPU work per call, no FFI hot loops. It matches the `argon2` profile 1:1 — and argon2 is measured in the repo as:
 
-- 1,43× schneller als `argon2` npm (C++-via-node-gyp)
-- 2,45× schneller als `hash-wasm` (WASM)
+- 1.43× faster than `argon2` npm (C++-via-node-gyp)
+- 2.45× faster than `hash-wasm` (WASM)
 
-(Quelle: `docs/data.json`, `argon2 - hash (low-cost)`)
+(Source: `docs/data.json`, `argon2 - hash (low-cost)`)
 
-Der 1,43×-Gewinn vs. C++-Bindings ist allein durch sauberere napi-rs-FFI begründet (kein Vec/Array-Marshalling, kein doppeltes Parsen der Optionen). Genau dieselbe Dynamik gilt für `bcrypt` vs. `bcrypt`-npm — gleiches node-gyp-Problem (langsamer Build, fragilere Plattform-Bindings, ältere NAN-API).
+The 1.43× win vs. C++ bindings comes entirely from cleaner napi-rs FFI (no Vec/array marshalling, no double-parsing of options). The exact same dynamic should apply to `bcrypt` vs. `bcrypt`-npm — same node-gyp problem (slower build, more fragile platform bindings, older NAN API).
 
-Vergleichspunkte aus Post-Mortems:
-- **Nicht** wie `deep-equal`/`mime`: kein Per-Property-FFI-Hop, keine ns-skalige JS-Arbeit
-- **Nicht** wie `levenshtein`: kein V8-JIT-konkurrenzfähiges DP-Muster (Blowfish-Schedule ist Bit-Twiddling, kein Schleifen-Hot-Path den V8 inlinen kann)
-- **Wie** `argon2`/`jwt`: krypto-schwere Compute, einmaliger Call pro User-Aktion, Bytes-rein/Bytes-raus
+Comparison points from post-mortems:
+- **Not** like `deep-equal`/`mime`: no per-property FFI hop, no ns-scale JS work
+- **Not** like `levenshtein`: no V8-JIT-competitive DP pattern (the Blowfish schedule is bit twiddling, not a loop hot path V8 can inline)
+- **Like** `argon2`/`jwt`: crypto-heavy compute, single call per user action, bytes-in/bytes-out
 
 ## If GO — proposed port
 
-- **Recommended crate-name:** `@amigo-labs/bcrypt`
+- **Recommended crate name:** `@amigo-labs/bcrypt`
 - **Primary API sketch:**
   ```ts
   export interface BcryptOptions {
@@ -69,87 +69,87 @@ Vergleichspunkte aus Post-Mortems:
   export declare function verify(hash: string, password: string): Promise<boolean>
   export declare function verifySync(hash: string, password: string): boolean
   ```
-  → **Bewusst identisch zu `crates/argon2/index.d.ts`.** Erlaubt direkte Adaption des argon2-Source-Layouts und des Konformitäts-Test-Setups.
+  → **Deliberately identical to `crates/argon2/index.d.ts`.** Allows direct adaptation of the argon2 source layout and the conformance test setup.
 
 - **Must-have benchmark scenarios:**
-  - `hash` bei Cost 4 (Smallest realistic — Test-Suites)
-  - `hash` bei Cost 10 (Industry-Standard)
-  - `hash` bei Cost 12 (`bcrypt`-Rust-Crate-Default, auch unser Default)
-  - `verify` bei Cost 10 (häufigster Real-World-Call: Login)
-  - **Beide JS-Baselines pflichtig:** `bcrypt` (npm, C++) **und** `bcryptjs` (pure JS) — verschiedene User-Segmente
+  - `hash` at cost 4 (smallest realistic — test suites)
+  - `hash` at cost 10 (industry standard)
+  - `hash` at cost 12 (`bcrypt` Rust crate default, also our default)
+  - `verify` at cost 10 (most common real-world call: login)
+  - **Both JS baselines required:** `bcrypt` (npm, C++) **and** `bcryptjs` (pure JS) — different user segments
 
 - **Acceptance thresholds (Green gate):**
-  - ≥1,4× vs. `bcrypt` npm bei Cost 10 (Spiegel argon2-Resultat)
-  - ≥1,8× vs. `bcryptjs` bei Cost 10
-  - ≥1,0× vs. beiden bei Cost 4 (Floor-Check)
-  - 100 % Parity bei 72-Byte-Trunkierung, Cost-Range 4–31, Hash-Format `$2a$`/`$2b$`/`$2y$`
+  - ≥1.4× vs. `bcrypt` npm at cost 10 (mirrors argon2 result)
+  - ≥1.8× vs. `bcryptjs` at cost 10
+  - ≥1.0× vs. both at cost 4 (floor check)
+  - 100% parity on 72-byte truncation, cost range 4–31, hash format `$2a$`/`$2b$`/`$2y$`
 
 - **Risks:**
-  1. **Adoption-Risiko bei `bcryptjs`-Usern:** Die wählen pure-JS bewusst (Edge-Runtime, Bundle-Size, kein node-gyp). Native Crate erreicht primär die `bcrypt`-npm-User. Akzeptabel — `bcrypt`-npm allein hat 3,5 M weekly.
-  2. **Cost-Factor-Default-Diskrepanz:** `bcrypt`-npm default ist 10, Rust-Crate default ist 12. Wir nehmen 12 als modernere Empfehlung, dokumentieren den Wechsel im README.
-  3. **Bundle-Size:** ~1 MB Binary (argon2 ist Referenz) vs. 9 KB für bcryptjs. Akzeptabel im Vergleich zu `bcrypt`-npm's 324 KB + node-gyp-Build-Footprint.
-  4. **Algorithm-Variants:** `bcrypt`-npm akzeptiert `$2a$`, `$2b$`, `$2y$`. Rust-Crate verifiziert alle drei, hasht in `$2b$`. Parity-OK.
+  1. **Adoption risk with `bcryptjs` users:** they choose pure JS deliberately (edge runtime, bundle size, no node-gyp). A native crate primarily reaches the `bcrypt`-npm users. Acceptable — `bcrypt`-npm alone has 3.5M weekly.
+  2. **Cost-factor default discrepancy:** `bcrypt`-npm's default is 10, the Rust crate's default is 12. We take 12 as the more modern recommendation and document the change in the README.
+  3. **Bundle size:** ~1 MB binary (argon2 is the reference) vs. 9 KB for bcryptjs. Acceptable compared to `bcrypt`-npm's 324 KB + node-gyp build footprint.
+  4. **Algorithm variants:** `bcrypt`-npm accepts `$2a$`, `$2b$`, `$2y$`. The Rust crate verifies all three and hashes as `$2b$`. Parity OK.
 
 ## If NO-GO — BACKLOG entry
 
-N/A — GO empfohlen.
+N/A — GO recommended.
 
-## Phase-B Messung (2026-04-19, linux-x64, Node v22.22.2)
+## Phase B measurement (2026-04-19, linux-x64, Node v22.22.2)
 
-Implementiert in `crates/bcrypt/`. Echte Bench-Resultate vs. argon2-Pattern-Vorhersage:
+Implemented in `crates/bcrypt/`. Actual bench results vs. the argon2-pattern prediction:
 
-| Szenario | @amigo-labs/bcrypt | bcrypt npm (C++) | bcryptjs (pure JS) | Speedup |
+| Scenario | @amigo-labs/bcrypt | bcrypt npm (C++) | bcryptjs (pure JS) | Speedup |
 |---|---:|---:|---:|---|
-| hash cost 4 | **848,75 hz** | 748,70 hz | 696,96 hz | 1,13× / 1,22× ✅ |
-| hash cost 10 | 14,64 hz | **16,18 hz** | 12,99 hz | **0,90×** / 1,13× ⚠️ |
-| verify cost 10 | 14,71 hz | **16,23 hz** | 12,95 hz | **0,91×** / 1,14× ⚠️ |
+| hash cost 4 | **848.75 hz** | 748.70 hz | 696.96 hz | 1.13× / 1.22× ✅ |
+| hash cost 10 | 14.64 hz | **16.18 hz** | 12.99 hz | **0.90×** / 1.13× ⚠️ |
+| verify cost 10 | 14.71 hz | **16.23 hz** | 12.95 hz | **0.91×** / 1.14× ⚠️ |
 
-**Ergebnis: 🟡 Yellow, nicht Green.** Vorhersage war falsch.
+**Result: 🟡 Yellow, not Green.** The prediction was wrong.
 
-**Warum die argon2-Analogie nicht durchschlägt:**
-- Argon2 vs argon2-npm: 1,43× schneller (gemessen) → wir haben das auf bcrypt extrapoliert
-- Bcrypt vs bcrypt-npm: 0,90× — wir verlieren bei realistischer Cost (10)
-- Hypothese: bcrypt-npm's C++-Implementierung (`bcrypt-pbkdf` C-Code mit hand-getuntem Blowfish-Schedule) ist signifikant schneller als RustCrypto's `blowfish`-Crate. Argon2 hat keinen so optimierten C-Konkurrenten — Rust gewinnt dort durch sauberere FFI; bei bcrypt ist der C-Code-Konkurrent algorithmisch kompetitiv
+**Why the argon2 analogy doesn't carry over:**
+- argon2 vs. argon2-npm: 1.43× faster (measured) → we extrapolated that to bcrypt
+- bcrypt vs. bcrypt-npm: 0.90× — we lose at the realistic cost (10)
+- Hypothesis: bcrypt-npm's C++ implementation (`bcrypt-pbkdf` C code with a hand-tuned Blowfish schedule) is significantly faster than RustCrypto's `blowfish` crate. argon2 has no similarly optimized C competitor — Rust wins there through cleaner FFI; for bcrypt the C competitor is algorithmically competitive
 
-**Was wir trotzdem gewinnen:**
-- vs. `bcryptjs` (6,5 M weekly, größere Userbase als bcrypt-npm) gewinnen wir an **allen** Cost-Stufen — 1,13–1,22× (klein bis Standard)
-- Bei Cost 4 (Test-Use-Cases) auch vs. bcrypt-npm
-- Cross-Platform-Prebuilds ohne node-gyp-Build-Dependency
+**What we win anyway:**
+- vs. `bcryptjs` (6.5M weekly, larger user base than bcrypt-npm) we win at **every** cost level — 1.13–1.22× (small up to standard)
+- at cost 4 (test use cases) also vs. bcrypt-npm
+- cross-platform prebuilds without node-gyp build dependency
 
-**Optionen für Phase C / D:**
-- **C.6 Algorithm-Swap:** `bcrypt`-Crate evaluieren mit alternativen Blowfish-Backends. `bcrypt = "0.18"` nutzt `blowfish 0.9` — vermutlich keine SIMD/ASM-Variante verfügbar
-- **Yellow halten:** ehrlich positionieren als "bcryptjs-Ersatz mit native-Speed", nicht als bcrypt-npm-Killer
-- **Re-Review in 6 Monaten** falls `blowfish`-Crate eine schnellere Variante kriegt
+**Options for Phase C / D:**
+- **C.6 algorithm swap:** evaluate the `bcrypt` crate with alternative Blowfish backends. `bcrypt = "0.18"` uses `blowfish 0.9` — probably no SIMD/ASM variant available
+- **Hold Yellow:** honestly position as a "bcryptjs replacement with native speed", not as a bcrypt-npm killer
+- **Re-review in 6 months** if the `blowfish` crate gets a faster variant
 
-**Empfehlung:** Yellow halten, Phase-C nicht priorisieren. Die `bcryptjs` → @amigo-labs/bcrypt Migration ist ein klarer Win; bcrypt-npm-User haben weniger Grund zum Wechsel (außer Build-Friction). README muss diese Positionierung explizit machen.
+**Recommendation:** hold Yellow, don't prioritize Phase C. The `bcryptjs` → @amigo-labs/bcrypt migration is a clear win; bcrypt-npm users have less reason to switch (other than build friction). The README has to make this positioning explicit.
 
-## Phase-C Sprint (2026-04-19, dieselbe Session)
+## Phase C sprint (2026-04-19, same session)
 
-User wählte **Option C: tiefe Investition** trotz <30 % Probability-of-Green Schätzung.
+User picked **Option C: deep investment** despite <30% probability-of-Green estimate.
 
-**Maßnahme:** Pure-Rust `bcrypt`-Crate komplett ersetzt durch vendored Solar-Designer-`crypt_blowfish` C-Source (public domain, identische Code-Basis wie bcrypt-npm). Compile-Flags: `-O3 -fomit-frame-pointer -funroll-loops` via `cc 1.x`.
+**Action:** pure-Rust `bcrypt` crate fully replaced with vendored Solar Designer `crypt_blowfish` C source (public domain, identical code base as bcrypt-npm). Compile flags: `-O3 -fomit-frame-pointer -funroll-loops` via `cc 1.x`.
 
-| Szenario | Vor (Rust) | Nach (C-vendor) | Δ vs bcrypt npm | Δ vs bcryptjs |
+| Scenario | Before (Rust) | After (C vendor) | Δ vs. bcrypt npm | Δ vs. bcryptjs |
 |---|---:|---:|---|---|
-| hash cost 4 | 848,75 hz | **980,98 hz** | 0,90× → **1,42×** | 1,22× → **1,56×** |
-| hash cost 10 | 14,64 hz | **17,62 hz** | 0,90× → **1,10×** | 1,13× → **1,37×** |
-| verify cost 10 | 14,71 hz | **17,62 hz** | 0,91× → **1,09×** | 1,14× → **1,36×** |
+| hash cost 4 | 848.75 hz | **980.98 hz** | 0.90× → **1.42×** | 1.22× → **1.56×** |
+| hash cost 10 | 14.64 hz | **17.62 hz** | 0.90× → **1.10×** | 1.13× → **1.37×** |
+| verify cost 10 | 14.71 hz | **17.62 hz** | 0.91× → **1.09×** | 1.14× → **1.36×** |
 
-**Flip von 🔴 Red → 🟡 Yellow.** Wir gewinnen jetzt an **allen** Szenarien gegen beide Konkurrenten.
+**Flip from 🔴 Red → 🟡 Yellow.** We now win in **every** scenario against both competitors.
 
-**Warum hat das funktioniert?**
-- bcrypt-npm nutzt _eine ältere Version_ von crypt_blowfish (aus dem [node.bcrypt.js Repo](https://github.com/kelektiv/node.bcrypt.js), zuletzt synchronisiert vor mehreren Jahren) plus node-gyp's Default-Compile-Flags
-- Wir nutzen die _aktuelle_ Upstream-Version + aggressive Compile-Flags + sauberere napi-rs FFI vs. NAN
-- Resultat: ~10 % schneller bei identischem Algorithmus. Genau das argon2-Pattern, jetzt verifiziert für bcrypt.
+**Why did this work?**
+- bcrypt-npm uses _an older version_ of crypt_blowfish (from the [node.bcrypt.js repo](https://github.com/kelektiv/node.bcrypt.js), last synced several years ago) plus node-gyp's default compile flags
+- We use the _current_ upstream version + aggressive compile flags + cleaner napi-rs FFI vs. NAN
+- Result: ~10% faster at identical algorithm. Exactly the argon2 pattern, now verified for bcrypt.
 
-**Warum nicht Green (≥2×)?**
-- Beide Implementierungen kompilieren denselben Blowfish-Inner-Loop. Der Algorithmus ist nicht parallelisierbar (Daten-Dependencies zwischen Runden).
-- Die 1,10×-Wand bei Cost 10 ist ein _struktureller_ Plafond — nur durch radikale algorithmische Änderungen (gibt's nicht) durchbrechbar
-- 2× Green-Gate ist nicht erreichbar. **Yellow ist der Endzustand.**
+**Why not Green (≥2×)?**
+- Both implementations compile the same Blowfish inner loop. The algorithm is not parallelizable (data dependencies between rounds).
+- The 1.10× wall at cost 10 is a _structural_ ceiling — only breakable by radical algorithmic changes (which don't exist)
+- The 2× Green gate is not reachable. **Yellow is the end state.**
 
-**40/40 Tests passing** mit C-Backend (incl. 32 Cross-Verify mit bcrypt-npm + bcryptjs). Identische Hash-Outputs, da identische Algorithm-Implementierung.
+**40/40 tests passing** with the C backend (incl. 32 cross-verify against bcrypt-npm + bcryptjs). Identical hash outputs since we use an identical algorithm implementation.
 
-**Endklassifikation:** 🟡 Yellow. Akzeptabel als Yellow weil:
-- Wir gewinnen alle realistischen Konkurrenz-Vergleiche
-- Bundle-Disziplin: `bcrypt`-npm benötigt node-gyp + python; wir liefern Prebuilt-Binaries
-- Cross-Verify-Korrektheit garantiert durch identischen Algorithm
+**Final classification:** 🟡 Yellow. Acceptable as Yellow because:
+- we win every realistic competitor comparison
+- bundle discipline: `bcrypt`-npm needs node-gyp + python; we ship prebuilt binaries
+- cross-verify correctness guaranteed by the identical algorithm

--- a/docs/perf-review/chartjs.md
+++ b/docs/perf-review/chartjs.md
@@ -4,64 +4,64 @@
 
 ## Verdict
 
-`chart.js` ist eine **Browser-Rendering-Bibliothek** für Canvas-2D mit Plugin-Callbacks, Animations-Loop und Event-Handler-Surface. Der typische Nutzer ruft es in Browsern auf — dort gibt es kein NAPI. Der Server-Side-Pfad (`chartjs-node-canvas`) liegt bereits auf `node-canvas` (Skia/Cairo, nativ C++); ein Rust-Port würde eine bereits native Baseline re-wrappen. Die API-Surface (9+ Chart-Typen, Plugin-Lifecycle, Scales, Tooltips, Animationen) ist strukturell ein `jsdom`/`ejs`-Hybrid — riesiger Scope **und** JS-Callback-Pflicht pro Frame.
+`chart.js` is a **browser rendering library** for Canvas 2D with plugin callbacks, an animation loop, and an event-handler surface. The typical user calls it in browsers — where there is no NAPI. The server-side path (`chartjs-node-canvas`) already sits on `node-canvas` (Skia/Cairo, native C++); a Rust port would re-wrap an already-native baseline. The API surface (9+ chart types, plugin lifecycle, scales, tooltips, animations) is structurally a `jsdom`/`ejs` hybrid — huge scope **and** mandatory JS callbacks per frame.
 
 ## JS package
 
 - **npm:** [`chart.js`](https://www.npmjs.com/package/chart.js)
-- **Downloads:** ~5 M/Woche (Q1 2026, aller Majors zusammengerechnet; v4.x dominant)
-- **Exports / API surface:** `Chart`-Class (stateful, per Canvas-`ctx` instanziiert), `registerables`, Controller pro Chart-Typ (Line/Bar/Radar/Pie/Doughnut/PolarArea/Bubble/Scatter), Plugin-System mit ~20 Lifecycle-Hooks (`beforeDraw`, `afterRender`, `beforeEvent`, …), Scales (linear/log/time/category), Animations-Engine, Interaction-Layer (Hover/Click/Tooltips), Legend-Renderer
-- **Typical input:** Canvas-`CanvasRenderingContext2D` + großes Config-Objekt (`{ type, data: { datasets, labels }, options: { scales, plugins, animation, … } }`)
-- **Typical output:** Rendering-Nebeneffekt auf `<canvas>` + `Chart`-Instance mit `.update()`/`.destroy()`/`.resize()`/Event-API
-- **Realistic median use-case:** **Browser-interaktive Dashboards** — einmal `new Chart(ctx, cfg)`, dann Mutations-Loop (`chart.data.datasets[0].data.push(x); chart.update()`), Hover-Events, Responsive-Resize. Nicht-Browser-Nutzung (Node/SSR) ist <5% des Traffics und läuft standardmäßig über `chartjs-node-canvas` (Wrapper um `node-canvas`, der selbst nativ C++/Skia ist)
+- **Downloads:** ~5M/week (Q1 2026, all majors combined; v4.x dominant)
+- **Exports / API surface:** `Chart` class (stateful, instantiated per canvas `ctx`), `registerables`, a controller per chart type (Line/Bar/Radar/Pie/Doughnut/PolarArea/Bubble/Scatter), plugin system with ~20 lifecycle hooks (`beforeDraw`, `afterRender`, `beforeEvent`, …), scales (linear/log/time/category), animation engine, interaction layer (hover/click/tooltips), legend renderer
+- **Typical input:** Canvas `CanvasRenderingContext2D` + a large config object (`{ type, data: { datasets, labels }, options: { scales, plugins, animation, … } }`)
+- **Typical output:** rendering side effect on `<canvas>` + `Chart` instance with `.update()`/`.destroy()`/`.resize()`/event API
+- **Realistic median use-case:** **browser-interactive dashboards** — one `new Chart(ctx, cfg)`, then a mutation loop (`chart.data.datasets[0].data.push(x); chart.update()`), hover events, responsive resize. Non-browser usage (Node/SSR) is <5% of traffic and by default runs through `chartjs-node-canvas` (a wrapper around `node-canvas`, which itself is native C++/Skia)
 
 ## Rust replacement
 
-- **Candidate crate(s):** keine mit `chart.js`-kompatibler API. Existierende Rust-Chart-Crates verfolgen andere Philosophien:
-  - `plotters` (aktiv, MIT, ~2k⭐) — Builder-API, rendert PNG/SVG/Bitmap, kein interaktives Rendering, keine Plugin-Surface
-  - `poloto` (SVG-only, statisch)
-  - `charming` (Rust-Binding zu Apache ECharts — JS-Engine erforderlich, schiebt das Problem nur weiter)
+- **Candidate crate(s):** none with a `chart.js`-compatible API. Existing Rust chart crates follow different philosophies:
+  - `plotters` (active, MIT, ~2k⭐) — builder API, renders PNG/SVG/bitmap, no interactive rendering, no plugin surface
+  - `poloto` (SVG only, static)
+  - `charming` (Rust binding to Apache ECharts — requires a JS engine, only pushes the problem further)
   - `textplots` (irrelevant)
-- **Maintenance / license:** `plotters` ist die einzige ernsthafte Option, aber strukturell inkompatibel mit der `chart.js`-Nutzung (keine stateful Mutation, keine Plugins, keine Browser-Events)
-- **Known gotchas / divergences:** `chart.js` ist primär **interaktiv**. Jede sinnvolle Nutzung involviert DOM-Events, RAF-gesteuerte Animationen, und Plugin-Callbacks — alles Features, die ein Rust-Crate nicht bereitstellen kann, ohne pro Frame N FFI-Crossings nach V8 auszulösen
+- **Maintenance / license:** `plotters` is the only serious option, but structurally incompatible with how `chart.js` is used (no stateful mutation, no plugins, no browser events)
+- **Known gotchas / divergences:** `chart.js` is primarily **interactive**. Any meaningful use involves DOM events, RAF-driven animations, and plugin callbacks — all features a Rust crate cannot provide without triggering N FFI crossings into V8 per frame
 
 ## BACKLOG check
 
-Kein bestehender `chart.js`- oder `chartjs`-Eintrag in `BACKLOG.md`. Keine Chart-/Visualisierungs-Bibliothek bisher bewertet. Kein Eintrag in `docs/packages.json`. Dieses Review ist der erste dokumentierte Ausschluss dieser Kategorie.
+No existing `chart.js` or `chartjs` entry in `BACKLOG.md`. No chart/visualization library rated so far. No entry in `docs/packages.json`. This review is the first documented exclusion of this category.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Zwei Pfade, beide problematisch.** Browser: irrelevant — NAPI existiert dort nicht. Server-Side Static-Render: substantiell (Layout + Canvas-Draw ~1–10 ms), aber der konkurrierende Pfad (`chartjs-node-canvas` → `node-canvas` → Skia) ist bereits nativ |
-| Input size distribution | Config-Objekt ~1–50 KB JSON, Datasets können groß sein (10k+ Punkte). JSON-Serialisierung pro `update()` wäre zusätzlicher Overhead |
-| Output size distribution | Browser: n/a (Canvas-Nebeneffekt). Server: PNG/SVG 10 KB – 5 MB — `Buffer`-Return wäre flach (siehe `docs/BASELINE.md`), aber der Rest der Gleichung kippt nicht auf Green |
-| Reusable setup (stateful potential) | **Hoch** (`Chart`-Instance lebt lange), aber genau das ist die Falle: `update()`/Mutations-Callbacks pro Frame = N FFI-Crossings. `jsdom`-Shape (Object-Mutation-Hot-Loop) |
-| Batch-usage realism | Null. Charts werden stateful mutiert, nicht gebatcht |
-| FFI-share estimate vs. Rust work | Browser-Use: 100% (NAPI nicht verfügbar). Server-Static: ~20–40% gegen Rust-Draw, aber Konkurrent ist `node-canvas` (C++), nicht reines JS — Gewinn gegen echte Baseline marginal bis negativ. Plugin-/Animation-Pfade: >80% FFI für Callback-Roundtrips |
+| Per-call algorithmic work | **Two paths, both problematic.** Browser: irrelevant — NAPI doesn't exist there. Server-side static render: substantial (layout + canvas draw ~1–10 ms), but the competing path (`chartjs-node-canvas` → `node-canvas` → Skia) is already native |
+| Input size distribution | Config object ~1–50 KB JSON, datasets can be large (10k+ points). JSON serialization per `update()` would be additional overhead |
+| Output size distribution | Browser: n/a (canvas side effect). Server: PNG/SVG 10 KB – 5 MB — a `Buffer` return would be flat (see `docs/BASELINE.md`), but the rest of the equation doesn't tip to Green |
+| Reusable setup (stateful potential) | **High** (a `Chart` instance lives long), but that's exactly the trap: `update()`/mutation callbacks per frame = N FFI crossings. `jsdom` shape (object-mutation hot loop) |
+| Batch-usage realism | Zero. Charts are mutated statefully, not batched |
+| FFI-share estimate vs. Rust work | Browser use: 100% (NAPI not available). Server static: ~20–40% versus Rust draw, but the competitor is `node-canvas` (C++), not pure JS — win vs. the actual baseline is marginal to negative. Plugin/animation paths: >80% FFI for callback roundtrips |
 
 ## Classification reasoning
 
-Drei Probleme, jedes einzeln Black-würdig, zusammen permanent unportierbar:
+Three problems, each one Black-worthy alone, together permanently unportable:
 
-1. **Falsches Runtime.** Chart.js' dominanter Use-Case ist der Browser. NAPI-Binaries laden nicht im Browser. >95% der Nutzerbasis ist für einen Port strukturell nicht adressierbar. Selbst die besten Rust-Optimierungen produzieren Null Wert im Primär-Use-Case. Das ist derselbe Fehler, den `docs/post-mortems/xml.md` unter "wrong baseline" beschreibt — nur eine Stufe davor: hier ist die Runtime falsch, nicht die Baseline.
+1. **Wrong runtime.** chart.js's dominant use-case is the browser. NAPI binaries don't load in the browser. >95% of the user base is structurally unaddressable for a port. Even the best Rust optimizations produce zero value in the primary use-case. This is the same mistake `docs/post-mortems/xml.md` describes under "wrong baseline" — only a level earlier: here the runtime is wrong, not the baseline.
 
-2. **Konkurrent ist bereits nativ.** Für den Server-Side-Niche-Pfad (`chartjs-node-canvas`) ist die JS-Baseline gar nicht JS — es ist `node-canvas`, ein C++-Skia-Binding. Ein Rust-Port gegen eine native Baseline zu messen wiederholt den Fehler aus `docs/perf-review/gpt-tokenizer.md` (Rust vs. V8-tuned JS), nur extremer: wir würden Rust/Skia gegen C++/Skia messen. Kein erwartbarer Win.
+2. **Competitor is already native.** For the server-side niche path (`chartjs-node-canvas`), the JS baseline isn't JS at all — it's `node-canvas`, a C++/Skia binding. Measuring a Rust port against a native baseline repeats the mistake from `docs/perf-review/gpt-tokenizer.md` (Rust vs. V8-tuned JS), only more extreme: we'd be measuring Rust/Skia against C++/Skia. No expected win.
 
-3. **Plugin- und Animations-Callbacks erzwingen JS-Engine-Kopplung.** Chart.js' Plugin-API (`beforeDraw`, `afterRender`, Tooltip-Generatoren als Callbacks) hat exakt dieselbe Shape wie `ejs`' Expression-Eval: user-supplied JS, pro Frame (60fps = 60 Callbacks/sec minimum) über FFI zurück in V8. Das ist die `docs/perf-review/ejs.md`-Falle. Selbst wenn Plugins "optional" gemacht würden, sind die Standard-Tooltip-/Legend-Formatter bereits Callbacks — der Median-User trifft den Worst-Case.
+3. **Plugin and animation callbacks force coupling to the JS engine.** chart.js's plugin API (`beforeDraw`, `afterRender`, tooltip generators as callbacks) has exactly the same shape as `ejs`'s expression eval: user-supplied JS, per frame (60fps = 60 callbacks/sec minimum) back across the FFI into V8. That's the `docs/perf-review/ejs.md` trap. Even if plugins were made "optional", the default tooltip/legend formatters are already callbacks — the median user hits the worst case.
 
-Bonus-Problem: **Scope ist groß wie jsdom** — 9 Chart-Typ-Controller, Scales-Hierarchie, Animations-Engine, Hit-Testing, Responsive-Layout. Parity-Investment in Monaten, nicht Tagen.
+Bonus problem: **scope is as large as jsdom** — 9 chart-type controllers, scales hierarchy, animation engine, hit-testing, responsive layout. Parity investment in months, not days.
 
-Reference-Patterns: **jsdom** (Browser-Runtime, Object-Mutation) + **ejs** (Callback-pro-Expression) + **gpt-tokenizer-Lehre** (Rust gewinnt nicht gegen bereits-native Konkurrenz). Kein Overlap mit Green-Shapes (`commonmark`/`inflate`/`pdfkit-neu`) — dort ist ein Spec-Objekt → ein `Buffer`-Return mit substantieller One-Shot-Compute. Chart.js ist das Gegenteil: long-lived Instance, viele kleine State-Mutationen, Callback-heavy Rendering.
+Reference patterns: **jsdom** (browser runtime, object mutation) + **ejs** (callback-per-expression) + **gpt-tokenizer lesson** (Rust doesn't win against already-native competition). No overlap with Green shapes (`commonmark`/`inflate`/`pdfkit-new`) — those take one spec object → one `Buffer` return with substantial one-shot compute. chart.js is the opposite: long-lived instance, many small state mutations, callback-heavy rendering.
 
-**Kein "neues Paket"-Ausweg wie bei `pdfkit`.** Der `pdfkit`-Review zeigt, dass eine document-as-data-Reframing einen Chain-API-Drop-in retten kann. Für Chart.js funktioniert das nicht: (a) Der äquivalente Pfad — "plain Spec-Objekt → PNG/SVG-Buffer" — ist exakt das, was `plotters` nativ in Rust bietet, ohne NAPI-Wrapper. Jeder Rust-Node-User kann `plotters` direkt über sein eigenes Rust-Projekt anbinden; wir fügen keinen Wert hinzu. (b) Der interaktive Pfad (der eigentliche `chart.js`-Use-Case) ist per Definition Browser-gebunden und damit NAPI-unerreichbar. Es gibt keine Mittelebene, auf der ein amigo-Paket sinnvoll landet.
+**No "new package" escape hatch like in `pdfkit`.** The `pdfkit` review shows that a document-as-data reframing can rescue a chain-API drop-in. That doesn't work for chart.js: (a) the equivalent path — "plain spec object → PNG/SVG buffer" — is exactly what `plotters` offers natively in Rust, without a NAPI wrapper. Any Rust/Node user can bind `plotters` directly via their own Rust project; we add no value. (b) The interactive path (the actual `chart.js` use-case) is by definition browser-bound and therefore NAPI-unreachable. There is no middle layer on which an amigo package could sensibly land.
 
-**Benchmark-Gap-Flag:** Nicht relevant — die Klassifikation hängt nicht an Messwerten, sondern an Runtime/Shape-Argumenten. Benchmarks würden nur die strukturelle Ablehnung numerisch bestätigen.
+**Benchmark gap flag:** not relevant — the classification doesn't hinge on measurements, but on runtime/shape arguments. Benchmarks would only numerically confirm the structural rejection.
 
 ## If NO-GO — BACKLOG entry
 
 ```markdown
-- **chart.js** (~5M). Browser-first Canvas-2D-Charting-Library mit Plugin-Callbacks und Animations-Loop. Drei strukturelle Blocker: (1) dominanter Use-Case ist der Browser, wo NAPI nicht lädt — >95% der Nutzerbasis unerreichbar; (2) der Server-Side-Niche (`chartjs-node-canvas`) konkurriert gegen `node-canvas`/Skia, also bereits native C++-Baseline; (3) Plugin-/Animations-Callbacks erzwingen per-Frame FFI-Roundtrips nach V8 (`ejs`-Falle). Kein "neues Paket"-Reframing rettet das — der äquivalente Pfad (Spec → PNG/SVG-Buffer) ist bereits durch `plotters` direkt bedient, ohne NAPI-Wrapper. Keine Rust-Chart-Crate hat `chart.js`-kompatible API. Permanent NO-GO. Gleicher Ausschluss gilt analog für `chartjs-node-canvas`, `react-chartjs-2`, `chartkick` und verwandte Visualisierungs-Wrappers. Siehe `docs/perf-review/chartjs.md`.
+- **chart.js** (~5M). Browser-first Canvas-2D charting library with plugin callbacks and an animation loop. Three structural blockers: (1) the dominant use-case is the browser, where NAPI doesn't load — >95% of the user base is unreachable; (2) the server-side niche (`chartjs-node-canvas`) competes against `node-canvas`/Skia, i.e. an already-native C++ baseline; (3) plugin/animation callbacks force per-frame FFI roundtrips back into V8 (`ejs` trap). No "new package" reframing rescues this — the equivalent path (spec → PNG/SVG buffer) is already served directly by `plotters`, without a NAPI wrapper. No Rust chart crate has a `chart.js`-compatible API. Permanent NO-GO. The same exclusion applies analogously to `chartjs-node-canvas`, `react-chartjs-2`, `chartkick` and related visualization wrappers. See `docs/perf-review/chartjs.md`.
 ```
 
-Section in `BACKLOG.md`: **Scope too large** (primär) — sekundäre Zuordnung zu **Needs a JS engine** wegen Plugin-/Animation-Callbacks wäre ebenfalls korrekt.
+Section in `BACKLOG.md`: **Scope too large** (primary) — a secondary classification under **Needs a JS engine** for the plugin/animation callbacks would also be correct.

--- a/docs/perf-review/commonmark.md
+++ b/docs/perf-review/commonmark.md
@@ -1,52 +1,52 @@
 # Candidate review: `commonmark`
 
-> **Status:** GO (als neues Paket, kein Drop-in für `marked`) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-19
+> **Status:** GO (as a new package, not a drop-in for `marked`) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-`pulldown-cmark` ist ein Lehrbuch-Green-Shape: bytes-in / bytes-out, substantielle Compute-Arbeit pro Byte, kein Object-Traversal, kein Callback-Boundary-Problem. Als *neues* Paket mit ehrlicher Positionierung (CommonMark+GFM spec-strict, nicht `marked`-kompatibel) umgeht es die Parity-Falle, die `marked` selbst blockiert.
+`pulldown-cmark` is a textbook Green shape: bytes-in / bytes-out, substantial compute work per byte, no object traversal, no callback-boundary problem. As a *new* package with honest positioning (CommonMark + GFM spec-strict, not `marked`-compatible) it sidesteps the parity trap that blocks `marked` itself.
 
 ## JS package
 
-- **npm:** kein direkter Kandidat als Drop-in-Ziel — dieses Paket ist ein **neues Produkt**. Vergleichs-Alternativen in JS: `marked` (~30M/Woche), `markdown-it` (~25M/Woche), `commonmark.js` (~2M/Woche)
-- **Downloads:** n/a (Neuling)
-- **Exports / API surface:** klein gehalten — `render(md: string, opts?): string`, evtl. `parse(md) → token-array` für Streaming-/Walk-Use-Cases
-- **Typical input:** Markdown-Dokument 1 KB – 1 MB
-- **Typical output:** HTML-String
-- **Realistic median use-case:** Site-Builder (Astro/Docusaurus-artige Tools) rendert 500–5000 Docs pro Build; CLI-README-Viewer; AI-Chat-UIs, die Markdown-Antworten serverseitig rendern
+- **npm:** no direct candidate as a drop-in target — this package is a **new product**. Comparison alternatives in JS: `marked` (~30M/week), `markdown-it` (~25M/week), `commonmark.js` (~2M/week)
+- **Downloads:** n/a (newcomer)
+- **Exports / API surface:** kept small — `render(md: string, opts?): string`, possibly `parse(md) → token-array` for streaming/walk use-cases
+- **Typical input:** Markdown document 1 KB – 1 MB
+- **Typical output:** HTML string
+- **Realistic median use-case:** site builders (Astro/Docusaurus-style tools) rendering 500–5000 docs per build; CLI README viewers; AI chat UIs that render Markdown responses server-side
 
 ## Rust replacement
 
-- **Candidate crate(s):** `pulldown-cmark` (primär — minimal, schnell, CommonMark-konform, GFM-Extensions via Feature-Flags), `comrak` (feature-reicher, mehr GFM-Parity mit GitHub, größerer Bundle)
-- **Maintenance / license:** `pulldown-cmark` aktiv (raphlinus + Mitwirkende), MIT; `comrak` aktiv, BSD-2
-- **Known gotchas / divergences:** CommonMark 0.30 spec als Baseline — wenn wir das sauber kommunizieren, ist "Divergence" kein Bug, sondern ein Feature
+- **Candidate crate(s):** `pulldown-cmark` (primary — minimal, fast, CommonMark-compliant, GFM extensions via feature flags), `comrak` (more feature-rich, more GFM parity with GitHub, larger bundle)
+- **Maintenance / license:** `pulldown-cmark` active (raphlinus + contributors), MIT; `comrak` active, BSD-2
+- **Known gotchas / divergences:** CommonMark 0.30 spec as the baseline — if we communicate that cleanly, "divergence" is not a bug but a feature
 
 ## BACKLOG check
 
-Kein bestehender BACKLOG-Eintrag. `marked` ist dort als Drop-in-NO-GO geführt — dieses Paket ist explizit **kein** `marked`-Ersatz, sondern ein eigenständiges Angebot.
+No existing BACKLOG entry. `marked` is listed there as a drop-in NO-GO — this package is explicitly **not** a `marked` replacement but a stand-alone offering.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Substantiell: 100 KB Markdown ~500 µs – 1 ms in `pulldown-cmark`, JS-Baseline `marked` ~5 ms → 5–10× Kopfraum |
-| Input size distribution | 1 KB – 1 MB, `Buffer`-input möglich → FFI-Input-Kosten vernachlässigbar |
-| Output size distribution | HTML-String ~1.5× Input-Größe; 0.35 ns/Byte FFI-Output-Kost = bei 150 KB Output ~50 µs — tolerabel |
-| Reusable setup (stateful potential) | Niedrig — Options sind klein, kein teures Setup |
-| Batch-usage realism | Hoch: Site-Builder rendert hunderte Docs pro Build; `renderMany(docs: string[])`-API ist sinnvoll |
-| FFI-share estimate vs. Rust work | <15% bei ≥10 KB Dokumenten; bei 1 KB ~40% aber Speedup immer noch ≥2× |
+| Per-call algorithmic work | Substantial: 100 KB Markdown ~500 µs – 1 ms in `pulldown-cmark`, JS baseline `marked` ~5 ms → 5–10× headroom |
+| Input size distribution | 1 KB – 1 MB, `Buffer` input possible → FFI input cost negligible |
+| Output size distribution | HTML string ~1.5× input size; 0.35 ns/byte FFI output cost = ~50 µs at 150 KB output — tolerable |
+| Reusable setup (stateful potential) | Low — options are small, no expensive setup |
+| Batch-usage realism | High: site builders render hundreds of docs per build; a `renderMany(docs: string[])` API makes sense |
+| FFI-share estimate vs. Rust work | <15% on documents ≥10 KB; ~40% at 1 KB but speedup is still ≥2× |
 
 ## Classification reasoning
 
-Der Shape matcht exakt `sanitize-html` und `inflate` aus dem Repo: bytes-in, substantielle Compute, bytes-out. Kein `deep-equal`-Shape (kein Object-Traversal), kein `handlebars`-Shape (keine Callbacks), kein `mime`-Shape (kein FFI-Trap). `pulldown-cmark` ist zudem ein Pull-Parser, streamt intern — Memory-Footprint ist gut.
+The shape matches `sanitize-html` and `inflate` in the repo exactly: bytes-in, substantial compute, bytes-out. Not a `deep-equal` shape (no object traversal), not a `handlebars` shape (no callbacks), not a `mime` shape (no FFI trap). `pulldown-cmark` is also a pull parser, streams internally — memory footprint is good.
 
-Die einzige Bedingung für Green statt Yellow: der kleinste realistische Input muss sauber performen. Bei 1 KB Markdown ist JS-`marked` ~50 µs, `pulldown-cmark` über FFI läuft auf geschätzt ~15–20 µs — über 2×. Bei 100 KB wird es 8–10×. Der 2×-Kleinster-Input-Gate hält.
+The single condition for Green instead of Yellow: the smallest realistic input has to perform cleanly. At 1 KB Markdown JS `marked` is ~50 µs, `pulldown-cmark` over FFI comes in at an estimated ~15–20 µs — above 2×. At 100 KB it becomes 8–10×. The 2×-at-smallest-input gate holds.
 
-GFM-Parity mit `pulldown-cmark` ist gut: Tables, Strikethrough, Task-Lists, Footnotes, Autolinks via Feature-Flags. Das ist nicht `marked`-kompatibel, aber es ist **spec-kompatibel** — und ein spec-kompatibles CommonMark/GFM ist eine ehrliche, verteidigbare Position.
+GFM parity with `pulldown-cmark` is good: tables, strikethrough, task lists, footnotes, autolinks via feature flags. It's not `marked`-compatible, but it is **spec-compatible** — and a spec-compatible CommonMark/GFM is an honest, defensible position.
 
 ## If GO — proposed port
 
-- **Recommended crate-name:** `@amigo-labs/commonmark`
+- **Recommended crate name:** `@amigo-labs/commonmark`
 - **Primary API sketch:**
   ```ts
   export interface CommonMarkOptions {
@@ -59,10 +59,10 @@ GFM-Parity mit `pulldown-cmark` ist gut: Tables, Strikethrough, Task-Lists, Foot
 
   export function render(markdown: string | Buffer, opts?: CommonMarkOptions): string;
 
-  // Batch-API für Site-Builder
+  // Batch API for site builders
   export function renderMany(docs: Array<string | Buffer>, opts?: CommonMarkOptions): string[];
 
-  // Optional: stateful Renderer-Class für wiederholte Calls mit gleichem Opts-Set
+  // Optional: stateful renderer class for repeated calls with the same opts set
   export class Renderer {
     constructor(opts?: CommonMarkOptions);
     render(markdown: string | Buffer): string;
@@ -70,24 +70,24 @@ GFM-Parity mit `pulldown-cmark` ist gut: Tables, Strikethrough, Task-Lists, Foot
   ```
 
 - **Must-have benchmark scenarios:**
-  - **small**: 1 KB Markdown (typischer Blog-Absatz) vs. `marked`, `markdown-it`
-  - **medium**: 50 KB (langer Blog-Post / README) vs. gleiche
-  - **large**: 500 KB (Docusaurus-API-Referenz) vs. gleiche
-  - **batch**: `renderMany(500 × 10KB-docs)` — Site-Build-Shape
-  - **realistic median**: AI-Chat-Response-Shape, 2–5 KB mit Code-Blocks + Inline-Formatting
+  - **small**: 1 KB Markdown (typical blog paragraph) vs. `marked`, `markdown-it`
+  - **medium**: 50 KB (long blog post / README) vs. same
+  - **large**: 500 KB (Docusaurus API reference) vs. same
+  - **batch**: `renderMany(500 × 10KB docs)` — site-build shape
+  - **realistic median**: AI chat response shape, 2–5 KB with code blocks + inline formatting
 
 - **Acceptance thresholds (Green gate):**
-  - ≥2× vs. `marked` bei 1 KB
-  - ≥5× bei 50 KB
-  - ≥8× bei 500 KB
-  - `renderMany`-Overhead pro Item ≤15% vs. Einzelaufruf (sonst kein Batch-Gain)
+  - ≥2× vs. `marked` at 1 KB
+  - ≥5× at 50 KB
+  - ≥8× at 500 KB
+  - `renderMany` per-item overhead ≤15% vs. single call (otherwise no batch gain)
 
 - **Risks:**
-  - **Feature-Request-Drift**: Nutzer wollen `marked`-Plugins oder `markdown-it`-Plugins portiert — klare Doku "spec-only, keine Plugin-API v1"
-  - **Heading-IDs / Slug-Verhalten**: `github-slugger` ist der De-facto-Standard in JS; müssen wir entweder `slug`/`slugify` reusen (wir haben `@amigo-labs/slugify`) oder ein neues `headingSlugger` einführen
-  - **HTML-Sanitizing-Interaktion**: `unsafeHtml: false` muss klar dokumentiert sein; Nutzer, die rohes HTML brauchen, werden es anschalten und dann einen XSS-Vorfall haben → README-Warnung, Link auf `@amigo-labs/sanitize-html` als empfohlene Kette
-  - **GFM-Edge-Cases vs. GitHub**: `pulldown-cmark`s GFM ≈ GitHubs GFM, aber nicht byte-identisch. Für die meisten Nutzer irrelevant, für GitHub-Rendering-Klone problematisch — in README dokumentieren
+  - **Feature-request drift**: users want `marked` plugins or `markdown-it` plugins ported — clearly document "spec-only, no plugin API in v1"
+  - **Heading IDs / slug behavior**: `github-slugger` is the de-facto standard in JS; we either have to reuse `slug`/`slugify` (we ship `@amigo-labs/slugify`) or introduce a new `headingSlugger`
+  - **HTML sanitizing interaction**: `unsafeHtml: false` must be clearly documented; users who need raw HTML will turn it on and then have an XSS incident → README warning, link to `@amigo-labs/sanitize-html` as the recommended chain
+  - **GFM edge cases vs. GitHub**: `pulldown-cmark`'s GFM ≈ GitHub's GFM, but not byte-identical. Irrelevant for most users, problematic for GitHub-rendering clones — document in the README
 
 ## If NO-GO — BACKLOG entry
 
-n/a — Empfehlung ist GO.
+n/a — recommendation is GO.

--- a/docs/perf-review/cosmiconfig.md
+++ b/docs/perf-review/cosmiconfig.md
@@ -4,41 +4,41 @@
 
 ## Verdict
 
-`cosmiconfig` ist fs-Traversal: suche `.fooconfig.js`, `.fooconfig.json`, `foo.config.ts`, `package.json#foo` hoch durchs Dateisystem, bis gefunden. Bottleneck ist `fs.stat`/`fs.readFile`, nicht CPU. NAPI würde zwischen Rust und Nodes fs eine zusätzliche Kreuzung einfügen.
+`cosmiconfig` is fs traversal: search for `.fooconfig.js`, `.fooconfig.json`, `foo.config.ts`, `package.json#foo` up the filesystem until found. The bottleneck is `fs.stat`/`fs.readFile`, not CPU. NAPI would add an extra crossing between Rust and Node's fs.
 
 ## JS package
 
 - **npm:** `cosmiconfig`
-- **Downloads:** ~143M/Woche
+- **Downloads:** ~143M/week
 - **Exports / API surface:** `cosmiconfig(moduleName, options)` → `{ search(from), load(filepath), clearCaches() }`, async + sync
-- **Typical input:** Start-Directory, durchsucht bis zur Home-Directory
-- **Typical output:** `{ config, filepath }` oder `null`
-- **Realistic median use-case:** Tool-Start (ESLint, Prettier, Stylelint) sucht Config-Datei — einmal pro Lauf
+- **Typical input:** start directory, searched up to the home directory
+- **Typical output:** `{ config, filepath }` or `null`
+- **Realistic median use-case:** tool startup (ESLint, Prettier, Stylelint) searching for a config file — once per run
 
 ## Rust replacement
 
-- **Candidate crate(s):** kein direkter Ersatz. `figment`, `config-rs` sind andere Philosophie (explizite Sources)
+- **Candidate crate(s):** no direct replacement. `figment`, `config-rs` follow a different philosophy (explicit sources)
 - **Maintenance / license:** n/a
-- **Known gotchas / divergences:** `cosmiconfig` lädt `.ts`/`.mjs`/`.cjs`-Configs durch Node-Require-Hook — das muss JS machen, nicht Rust
+- **Known gotchas / divergences:** `cosmiconfig` loads `.ts`/`.mjs`/`.cjs` configs through Node's require hook — that has to be done by JS, not Rust
 
 ## BACKLOG check
 
-BACKLOG: *FFI overhead > gain* — bestätigt. Klassifikation: I/O-bound, nicht CPU-bound.
+BACKLOG: *FFI overhead > gain* — confirmed. Classification: I/O-bound, not CPU-bound.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Minimal — Pfad-String-Manipulation + fs-Calls |
-| Input size distribution | Pfade, klein |
-| Output size distribution | Config-Object (JSON-parsed) |
-| Reusable setup (stateful potential) | Cache für search-Ergebnisse — schon in JS implementiert |
-| Batch-usage realism | Null |
-| FFI-share estimate vs. Rust work | Rust müsste fs durch `std::fs` oder `tokio::fs` machen — eigene I/O-Implementierung parallel zu libuv, kein Gain |
+| Per-call algorithmic work | Minimal — path-string manipulation + fs calls |
+| Input size distribution | Paths, small |
+| Output size distribution | Config object (JSON-parsed) |
+| Reusable setup (stateful potential) | Cache for search results — already implemented in JS |
+| Batch-usage realism | Zero |
+| FFI-share estimate vs. Rust work | Rust would have to do fs via `std::fs` or `tokio::fs` — its own I/O implementation parallel to libuv, no gain |
 
 ## Classification reasoning
 
-`cosmiconfig` verbringt 99% der Zeit in `fs.stat` (existiert die Datei?) und `fs.readFile`. Diese Syscalls durchlaufen ohnehin den OS-Kernel — ob aufgerufen aus Rust oder JS ist egal, aber der Wechsel Rust→JS oder Rust-`std::fs`→Kernel spart nichts. Zusätzlich: Die killer-Feature von `cosmiconfig` — das Laden von `.ts`/`.mjs`-Configs — ist pure Node-Semantik (`require`/dynamic-import-Hook). Rust kann `.ts` nicht ausführen. Ein Rust-`cosmiconfig` wäre also zwingend ein Subset, wodurch Drop-in-Parity verloren geht.
+`cosmiconfig` spends 99% of its time in `fs.stat` (does the file exist?) and `fs.readFile`. These syscalls go through the OS kernel anyway — whether called from Rust or JS doesn't matter, but the switch Rust→JS or Rust `std::fs`→kernel saves nothing. On top of that: `cosmiconfig`'s killer feature — loading `.ts`/`.mjs` configs — is pure Node semantics (`require`/dynamic-import hook). Rust cannot execute `.ts`. A Rust `cosmiconfig` would therefore necessarily be a subset, and that breaks drop-in parity.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/d3-force.md
+++ b/docs/perf-review/d3-force.md
@@ -1,57 +1,57 @@
 # Candidate review: `d3-force`
 
-> **Status:** GO (als neues Paket `@amigo-labs/force-layout`, kein Drop-in) · **Predicted:** 🟡 Yellow leaning 🟢 Green · **Reviewed:** 2026-04-20
+> **Status:** GO (as a new package `@amigo-labs/force-layout`, not a drop-in) · **Predicted:** 🟡 Yellow leaning 🟢 Green · **Reviewed:** 2026-04-20
 
 ## Verdict
 
-`d3-force` ist eine **N-Body-Simulation** auf Graph-Nodes — Quad-Tree-basierte many-body repulsion + Feder-Forces für Edges, iterativ über Ticks. Pure Math auf Float-Arrays, keine DOM-Dependency. Shape ist Green für mittlere/große Graphen, aber **Tick-Callback-Semantik** ist die Falle: der idiomatische Use (`simulation.on('tick', draw)`) ruft JS 300× pro Simulation — exakt die `chart.js`-Animation-Falle. Als Batch-API (`simulate(nodes, edges, iterations) → finalPositions`) ist es Green; als Tick-Mirror ist es Black.
+`d3-force` is an **N-body simulation** over graph nodes — quad-tree-based many-body repulsion + spring forces for edges, iterated over ticks. Pure math on float arrays, no DOM dependency. The shape is Green for medium/large graphs, but the **tick-callback semantics** are the trap: the idiomatic use (`simulation.on('tick', draw)`) calls JS 300× per simulation — exactly the `chart.js` animation trap. As a batch API (`simulate(nodes, edges, iterations) → finalPositions`) it's Green; as a tick mirror it's Black.
 
 ## JS package
 
-- **npm:** [`d3-force`](https://www.npmjs.com/package/d3-force) (~2 M/Woche standalone) + via `d3`-bundle (~5 M/Woche)
+- **npm:** [`d3-force`](https://www.npmjs.com/package/d3-force) (~2M/week standalone) + via the `d3` bundle (~5M/week)
 - **Exports:** `forceSimulation(nodes)`, `forceManyBody()`, `forceLink(edges)`, `forceCenter()`, `forceCollide()`, `forceX()`, `forceY()`, `simulation.tick()`, `.on('tick'|'end', cb)`, `.restart()`, `.alpha()`
-- **Typical input:** Nodes mit `{id, x?, y?, vx?, vy?}` + Edges mit `{source, target, distance?}`
-- **Typical output:** In-place mutation der Nodes mit `x, y, vx, vy` nach N Ticks
-- **Realistic median use-case:** Force-directed Graph-Darstellung in Browsern (ObservableHQ, Kumu, Gephi-Web) — 50–500 Nodes, 60–300 Ticks bis Konvergenz, animiert per Tick-Callback
+- **Typical input:** nodes with `{id, x?, y?, vx?, vy?}` + edges with `{source, target, distance?}`
+- **Typical output:** in-place mutation of the nodes with `x, y, vx, vy` after N ticks
+- **Realistic median use-case:** force-directed graph visualization in browsers (ObservableHQ, Kumu, Gephi web) — 50–500 nodes, 60–300 ticks until convergence, animated via tick callback
 
 ## Rust replacement
 
-- **Candidate crates:** `fdg` (force-directed-graph, aktiv, MIT, Quadtree + Barnes-Hut), `fdg-sim` (Kernkomponente), alternativ direkter Port auf `petgraph` + custom Barnes-Hut
-- **Maintenance:** `fdg` aktiv, letzte Commits Q4 2025
-- **Gotchas:** d3's spezifische Force-Kombination (Link-Distance + many-body + collision) ist stabil-abgestimmt; Rust-Parity braucht identische Parameter-Semantik. Fixed-Nodes (pinned) müssen unterstützt werden.
+- **Candidate crates:** `fdg` (force-directed-graph, active, MIT, Quadtree + Barnes-Hut), `fdg-sim` (core component), alternatively a direct port onto `petgraph` + custom Barnes-Hut
+- **Maintenance:** `fdg` active, last commits Q4 2025
+- **Gotchas:** d3's specific force combination (link distance + many-body + collision) is stably tuned; Rust parity needs identical parameter semantics. Fixed (pinned) nodes must be supported.
 
 ## BACKLOG check
 
-Kein Eintrag. Kein `docs/packages.json`-Entry. Erster Force-Simulation-Kandidat.
+No entry. No `docs/packages.json` entry. First force-simulation candidate.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call work | Tick: O((V+E) log V) mit Barnes-Hut. 100 Nodes × 300 Ticks ≈ 30–80 ms JS. 500 Nodes × 300 Ticks ≈ 500 ms–2 s. Substantiell. |
-| Input size | Nodes-Array 50–500 × ~40 B + Edges ~60–800 × ~20 B = 2–30 KB. Ein Crossing. |
-| Output size | Positions flach, ~16 B × V. ≤10 KB für Median. `Buffer`/Float64Array flach. |
-| Stateful potential | **Hoch.** Simulation-State (Quadtree-Budget, Alpha-Decay) gehört in NAPI-Klasse — Caller kann mehrere `tick(n)`-Calls machen ohne Setup neu aufzubauen. |
-| Batch realism | Ein `simulate(iterations)` liefert Final-Positions; Tick-by-Tick ist der animierte Pfad. Server-Side (SSR-Graphen, Layout-Precompute) ist Batch-natürlich. |
-| FFI-share | Batch-simulate: <1% FFI auf Median (30 ms Rust, 200 ns Crossings). Tick-Mirror (`tick()` × 300 mit JS-Callback): 300 × ~300 ns = 90 µs Overhead bei 30 ms Work = 0.3%. Akzeptabel — aber Callback-Pattern bleibt API-hygienisch unsauber. |
+| Per-call work | Tick: O((V+E) log V) with Barnes-Hut. 100 nodes × 300 ticks ≈ 30–80 ms JS. 500 nodes × 300 ticks ≈ 500 ms–2 s. Substantial. |
+| Input size | Nodes array 50–500 × ~40 B + edges ~60–800 × ~20 B = 2–30 KB. One crossing. |
+| Output size | Positions flat, ~16 B × V. ≤10 KB for median. `Buffer`/Float64Array flat. |
+| Stateful potential | **High.** Simulation state (quadtree budget, alpha decay) belongs in a NAPI class — the caller can make several `tick(n)` calls without rebuilding setup. |
+| Batch realism | One `simulate(iterations)` delivers final positions; tick-by-tick is the animated path. Server-side (SSR graphs, layout precompute) is naturally batch. |
+| FFI-share | Batch simulate: <1% FFI on median (30 ms Rust, 200 ns crossings). Tick mirror (`tick()` × 300 with JS callback): 300 × ~300 ns = 90 µs overhead on 30 ms of work = 0.3%. Acceptable — but the callback pattern remains API-hygienically unclean. |
 
 ## Classification reasoning
 
-Drei Pfade:
+Three paths:
 
-1. **Batch `simulate(nodes, edges, iterations) → positions`** — 🟢 Green. One-Shot-Compute. Passt zu SSR, statischen Graph-Previews, CI-Layout-Precompute, Mermaid-Force-Renderern.
-2. **Stateful `ForceSimulation`-Klasse mit `.tick(n)`** — 🟡 Yellow. User ruft `.tick(1)` × 300 in RAF-Loop für Animation. 300 FFI-Crossings sind tolerabel (BASELINE), aber jeder Tick verlangt Positions-Transfer zurück nach JS. Bei 500 Nodes = 8 KB × 300 Crossings = ~2.5 MB/Simulation durchgeschaufelt. Messbar aber nicht Killer.
-3. **Tick-Callback `.on('tick', cb)` mit User-JS pro Tick** — 🔴 Red/Black. `chart.js`-Animation-Falle reinkarniert. Nicht anbieten.
+1. **Batch `simulate(nodes, edges, iterations) → positions`** — 🟢 Green. One-shot compute. Fits SSR, static graph previews, CI layout precompute, mermaid force renderers.
+2. **Stateful `ForceSimulation` class with `.tick(n)`** — 🟡 Yellow. The user calls `.tick(1)` × 300 in a RAF loop for animation. 300 FFI crossings are tolerable (BASELINE), but every tick requires a positions transfer back to JS. At 500 nodes = 8 KB × 300 crossings = ~2.5 MB shuffled per simulation. Measurable, not killer.
+3. **Tick callback `.on('tick', cb)` with user JS per tick** — 🔴 Red/Black. `chart.js` animation trap reincarnated. Don't offer.
 
-Für den Median-Server-Side-Use-Case (Layout-Precompute, Graph-Export) ist Pfad 1 ausreichend und liefert Green. Für Browser-interaktive Animation (d3-forces Haupt-Use-Case) bleibt JS-Baseline optimal — kein Port-Wert. Also: Paket addressiert den **Server-Side-Pfad** explizit, Browser-User bleiben auf d3-force.
+For the median server-side use-case (layout precompute, graph export), path 1 is sufficient and delivers Green. For browser-interactive animation (d3-force's main use-case) the JS baseline stays optimal — no port value. So: the package addresses the **server-side path** explicitly, browser users stay on d3-force.
 
-**Shape-Match:** wie `commonmark`/`pdfkit-batch` (spec-in, result-out, substantielle Compute). **Nicht** wie `chart.js` (keine Plugin-Callbacks im v1-API).
+**Shape match:** like `commonmark`/`pdfkit-batch` (spec-in, result-out, substantial compute). **Not** like `chart.js` (no plugin callbacks in the v1 API).
 
-**Benchmark-Gap-Flag:** Kleiner Graph (20 Nodes × 100 Ticks) muss ≥1× treffen sonst Yellow-Downgrade. d3's Quadtree ist hochoptimiert in V8 — der Rust-Gewinn könnte auf kleinen Graphen unter 1.5× liegen.
+**Benchmark gap flag:** a small graph (20 nodes × 100 ticks) has to hit ≥1× or Yellow downgrade. d3's quadtree is highly optimized in V8 — the Rust win on small graphs could come in under 1.5×.
 
 ## If GO — proposed port
 
-- **Crate-name:** `@amigo-labs/force-layout`
+- **Crate name:** `@amigo-labs/force-layout`
 - **API sketch:**
   ```ts
   type ForceNode = { id: string; x?: number; y?: number; fx?: number; fy?: number };
@@ -62,7 +62,7 @@ Für den Median-Server-Side-Use-Case (Layout-Precompute, Graph-Export) ist Pfad 
     centerX?: number; centerY?: number;
     collideRadius?: number;
     alphaMin?: number;           // default: 0.001
-    alphaDecay?: number;         // default: 0.0228 (→ ~300 Ticks)
+    alphaDecay?: number;         // default: 0.0228 (→ ~300 ticks)
     velocityDecay?: number;      // default: 0.4
   };
 
@@ -80,23 +80,23 @@ Für den Median-Server-Side-Use-Case (Layout-Precompute, Graph-Export) ist Pfad 
     setLinks(links: ForceLink[]): void;
   }
   ```
-  Kein `.on('tick', cb)`-Callback. Browser-Animationen bleiben bei d3.
+  No `.on('tick', cb)` callback. Browser animations stay on d3.
 - **Must-have benchmark scenarios:**
-  - **Tiny (20/30):** 20 Nodes, 30 Edges, 100 Ticks. Green-Gate: ≥ 1×.
-  - **Median (100/150):** **Entscheider** — 100 Nodes, 150 Edges, bis Konvergenz (~300 Ticks). Green-Gate: ≥ 2×.
-  - **Large (500/800):** 500/800, 300 Ticks. Green-Gate: ≥ 3×.
-  - **Tick-API (100/150, 300 × tick(1)):** misst Stateful-Class-Pfad mit JS-Loop. Yellow akzeptabel, Red-Warnung bei < 1.5×.
-- **Green gate:** alle Batch-Szenarien + ≥2× Median.
+  - **Tiny (20/30):** 20 nodes, 30 edges, 100 ticks. Green gate: ≥ 1×.
+  - **Median (100/150):** **the decider** — 100 nodes, 150 edges, to convergence (~300 ticks). Green gate: ≥ 2×.
+  - **Large (500/800):** 500/800, 300 ticks. Green gate: ≥ 3×.
+  - **Tick API (100/150, 300 × tick(1)):** measures the stateful-class path with a JS loop. Yellow acceptable, Red warning below 1.5×.
+- **Green gate:** all batch scenarios + ≥2× median.
 - **Risks:**
-  - **V8-Optimum:** d3's ManyBodyForce ist V8-JIT-freundlich — kleine Graphen könnten unter 2× liegen, weil die Rust-Pipeline pro Tick vergleichsweise wenig Arbeit hat.
-  - **Force-Parity:** Exakte Reproduktion der d3-Force-Kombination ist nicht Ziel; Layout-Qualität "gleichwertig" reicht. Pixel-Regression-Tests werden brechen.
-  - **Positions-Marshaling:** Float64Array/`Buffer` statt `{id, x, y}[]` könnte den Output-Overhead halbieren — v2-Optimierung falls Yellow.
-  - **Baseline-Gap:** `docs/BASELINE.md` deckt nicht "Array of 500 Number-Objekte". Vor Port-Start `nodeArrayEcho`-Case im `_ffi-bench` ergänzen.
+  - **V8 optimum:** d3's ManyBodyForce is V8-JIT-friendly — small graphs could land below 2× because the Rust pipeline has comparatively little work per tick.
+  - **Force parity:** exact reproduction of d3's force combination isn't the goal; layout quality "equivalent" is enough. Pixel-regression tests will break.
+  - **Positions marshalling:** Float64Array/`Buffer` instead of `{id, x, y}[]` could halve the output overhead — v2 optimization if Yellow.
+  - **Baseline gap:** `docs/BASELINE.md` doesn't cover "array of 500 Number objects". Before the port starts, add a `nodeArrayEcho` case in `_ffi-bench`.
 
 ## If NO-GO — BACKLOG entry
 
 ```markdown
-- **d3-force** (~2M/Woche standalone). N-Body-Force-Simulation. Shape-Green für Server-Side-Batch, aber Measurement ergab <2× auf dem Median-Case (100 Nodes × 300 Ticks), weil d3's Quadtree in V8 bereits JIT-optimal läuft. Eingefroren bis messbarer Hebel (SIMD-Quadtree?) oder Median-Graph wächst. Siehe `docs/perf-review/d3-force.md`.
+- **d3-force** (~2M/week standalone). N-body force simulation. Shape-Green for server-side batch, but measurement showed <2× on the median case (100 nodes × 300 ticks) because d3's Quadtree already runs JIT-optimal in V8. Frozen until there's a measurable lever (SIMD Quadtree?) or the median graph grows. See `docs/perf-review/d3-force.md`.
 ```
 
-Section: **FFI overhead > gain** oder **Parity too expensive**.
+Section: **FFI overhead > gain** or **Parity too expensive**.

--- a/docs/perf-review/dagre.md
+++ b/docs/perf-review/dagre.md
@@ -1,73 +1,73 @@
 # Candidate review: `dagre` / `@dagrejs/dagre`
 
-> **Status:** GO (als neues Paket `@amigo-labs/graph-layout`, kein Drop-in) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-20
+> **Status:** GO (as a new package `@amigo-labs/graph-layout`, not a drop-in) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-20
 
 ## Verdict
 
-`dagre` ist ein reiner **Algorithmus** — Sugiyama-Style Layered-Layout für gerichtete Graphen — **ohne** DOM, Canvas, Events oder Plugin-Callbacks. Input: Graph-Topologie + Node-Größen. Output: Koordinaten. Das ist exakt die `commonmark` / `pdfkit`-neu Green-Shape: Bytes-in / Bytes-out, substantielle Compute pro Call, keine Callback-Boundary. Der einzige Fallstrick ist die Drop-in-Versuchung: die graphlib-Chain-API (`g.setNode(...); g.setEdge(...); dagre.layout(g)`) mit dutzenden `setNode`-Crossings pro Layout wäre die `xml`/`pdfkit-chain`-Falle. Als `layout(spec)`-Paket mit einem Call pro Graph ist es Green.
+`dagre` is a pure **algorithm** — Sugiyama-style layered layout for directed graphs — **without** DOM, canvas, events, or plugin callbacks. Input: graph topology + node sizes. Output: coordinates. This is exactly the `commonmark` / `pdfkit`-new Green shape: bytes-in / bytes-out, substantial compute per call, no callback boundary. The only pitfall is the drop-in temptation: the graphlib chain API (`g.setNode(...); g.setEdge(...); dagre.layout(g)`) with dozens of `setNode` crossings per layout would be the `xml`/`pdfkit`-chain trap. As a `layout(spec)` package with one call per graph it's Green.
 
 ## JS package
 
-- **npm:** [`dagre`](https://www.npmjs.com/package/dagre) (original, seit 2020 unmaintained) + [`@dagrejs/dagre`](https://www.npmjs.com/package/@dagrejs/dagre) (aktiver Fork, Major-Consumer-Empfehlung)
-- **Downloads:** `dagre` ~1.5 M/Woche + `@dagrejs/dagre` ~1.3 M/Woche ≈ **~2.8 M/Woche kombiniert** (Q1 2026)
-- **Exports / API surface:** `graphlib.Graph` (Node-Klasse, stateful), `layout(graph, opts?)`, `acyclic`, `normalize`, `rank`, `order`, `position` als Einzel-Phasen-Exports
-- **Typical input:** Graph-Objekt mit `setNode(id, {width, height, label, rank?})` + `setEdge(v, w, {weight?, minlen?, labelpos?})` + Graph-Optionen (`rankdir`, `nodesep`, `ranksep`, `marginx`, `marginy`)
-- **Typical output:** Der gleiche Graph, **in-place mutiert** — jeder Node bekommt `.x`, `.y`; jede Edge bekommt `.points: [{x, y}, …]` + Routing; Graph selbst bekommt `.width`, `.height`
-- **Realistic median use-case:** **Mermaid-Flowcharts** (~20–200 Nodes, neuer Layout pro Edit), **ReactFlow-Editoren** (~10–500 Nodes, Re-Layout auf User-Action), **Cytoscape/joint.js-Dashboards**. Graphen sind meist 20–300 Nodes, 30–500 Edges. Re-Layout passiert **häufig** (pro User-Keystroke in manchen Editoren), aber immer als ein `layout()`-Call — nicht in Hot-Loops aufgerufen
+- **npm:** [`dagre`](https://www.npmjs.com/package/dagre) (original, unmaintained since 2020) + [`@dagrejs/dagre`](https://www.npmjs.com/package/@dagrejs/dagre) (active fork, major consumer recommendation)
+- **Downloads:** `dagre` ~1.5M/week + `@dagrejs/dagre` ~1.3M/week ≈ **~2.8M/week combined** (Q1 2026)
+- **Exports / API surface:** `graphlib.Graph` (node class, stateful), `layout(graph, opts?)`, `acyclic`, `normalize`, `rank`, `order`, `position` as single-phase exports
+- **Typical input:** graph object with `setNode(id, {width, height, label, rank?})` + `setEdge(v, w, {weight?, minlen?, labelpos?})` + graph options (`rankdir`, `nodesep`, `ranksep`, `marginx`, `marginy`)
+- **Typical output:** the same graph, **mutated in place** — every node gets `.x`, `.y`; every edge gets `.points: [{x, y}, …]` + routing; the graph itself gets `.width`, `.height`
+- **Realistic median use-case:** **Mermaid flowcharts** (~20–200 nodes, new layout per edit), **ReactFlow editors** (~10–500 nodes, re-layout on user action), **Cytoscape/joint.js dashboards**. Graphs are usually 20–300 nodes, 30–500 edges. Re-layout happens **often** (per user keystroke in some editors), but always as a single `layout()` call — not invoked in hot loops
 
 ## Rust replacement
 
 - **Candidate crate(s):**
-  - `layout` / `layout-rs` (nadavrot/layout auf crates.io) — **primär**. Sugiyama-Layered-Layout, aktiv gepflegt, MIT, pure-Rust, renderfähig zu SVG aber Koordinaten-Output ist direkt zugänglich. Keine native Dependencies, WASM-tauglich.
-  - `petgraph` — für Graph-Primitive (DAG-Check, SCC, topological sort) als Baustein
-  - `rust-sugiyama` (weniger bekannt, kleinerer Scope) — sekundär
-  - Custom-Port: Der Sugiyama-Algorithmus aus `dagre/lib/` ist gut dokumentiert (~3000 Zeilen JS, davon ~1500 hot). Direkte Portierung mit `petgraph`-Backend ist tractable
-- **Maintenance / license:** `layout-rs` MIT, aktiv, letzte Commits Q1 2026. `petgraph` ist Standard-Crate des Ökosystems. Kein Supply-Chain-Risiko.
+  - `layout` / `layout-rs` (nadavrot/layout on crates.io) — **primary**. Sugiyama layered layout, actively maintained, MIT, pure-Rust, can render to SVG but coordinate output is directly accessible. No native dependencies, WASM-capable.
+  - `petgraph` — for graph primitives (DAG check, SCC, topological sort) as a building block
+  - `rust-sugiyama` (less known, smaller scope) — secondary
+  - Custom port: the Sugiyama algorithm in `dagre/lib/` is well documented (~3000 lines of JS, ~1500 of them hot). Direct porting with a `petgraph` backend is tractable
+- **Maintenance / license:** `layout-rs` MIT, active, last commits Q1 2026. `petgraph` is a standard ecosystem crate. No supply-chain risk.
 - **Known gotchas / divergences:**
-  - Pixel-Parity mit `dagre` **kein Ziel** — Sugiyama hat viele valide Lösungen pro Graph, jeder Implementer wählt marginal anders
-  - Edge-Routing: `dagre`'s Spline-Heuristik (via `graphlib-dot` indirekt) ist proprietär; `layout-rs` routet direkt. Konsumenten wie Mermaid akzeptieren das, weil sie die Points ohnehin durch ihre eigene Spline-Library schieben
-  - `ranker: 'network-simplex' | 'tight-tree' | 'longest-path'` — drei Ranker-Algorithmen in dagre. v1 kann auf `network-simplex` (der default) begrenzt sein; die anderen als Fast-Follow
-  - Label-Nodes: `dagre` fügt implizit Dummy-Nodes für Kanten-Labels ein. Muss repliziert werden, sonst kollidieren Labels mit Edges
+  - Pixel parity with `dagre` is **not a goal** — Sugiyama has many valid solutions per graph, each implementer picks marginally differently
+  - Edge routing: `dagre`'s spline heuristic (via `graphlib-dot` indirectly) is proprietary; `layout-rs` routes directly. Consumers like Mermaid accept this because they pass the points through their own spline library anyway
+  - `ranker: 'network-simplex' | 'tight-tree' | 'longest-path'` — three ranker algorithms in dagre. v1 can be limited to `network-simplex` (the default); the others as a fast-follow
+  - Label nodes: `dagre` implicitly inserts dummy nodes for edge labels. Must be replicated, otherwise labels collide with edges
 
 ## BACKLOG check
 
-Kein `dagre`-Eintrag in `BACKLOG.md`. Keine Graph-Layout- oder Visualisierungs-Bibliothek bisher bewertet (nur `chart.js` → Black). Kein Eintrag in `docs/packages.json`. Dieses Review ist der erste Kandidat in der Graph-Algorithmen-Kategorie und legt die Vorlage für `d3-force`, `cytoscape-layouts`, `elkjs` etc.
+No `dagre` entry in `BACKLOG.md`. No graph-layout or visualization library rated so far (only `chart.js` → Black). No entry in `docs/packages.json`. This review is the first candidate in the graph-algorithms category and sets the template for `d3-force`, `cytoscape-layouts`, `elkjs` etc.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Substantiell für den Median-Case.** 100 Nodes / 150 Edges: ~2–10 ms in dagre JS (abhängig von Ranker). 500 Nodes / 800 Edges: ~50–200 ms. Rust-Port sollte 2–5× darunter liegen. Kein Trivial-Compute-Risiko. |
-| Input size distribution | Graph-Spec als JSON/Array ~2–50 KB für den Median. Batch-Pass (ein Call mit `{nodes, edges}`) kollabiert die 150+ `setNode`/`setEdge` Crossings der graphlib-API auf **ein** Crossing. |
-| Output size distribution | Positions-Array ~100 × 16 B (x/y doubles) + Edge-Points ~200 × 4 × 16 B = ~15 KB für Median-Graph. `Buffer`/Typed-Array-Return oder einfaches JS-Objekt — `docs/BASELINE.md` sagt beides ist flach <200 ns bis ~1 MB. |
-| Reusable setup (stateful potential) | **Mittel.** Graph-Konfiguration (`rankdir`, `ranksep`, etc.) könnte in einer `GraphLayouter`-Klasse gecached werden. Größerer Hebel: bei Re-Layout auf User-Edit **mutiert** der User den Graph; wenn er eine NAPI-Klasse hält, könnte ein diff-basiertes Re-Layout später Punkte holen (Fast-Follow, nicht v1). |
-| Batch-usage realism | **Mittel-niedrig.** Ein User-Edit = ein `layout()`-Call. Mermaid-Server (z.B. Docusaurus-Build) rendert aber hunderte Diagramme pro Build — `layoutMany(specs: LayoutSpec[])` ist für diese Use-Cases der Hebel. |
-| FFI-share estimate vs. Rust work | Drop-in Chain-API (`setNode` × 150 + `layout()`): 150 Crossings × 180 ns = ~27 µs FFI bei ~5 ms Rust-Compute = **<1% FFI** — tolerabel, aber unnötig. Batch-Spec-API: <0.5% FFI. Beide sind Green-tauglich aus FFI-Sicht; Präferenz für Batch-API aus API-Hygiene-Gründen (kein Stateful-Object über FFI-Grenze mit Mutations-Semantik). |
+| Per-call algorithmic work | **Substantial for the median case.** 100 nodes / 150 edges: ~2–10 ms in dagre JS (depending on ranker). 500 nodes / 800 edges: ~50–200 ms. Rust port should land 2–5× below that. No trivial-compute risk. |
+| Input size distribution | Graph spec as JSON/array ~2–50 KB for the median. A batch pass (one call with `{nodes, edges}`) collapses the 150+ `setNode`/`setEdge` crossings of the graphlib API into **one** crossing. |
+| Output size distribution | Positions array ~100 × 16 B (x/y doubles) + edge points ~200 × 4 × 16 B = ~15 KB for the median graph. `Buffer`/typed-array return or plain JS object — `docs/BASELINE.md` says both are flat <200 ns up to ~1 MB. |
+| Reusable setup (stateful potential) | **Medium.** Graph configuration (`rankdir`, `ranksep`, etc.) could be cached in a `GraphLayouter` class. Bigger lever: on re-layout after a user edit the user **mutates** the graph; if they hold a NAPI class, diff-based re-layout could pick up points later (fast-follow, not v1). |
+| Batch-usage realism | **Medium-low.** One user edit = one `layout()` call. But Mermaid servers (e.g. Docusaurus build) render hundreds of diagrams per build — `layoutMany(specs: LayoutSpec[])` is the lever for those use-cases. |
+| FFI-share estimate vs. Rust work | Drop-in chain API (`setNode` × 150 + `layout()`): 150 crossings × 180 ns = ~27 µs FFI on ~5 ms Rust compute = **<1% FFI** — tolerable, but unnecessary. Batch spec API: <0.5% FFI. Both are Green-capable from an FFI perspective; preference for the batch API on API-hygiene grounds (no stateful object across the FFI boundary with mutation semantics). |
 
 ## Classification reasoning
 
-Dagre ist einer der **saubersten** Green-Shapes im JS-Ökosystem, gerade weil es keinen der drei `chart.js`-Blocker hat:
+Dagre is one of the **cleanest** Green shapes in the JS ecosystem, precisely because it has none of the three `chart.js` blockers:
 
-1. **Runtime-Symmetrie.** Dagre läuft identisch in Browser und Node — reiner Algorithmus, keine DOM-Dependencies. `@amigo-labs/graph-layout` erreicht den Node-Consumer-Pfad (Mermaid-Server, Docusaurus-Build, CI-Graph-Rendering, reactflow-SSR) ohne Runtime-Mismatch. Browser-Consumer bleiben auf JS, das ist OK — sie haben nie eine native Option.
+1. **Runtime symmetry.** Dagre runs identically in browser and Node — pure algorithm, no DOM dependencies. `@amigo-labs/graph-layout` reaches the Node consumer path (Mermaid server, Docusaurus build, CI graph rendering, reactflow SSR) without a runtime mismatch. Browser consumers stay on JS, which is fine — they never had a native option.
 
-2. **Keine native Konkurrenz.** Anders als `chart.js` (wo `node-canvas` → Skia das Feld hielt) hat Graph-Layout **keinen** nativen JS-Konkurrenten. Dagre ist pure JS, ELK ist Java (via GWT zu JS), alle anderen Layouter sind ebenfalls pure JS. Rust-Port misst gegen echte JS-Baseline.
+2. **No native competition.** Unlike `chart.js` (where `node-canvas` → Skia held the field), graph layout has **no** native JS competitor. Dagre is pure JS, ELK is Java (via GWT to JS), all other layouters are also pure JS. The Rust port measures against a real JS baseline.
 
-3. **Keine Callback-Surface.** Dagre hat keine Plugins, keine Tooltip-Formatter, keine Animationen. Der einzige Callback im API ist `nodeOrder` (optional, selten genutzt). v1 kann ihn weglassen.
+3. **No callback surface.** Dagre has no plugins, no tooltip formatters, no animations. The only callback in the API is `nodeOrder` (optional, rarely used). v1 can leave it out.
 
-Zusätzlich: der Algorithmus ist **compute-bound**, nicht memory-bound — Crossing-Reduction ist der typische Hot-Path und das ist pure Integer-Arithmetik auf Rank-/Order-Arrays. Rust hat hier nachmessbare Gewinne (kein GC-Druck auf den inneren Loops, Fixed-Size-Arrays statt V8-Arrays, kein Hashmap-Lookup für Node-IDs wenn man auf `usize`-Indices geht).
+Also: the algorithm is **compute-bound**, not memory-bound — crossing reduction is the typical hot path, and it's pure integer arithmetic on rank/order arrays. Rust has measurable wins here (no GC pressure on inner loops, fixed-size arrays instead of V8 arrays, no hashmap lookup for node IDs if you use `usize` indices).
 
-**Shape-Matching:**
-- ✅ Wie `commonmark` (Bytes-in-spec, Bytes-out-result, substantielle Compute)
-- ✅ Wie `pdfkit` (neues Paket, nicht Drop-in; Spec→Output; stateful-class optional)
-- ✅ Wie `sanitize-html` (AST-Transformation mit Parser + Algorithmus + Serializer)
-- ❌ **Nicht** wie `chartjs` (keine Browser-Runtime, keine Native-Konkurrenz, keine Callbacks)
-- ❌ **Nicht** wie `deep-equal`/`levenshtein` (kein Short-Input-Hot-Loop)
+**Shape matching:**
+- ✅ Like `commonmark` (bytes-in spec, bytes-out result, substantial compute)
+- ✅ Like `pdfkit` (new package, not drop-in; spec → output; stateful-class optional)
+- ✅ Like `sanitize-html` (AST transformation with parser + algorithm + serializer)
+- ❌ **Not** like `chartjs` (no browser runtime, no native competition, no callbacks)
+- ❌ **Not** like `deep-equal`/`levenshtein` (no short-input hot loop)
 
-**Benchmark-Gap-Flag:** Die Green-Prediction ist algorithmisch fundiert aber unmeasured. Vor Shipping müssen die vier Szenarien unten gemessen werden. Kleinster Graph (10 Nodes) muss mindestens `1×` treffen — darunter kippt es auf Yellow. Ranker-Wahl ist Faktor: `network-simplex` ist der schwerste Pfad in dagre und damit der beste Gewinn-Kandidat; `longest-path` ist trivial und bringt kaum Rust-Gewinn.
+**Benchmark gap flag:** the Green prediction is algorithmically grounded but unmeasured. Before shipping, the four scenarios below must be measured. The smallest graph (10 nodes) has to hit at least `1×` — below that it tips to Yellow. Ranker choice is a factor: `network-simplex` is the heaviest path in dagre and therefore the best win candidate; `longest-path` is trivial and brings barely any Rust win.
 
 ## If GO — proposed port
 
-- **Recommended crate-name:** `@amigo-labs/graph-layout` (nicht `@amigo-labs/dagre` — explizit nicht Drop-in, und öffnet Tür für weitere Layouter-Algorithmen als Fast-Follow: `force`, `elk-lite`, `hierarchical`)
+- **Recommended crate name:** `@amigo-labs/graph-layout` (not `@amigo-labs/dagre` — explicitly not drop-in, and opens the door to further layouter algorithms as fast-follow: `force`, `elk-lite`, `hierarchical`)
 - **Primary API sketch:**
   ```ts
   type NodeSpec = {
@@ -122,31 +122,31 @@ Zusätzlich: der Algorithmus ist **compute-bound**, nicht memory-bound — Cross
   ): LayoutResult[];
 
   export class GraphLayouter {
-    constructor(options?: LayoutOptions);   // Options einmal setzen, viele layouts
+    constructor(options?: LayoutOptions);   // set options once, many layouts
     layout(nodes: NodeSpec[], edges: EdgeSpec[]): LayoutResult;
   }
   ```
-  **Explizit nicht** `graphlib.Graph`-kompatibel. Keine stateful Mutation über die FFI-Grenze, kein `g.node(id).x = ...`.
+  **Explicitly not** `graphlib.Graph`-compatible. No stateful mutation across the FFI boundary, no `g.node(id).x = ...`.
 - **Must-have benchmark scenarios:**
-  - **Tiny (10/12):** 10 Nodes, 12 Edges — Mermaid-Minimal-Flowchart. Misst ob FFI-Overhead den Win auffrisst. Green-Gate: ≥ 1×.
-  - **Small (50/75):** typischer README-Flowchart. Green-Gate: ≥ 1.5×.
-  - **Median (100/150):** **der eigentliche Bench-Entscheider** — ReactFlow-Editor mit mittlerer Komplexität. Green-Gate: ≥ 2×.
-  - **Large (500/800):** CI/CD-DAG, Monorepo-Dep-Graph. Green-Gate: ≥ 3×.
-  - **Ranker-Matrix:** alle drei Szenarien × {`network-simplex`, `longest-path`} getrennt messen. `network-simplex` ist der Gewinn-Driver.
-- **Acceptance thresholds (Green gate):** alle oben + `layoutMany(100 × Median-Graph)` ≥ 3× dagre-Schleife (misst Batch-FFI-Amortisation). Ein Szenario unter dem Gate → Yellow, Review nach einem Sprint.
+  - **Tiny (10/12):** 10 nodes, 12 edges — Mermaid minimal flowchart. Measures whether FFI overhead eats the win. Green gate: ≥ 1×.
+  - **Small (50/75):** typical README flowchart. Green gate: ≥ 1.5×.
+  - **Median (100/150):** **the actual bench decider** — ReactFlow editor with medium complexity. Green gate: ≥ 2×.
+  - **Large (500/800):** CI/CD DAG, monorepo dep graph. Green gate: ≥ 3×.
+  - **Ranker matrix:** measure all three scenarios × {`network-simplex`, `longest-path`} separately. `network-simplex` is the win driver.
+- **Acceptance thresholds (Green gate):** all of the above + `layoutMany(100 × median-graph)` ≥ 3× a dagre loop (measures batch FFI amortization). One scenario below the gate → Yellow, review after one sprint.
 - **Risks:**
-  - **Parity-Tail:** dagre hat 10 Jahre Edge-Cases (self-loops, multi-edges, disconnected components, rank-constraints, compound-nodes). v1-Scope muss explizit ausgewiesen sein: **einfache gerichtete Graphen, keine Compound-Nodes, keine Multi-Edges**. Das schließt ~95% des Mermaid/ReactFlow-Traffics ein.
-  - **Output-Divergenz:** Positionen werden sich von dagre unterscheiden (auch schon zwischen `dagre` und `@dagrejs/dagre` gibt es Drift). Consumer müssen wissen: das Paket berechnet *ein gutes* Layout, nicht *dagre's* Layout. Mermaid-User die Pixel-Regression-Tests gegen dagre-Output haben, werden sie neu baseliine müssen.
-  - **Layout-rs-Maturity:** Falls `layout-rs` nicht alle drei Ranker hat oder Edge-Routing schwach ist, muss der Sugiyama-Pipeline custom implementiert werden. Das ist ~2000 Zeilen Rust statt ~300. Vor Port-Start muss verifiziert werden.
-  - **Benchmark-Realismus:** Der Median-Fall ist "User klickt, Layout neu" — also eine Single-Call-Latenz, nicht Throughput. Green ist erst dann Green, wenn die Single-Call-Latenz auch bei 100-Node-Graphen klar unter dem JS-Baseline liegt (inklusive First-Call-Cold-Start — keine Regex-Compile-o.ä. Kaltstart-Falle).
-  - **`_ffi-bench`-Baseline-Nuance:** `docs/BASELINE.md` deckt `echoBuffer`, nicht "JSON-Objekt mit 500 Nodes". Input-Marshaling-Kosten für tiefe Node-Arrays sind qualitativ geschätzt, nicht gemessen. Vor Port-Start einen `nodeArrayEcho(n)`-Case zum `_ffi-bench`-Crate ergänzen.
+  - **Parity tail:** dagre has 10 years of edge cases (self-loops, multi-edges, disconnected components, rank constraints, compound nodes). v1 scope must be explicitly declared: **simple directed graphs, no compound nodes, no multi-edges**. That covers ~95% of Mermaid/ReactFlow traffic.
+  - **Output divergence:** positions will differ from dagre (there's already drift between `dagre` and `@dagrejs/dagre`). Consumers need to know: the package computes *a good* layout, not *dagre's* layout. Mermaid users with pixel-regression tests against dagre output will need to re-baseline.
+  - **layout-rs maturity:** if `layout-rs` lacks any of the three rankers or edge routing is weak, the Sugiyama pipeline has to be implemented custom. That's ~2000 lines of Rust instead of ~300. Must be verified before the port starts.
+  - **Benchmark realism:** the median case is "user clicks, re-layout" — so single-call latency, not throughput. Green is only Green once single-call latency is clearly below the JS baseline at 100-node graphs (including first-call cold start — no regex-compile or similar cold-start trap).
+  - **`_ffi-bench` baseline nuance:** `docs/BASELINE.md` covers `echoBuffer`, not "JSON object with 500 nodes". Input marshalling costs for deep node arrays are qualitatively estimated, not measured. Add a `nodeArrayEcho(n)` case to the `_ffi-bench` crate before the port starts.
 
 ## If NO-GO — BACKLOG entry
 
-Nicht einschlägig — Prediction ist Green. Falls das Review-Ergebnis nach Messung aber Yellow oder Red würde (z.B. wenn `layout-rs` auf kleinen Graphen langsamer ist als dagre-JS weil JS' JIT die einfachen Integer-Loops schon optimal übersetzt), wäre die BACKLOG-Einordnung:
+Not applicable — prediction is Green. But if the review result after measurement turns Yellow or Red (for example because `layout-rs` is slower than dagre-JS on small graphs because V8's JIT already translates the simple integer loops optimally), the BACKLOG classification would be:
 
 ```markdown
-- **dagre / @dagrejs/dagre** (~2.8M/Woche kombiniert). Graph-Layout-Algorithmus (Sugiyama-layered). Shape-technisch Green — aber Measurement ergab <1.5× Gewinn auf dem Median-Case (100/150 Graph), weil V8 den Crossing-Reduction-Hotloop bereits gut JIT'd. Port eingefroren bis a) messbar schnellerer Rust-Sugiyama-Ansatz gefunden (SIMD für Rank-Arrays?), b) Median-Case sich zu größeren Graphen verschiebt. Siehe `docs/perf-review/dagre.md`.
+- **dagre / @dagrejs/dagre** (~2.8M/week combined). Graph-layout algorithm (Sugiyama-layered). Shape-Green — but measurement showed <1.5× win on the median case (100/150 graph) because V8 already JITs the crossing-reduction hotloop well. Port frozen until a) a measurably faster Rust Sugiyama approach is found (SIMD for rank arrays?), b) the median case shifts toward larger graphs. See `docs/perf-review/dagre.md`.
 ```
 
-Section in `BACKLOG.md`: **FFI overhead > gain** (falls klein-Graph-Problem) oder **Parity too expensive** (falls Sugiyama-Varianten-Tail zu lang wird).
+Section in `BACKLOG.md`: **FFI overhead > gain** (if small-graph problem) or **Parity too expensive** (if the Sugiyama-variants tail gets too long).

--- a/docs/perf-review/deep-equal.md
+++ b/docs/perf-review/deep-equal.md
@@ -1,84 +1,84 @@
-# Perf-Review: `@amigo-labs/deep-equal`
+# Perf review: `@amigo-labs/deep-equal`
 
-> **Status:** 🔴 Red (bestätigt) · **Reviewed:** 2026-04-19 · **Version:** 0.2.0 (deprecated)
+> **Status:** 🔴 Red (confirmed) · **Reviewed:** 2026-04-19 · **Version:** 0.2.0 (deprecated)
 
 ## Verdict
 
-Re-Review bestätigt die Deprecation-Entscheidung aus 0.2.0: es gibt strukturell keinen Hebel, `fast-deep-equal` mit einem NAPI-Binding zu schlagen — die Phase-C-Liste ist vollständig nicht-anwendbar.
+Re-review confirms the deprecation decision from 0.2.0: there is structurally no lever to beat `fast-deep-equal` with a NAPI binding — the Phase C list is completely inapplicable.
 
 ## Classification rationale
 
-Drei Dinge machen den Fall eindeutig:
+Three things make the case clear:
 
-1. **Die publizierte "1,3× faster"-Zahl stammt gar nicht vom Rust-Code.** `wrapper.js` exportiert per Default eine pure-JS-`equal`-Funktion (Zeilen 9–61) — `native.deepEqualJson` ist nur ein Opt-in-Export für Plain-JSON-Inputs und taucht im Default-Pfad nicht auf. Die Benches in `__bench__/index.bench.ts` importieren den Default-Export, messen also V8 gegen V8. Der Rust-Crate ist im gemessenen Hot-Path schlicht nicht beteiligt.
+1. **The published "1.3× faster" number doesn't come from the Rust code at all.** `wrapper.js` exports a pure-JS `equal` function by default (lines 9–61) — `native.deepEqualJson` is only an opt-in export for plain-JSON inputs and doesn't appear in the default path. The benches in `__bench__/index.bench.ts` import the default export, so they measure V8 vs. V8. The Rust crate simply isn't involved in the measured hot path.
 
-2. **Die FFI-Baseline schließt jede Rust-Route strukturell aus.** `BASELINE.md` zeigt: jeder NAPI-Call kostet mindestens 109 ns (Floor), `serde_json::Value`-Marshalling eines Objekts mit N Properties zahlt zusätzlich das `Vec<T>`-Element-Porto von ~43 ns pro Property. Ein 7-Key-Objekt landet damit *vor* dem ersten Vergleich bei ≥400 ns — `fast-deep-equal` ist für denselben Input mit ~680 ns insgesamt durch. Es gibt keinen Vergleichs-Algorithmus, der den FFI-Teil kompensiert.
+2. **The FFI baseline structurally excludes every Rust route.** `BASELINE.md` shows: every NAPI call costs at least 109 ns (floor), `serde_json::Value` marshalling of an object with N properties additionally pays the `Vec<T>` element toll of ~43 ns per property. A 7-key object therefore lands at ≥400 ns *before* the first comparison — `fast-deep-equal` is through the whole thing for the same input at ~680 ns. There is no comparison algorithm that can compensate for the FFI portion.
 
-3. **Der Alternative ist V8-JIT-Code.** `fast-deep-equal` ist ~32 Zeilen monomorphes JS, das V8 inline-cached und in eine Handvoll Maschinen-Instruktionen übersetzt. Rekursiver Property-Walk ist genau der Workload, den V8 seit einem Jahrzehnt optimiert. Kein Rust-Port mit `napi::JsObject::get_named_property` (ein FFI-Hop pro Property) kommt dagegen an.
+3. **The alternative is V8 JIT code.** `fast-deep-equal` is ~32 lines of monomorphic JS that V8 inline-caches and translates into a handful of machine instructions. Recursive property walk is exactly the workload V8 has been optimizing for a decade. No Rust port with `napi::JsObject::get_named_property` (one FFI hop per property) can match that.
 
 ## Evidence
 
 ### Measured speedup (from docs/data.json)
 
-| Szenario | `@amigo-labs/deep-equal` (JS-Wrapper) | `fast-deep-equal` | Ratio |
+| Scenario | `@amigo-labs/deep-equal` (JS wrapper) | `fast-deep-equal` | Ratio |
 |---|---:|---:|---:|
-| flat 7-key objects | 1.909.263 ops/s | 1.468.804 ops/s | 1,30× |
-| deeply nested (20 levels) | 334.890 ops/s | 316.431 ops/s | 1,06× |
-| 10k objects in array | 240 ops/s | 236 ops/s | 1,02× |
+| flat 7-key objects | 1,909,263 ops/s | 1,468,804 ops/s | 1.30× |
+| deeply nested (20 levels) | 334,890 ops/s | 316,431 ops/s | 1.06× |
+| 10k objects in array | 240 ops/s | 236 ops/s | 1.02× |
 
-Zur Einordnung: das sind **JS vs. JS**-Zahlen, nicht Rust vs. JS. Native wird in `amigoEqual(a, b)` nie aufgerufen.
+To put it in context: those are **JS vs. JS** numbers, not Rust vs. JS. Native is never called in `amigoEqual(a, b)`.
 
 ### Realistic use-case
 
-Deep-equal-Aufrufe in der Praxis sind kurz und häufig: React-Memo-Vergleiche, Redux-Selector-Caches, Jest-Matcher, Request-Diffs. Median ~5–50 Properties, Call-Frequenz hoch, keine Amortisation einer Setup-Phase. Das ist exakt die "tiny work per call, many calls"-FFI-Falle aus den Post-Mortems (mime, dotenv, shallow-clone).
+Deep-equal calls in practice are short and frequent: React memo comparisons, Redux selector caches, Jest matchers, request diffs. Median ~5–50 properties, high call frequency, no amortization of a setup phase. That's exactly the "tiny work per call, many calls" FFI trap from the post-mortems (mime, dotenv, shallow-clone).
 
 ### Benchmark gaps
 
-Keine für die Deprecation-Entscheidung relevanten — die drei gemessenen Size-Buckets decken die realistischen Fälle ab, und alle drei sind ≤1,3× oder Parität. Eine zusätzliche Messung des tatsächlichen `native.deepEqualJson`-Pfades gegen `fast-deep-equal` würde die Lücke noch deutlicher zeigen, ist aber nicht nötig — die FFI-Baseline gibt die Antwort bereits vorab.
+None relevant for the deprecation decision — the three measured size buckets cover the realistic cases, and all three are ≤1.3× or parity. An additional measurement of the actual `native.deepEqualJson` path against `fast-deep-equal` would show the gap even more clearly, but isn't needed — the FFI baseline already answers it up front.
 
 ### API surface
 
-`deep_equal_json(a: Value, b: Value) -> bool` in `src/lib.rs:39`. Zwei `serde_json::Value`-Inputs (owned), Bool-Output. Signatur ist *schon* so schlank wie sie an NAPI gehen kann — weiteres Input-Trimming ist nicht möglich, ohne die Semantik zu verlieren.
+`deep_equal_json(a: Value, b: Value) -> bool` in `src/lib.rs:39`. Two `serde_json::Value` inputs (owned), bool output. The signature is *already* as lean as it can be for NAPI — further input trimming isn't possible without losing the semantics.
 
 ### Bundle / binary size
 
-Nicht der Bottleneck. `wrapper.js` lädt den nativen Binary lazy, aber der komplette Payload inkl. prebuilds ist größer als `fast-deep-equal`s 32-Zeilen-Source. Im "Rust verliert schon am Floor"-Szenario ist das nur ein weiterer Nachteil, nicht der Hauptgrund.
+Not the bottleneck. `wrapper.js` lazy-loads the native binary, but the full payload incl. prebuilds is larger than `fast-deep-equal`'s 32-line source. In the "Rust loses already at the floor" scenario, that's just another disadvantage, not the main reason.
 
 ### FFI-overhead baseline
 
 `BASELINE.md`:
-- Floor: 109 ns/Call.
-- `sumArray(Vec<u32>)` (nächstbester Proxy für Property-Marshalling): 43 ns pro Element.
-- `echoBuffer` bleibt bei ~180 ns auch für 10 MB — **aber** deep-equal hat keinen Buffer-Input-Pfad, weil Object-Identity nicht aus Bytes rekonstruierbar ist (Referenz-Zyklen, Shared-Refs, NaN-Semantik, Typed-Arrays, Map/Set).
+- Floor: 109 ns/call.
+- `sumArray(Vec<u32>)` (closest proxy for property marshalling): 43 ns per element.
+- `echoBuffer` stays at ~180 ns even for 10 MB — **but** deep-equal has no buffer-input path, because object identity cannot be reconstructed from bytes (reference cycles, shared refs, NaN semantics, typed arrays, Map/Set).
 
-## Phase-C optimization checklist
+## Phase C optimization checklist
 
 | # | Lever | Applicable | Notes |
 |---|---|---|---|
-| C.1 | Input-type minimization (`String` → `&str`, `Vec<T>` → `&[T]`, Buffer-overload) | ❌ nicht anwendbar | `Value` ist bereits der schlankste JSON-Input-Typ. Buffer-Overload würde bedeuten, JS müsste vor dem Call canonical-serialisieren — das kostet allein schon mehr als fast-deep-equal komplett. |
-| C.2 | Output-type minimization (`String` → `&str`, `Vec<T>` → Buffer) | ❌ nicht anwendbar | Output ist `bool`, nicht optimierbar. |
-| C.3 | Batch API | ❌ nicht anwendbar | Real-World-Callers rufen eine Pair pro Memo-/Selector-Tick. `deepEqualMany(pairs)` würde nur die (fehlenden) Callsites für einen synthetischen Gewinn bauen. |
-| C.4 | Stateful API (reusable setup via NAPI class) | ❌ nicht anwendbar | Es gibt keinen wiederverwendbaren Setup-Schritt zwischen zwei ad-hoc-Values. Eine "Canonicalize-Once, Compare-Many"-API wäre ein anderes Produkt (Hashing/Fingerprint) und löst das semantische Problem nicht — NaN, RegExp, Map/Set sind nicht kanonisierbar. |
-| C.5 | Parallelization (rayon über große Inputs) | ❌ nicht anwendbar | Der 10k-Array-Bench zeigt: beide Implementierungen sind bei ~240 ops/s. Bottleneck ist **Marshalling**, nicht Compare. Rayon parallelisiert den Compare — die Marshalling-Phase läuft davor und seriell. Null Gewinn. |
-| C.6 | Algorithm swap (SIMD / Streaming / schnellerer Crate) | ❌ nicht anwendbar | Der Algorithmus ist schon trivial-optimal (O(n), ein Pass, Early-Exit bei Mismatch). Es gibt keine schnellere strukturelle Gleichheit — V8 JIT-Code schlägt generierte Rust-Compares auf dem Objektgraph, weil er die Indirection über NAPI nicht hat. |
-| C.7 | Allocator tuning (arena, caller-provided output buffer) | ❌ nicht anwendbar | `serde_json::Value` allokiert selbst nicht hot-path-relevant — die Kosten sitzen im NAPI-Bridge-Code, der außerhalb unserer Kontrolle liegt. |
-| C.8 | Bundle-size (LTO, features, panic=abort, strip) | ❌ nicht anwendbar | Der Workspace hat diese Flags bereits gesetzt. Und Bundle-Size ist hier nicht der Grund für das Red. |
+| C.1 | Input-type minimization (`String` → `&str`, `Vec<T>` → `&[T]`, buffer overload) | ❌ not applicable | `Value` is already the leanest JSON input type. A buffer overload would mean JS would have to canonical-serialize before the call — that alone costs more than fast-deep-equal in total. |
+| C.2 | Output-type minimization (`String` → `&str`, `Vec<T>` → Buffer) | ❌ not applicable | Output is `bool`, not optimizable. |
+| C.3 | Batch API | ❌ not applicable | Real-world callers invoke one pair per memo/selector tick. `deepEqualMany(pairs)` would only build the (missing) callsites for a synthetic gain. |
+| C.4 | Stateful API (reusable setup via NAPI class) | ❌ not applicable | There's no reusable setup step between two ad-hoc values. A "canonicalize-once, compare-many" API would be a different product (hashing/fingerprint) and doesn't solve the semantic problem — NaN, RegExp, Map/Set are not canonicalizable. |
+| C.5 | Parallelization (rayon over large inputs) | ❌ not applicable | The 10k array bench shows: both implementations are at ~240 ops/s. The bottleneck is **marshalling**, not compare. Rayon parallelizes the compare — the marshalling phase runs before it and serially. Zero gain. |
+| C.6 | Algorithm swap (SIMD / streaming / faster crate) | ❌ not applicable | The algorithm is already trivially optimal (O(n), one pass, early-exit on mismatch). There is no faster structural equality — V8 JIT code beats generated Rust compares over an object graph because it doesn't have the NAPI indirection. |
+| C.7 | Allocator tuning (arena, caller-provided output buffer) | ❌ not applicable | `serde_json::Value` doesn't allocate in a hot-path-relevant way — the cost sits in the NAPI bridge code, which is outside our control. |
+| C.8 | Bundle size (LTO, features, panic=abort, strip) | ❌ not applicable | The workspace already has those flags set. And bundle size is not the reason for Red here. |
 
-**Null aus acht** — das ist das Signal. Wenn die komplette Hebel-Liste nicht-anwendbar ist, ist nicht die Implementierung das Problem, sondern die Passform des Packages.
+**Zero out of eight** — that's the signal. When the full lever list is non-applicable, the implementation isn't the problem, the package's fit is.
 
 ## Action plan
 
-**Plan: Deprecation weiterführen, nicht revidieren.**
+**Plan: continue deprecation, don't revise.**
 
-1. **Keine Optimization-Sprint-Investition.** Die Phase-C-Analyse bestätigt: es gibt keinen realistischen Hebel. Jede investierte Stunde landet in dem einen Fenster, das der FFI-Floor ohnehin schließt.
-2. **Deprecation-Schedule unverändert lassen:**
-   - 0.2.0 (shipped): `deprecated`-Field in `package.json`, README-Warning, `MIGRATION.md` verweist auf `fast-deep-equal` und `fast-deep-equal/es6`. ✅ erledigt.
-   - Fenster bis ~2026-07 offenhalten, damit Caller migrieren können.
-   - Danach: Move nach `archived/deep-equal/`, CI skippt den Crate.
-3. **`docs/packages.json`-Einträge ziehen.** Die "up to 1,3× faster"-Zahl ist irreführend — sie gehört zum JS-Wrapper, nicht zum Rust-Crate. Empfehlung: beim Archive-Move den Eintrag aus der Registry entfernen, damit er nicht in die Marketing-Sektion der Landing-Page rutscht. (Skill schreibt das hier nur auf — Edit liegt beim User.)
-4. **Post-Mortem als Lerneintrag lassen.** `docs/post-mortems/deep-equal.md` ist gut und wird als negatives Referenzmuster ("FFI-Trap-Shape: tiny-work-per-call, property-walking APIs") für künftige Candidate-Reviews weiter zitiert.
+1. **No optimization-sprint investment.** The Phase C analysis confirms: there is no realistic lever. Every hour invested lands in the one window the FFI floor already closes.
+2. **Leave the deprecation schedule unchanged:**
+   - 0.2.0 (shipped): `deprecated` field in `package.json`, README warning, `MIGRATION.md` points to `fast-deep-equal` and `fast-deep-equal/es6`. ✅ done.
+   - Keep the window open until ~2026-07 so callers can migrate.
+   - Then: move to `archived/deep-equal/`, CI skips the crate.
+3. **Drop the `docs/packages.json` entries.** The "up to 1.3× faster" number is misleading — it belongs to the JS wrapper, not the Rust crate. Recommendation: remove the entry from the registry at the archive move, so it doesn't slip into the marketing section of the landing page. (The skill only writes this down here — the edit is up to the user.)
+4. **Keep the post-mortem as a learning entry.** `docs/post-mortems/deep-equal.md` is good and keeps being cited as a negative reference pattern ("FFI trap shape: tiny-work-per-call, property-walking APIs") for future candidate reviews.
 
-**Was wir nicht tun sollten:** den Crate nochmal öffnen, um `deepEqualJson` einen anderen Algorithmus zu verpassen. Die Frage ist beantwortet — nicht der Algorithmus ist zu langsam, die Aufrufform ist falsch.
+**What we shouldn't do:** open the crate again to give `deepEqualJson` a different algorithm. The question is answered — the algorithm isn't too slow, the call shape is wrong.
 
 ## References
 
@@ -86,7 +86,7 @@ Nicht der Bottleneck. `wrapper.js` lädt den nativen Binary lazy, aber der kompl
 - Bench: `crates/deep-equal/__bench__/index.bench.ts`
 - Lib: `crates/deep-equal/src/lib.rs`
 - Cargo: `crates/deep-equal/Cargo.toml`
-- Wrapper: `crates/deep-equal/wrapper.js` (Default-Export = pure JS!)
-- Post-Mortem: `docs/post-mortems/deep-equal.md`
-- FFI-Baseline: `docs/BASELINE.md`
-- `docs/packages.json` speedup field: `"up to 1.3× faster"` (Achtung: misst den JS-Wrapper, nicht den Rust-Crate)
+- Wrapper: `crates/deep-equal/wrapper.js` (default export = pure JS!)
+- Post-mortem: `docs/post-mortems/deep-equal.md`
+- FFI baseline: `docs/BASELINE.md`
+- `docs/packages.json` speedup field: `"up to 1.3× faster"` (note: measures the JS wrapper, not the Rust crate)

--- a/docs/perf-review/dotenv.md
+++ b/docs/perf-review/dotenv.md
@@ -4,45 +4,45 @@
 
 ## Verdict
 
-Parser ist ~50 Zeilen JS, einmaliger Call beim Prozessstart. FFI-Floor > Parse-Zeit für typische `.env`-Dateien (<1 KB). Kein Batch, kein State, kein Win.
+The parser is ~50 lines of JS, called once at process start. FFI floor > parse time for typical `.env` files (<1 KB). No batch, no state, no win.
 
 ## JS package
 
 - **npm:** `dotenv`
-- **Downloads:** ~91M/Woche
+- **Downloads:** ~91M/week
 - **Exports / API surface:** `config({ path, encoding, debug, override })`, `parse(src)`, `populate`
-- **Typical input:** `.env`-Datei, typisch 10 Zeilen / 200 B, maximal ein paar KB
+- **Typical input:** `.env` file, typically 10 lines / 200 B, at most a few KB
 - **Typical output:** `{ parsed: { KEY: value, … } }`
-- **Realistic median use-case:** **Einmal** beim Prozessstart — nicht in der Hot-Path
+- **Realistic median use-case:** **once** at process start — not on the hot path
 
 ## Rust replacement
 
 - **Candidate crate(s):** `dotenvy` (fork), `dotenv`
-- **Maintenance / license:** `dotenvy` aktiv, MIT
-- **Known gotchas / divergences:** Quoting-Semantik (`"foo\nbar"` vs. `'foo\nbar'`), Variable-Expansion (`$OTHER`), Multiline-Values (seit `dotenv@16`) — leichte Abweichungen möglich
+- **Maintenance / license:** `dotenvy` active, MIT
+- **Known gotchas / divergences:** quoting semantics (`"foo\nbar"` vs. `'foo\nbar'`), variable expansion (`$OTHER`), multiline values (since `dotenv@16`) — minor deviations possible
 
 ## BACKLOG check
 
-BACKLOG: *FFI overhead > gain* — bestätigt.
+BACKLOG: *FFI overhead > gain* — confirmed.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | 200 B Parse ~5 µs in JS (regex-ähnlich) |
-| Input size distribution | Typisch <1 KB |
-| Output size distribution | Kleines Object mit 5–30 Feldern — Object-Materialisierung ist hier der größte Posten |
-| Reusable setup (stateful potential) | Null |
-| Batch-usage realism | Null — `.env` wird einmal geladen |
-| FFI-share estimate vs. Rust work | >80%: einmaliger Call bei Start, fs-Read dominiert ohnehin |
+| Per-call algorithmic work | 200 B parse ~5 µs in JS (regex-like) |
+| Input size distribution | Typically <1 KB |
+| Output size distribution | Small object with 5–30 fields — object materialization is the largest item here |
+| Reusable setup (stateful potential) | Zero |
+| Batch-usage realism | Zero — `.env` is loaded once |
+| FFI-share estimate vs. Rust work | >80%: one call at startup, fs read already dominates |
 
 ## Classification reasoning
 
-Zwei Gründe, warum das selbst bei Rust-2×-Parse-Speedup nicht lohnt:
-1. **Frequenz**: `dotenv.config()` wird einmal gerufen, vor allen Requests. Selbst 10× schneller = 50 µs statt 500 µs → irrelevant im Prozess-Startup-Budget.
-2. **Output-Shape**: Object mit N Feldern via `get_named_property`/`set_named_property` = N FFI-Kreuzungen, dominiert die Rust-Arbeit (siehe `deep-equal`-Post-Mortem).
+Two reasons why, even at a 2× Rust parse speedup, this doesn't pay off:
+1. **Frequency**: `dotenv.config()` is called once, before all requests. Even 10× faster = 50 µs instead of 500 µs → irrelevant in the process-startup budget.
+2. **Output shape**: object with N fields via `get_named_property`/`set_named_property` = N FFI crossings, dominates the Rust work (see the `deep-equal` post-mortem).
 
-Keine Batch-API möglich (es gibt nur eine `.env`). Keine Stateful-API sinnvoll. Kein Hot-Path.
+No batch API possible (there is only one `.env`). No stateful API makes sense. No hot path.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/ejs.md
+++ b/docs/perf-review/ejs.md
@@ -4,43 +4,43 @@
 
 ## Verdict
 
-`ejs` ist "JavaScript in Templates": `<% if (user.admin) { %>…<% } %>` — Template-Code ist echter JS-Code, zur Render-Zeit ausgeführt. Ohne eingebettete JS-Engine (QuickJS/Boa) nicht portierbar, und die Engine-Integration würde den Win sofort vernichten.
+`ejs` is "JavaScript in templates": `<% if (user.admin) { %>…<% } %>` — template code is real JS code, executed at render time. Not portable without an embedded JS engine (QuickJS/Boa), and the engine integration would immediately wipe out the win.
 
 ## JS package
 
 - **npm:** `ejs`
-- **Downloads:** ~39M/Woche
-- **Exports / API surface:** `render(template, data, opts)`, `compile`, `renderFile`, `Template`-Class, Custom-Delimiters, Includes
-- **Typical input:** Template-String mit eingebettetem JS + Data-Object
-- **Typical output:** HTML-String
-- **Realistic median use-case:** Express-View-Rendering, 10–50 KB HTML-Output
+- **Downloads:** ~39M/week
+- **Exports / API surface:** `render(template, data, opts)`, `compile`, `renderFile`, `Template` class, custom delimiters, includes
+- **Typical input:** template string with embedded JS + data object
+- **Typical output:** HTML string
+- **Realistic median use-case:** Express view rendering, 10–50 KB HTML output
 
 ## Rust replacement
 
-- **Candidate crate(s):** keine, die JS-Expressions ausführen. `tera`, `askama`, `minijinja` haben eigene DSL, nicht JS
+- **Candidate crate(s):** none that execute JS expressions. `tera`, `askama`, `minijinja` have their own DSL, not JS
 - **Maintenance / license:** n/a
-- **Known gotchas / divergences:** ejs-Syntax ist nicht adaptierbar — Jede non-trivial Template nutzt `<%= someJsFunction() %>` oder `<% items.forEach(…) %>`
+- **Known gotchas / divergences:** ejs syntax is not adaptable — every non-trivial template uses `<%= someJsFunction() %>` or `<% items.forEach(…) %>`
 
 ## BACKLOG check
 
-BACKLOG: *Needs a JS engine* — bestätigt, Black-Klassifikation (nicht nur NO-GO — strukturell unmöglich).
+BACKLOG: *Needs a JS engine* — confirmed, Black classification (not just NO-GO — structurally impossible).
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Template-Compile ist trivial; **alle** Kosten liegen im JS-Expression-Eval zur Render-Zeit |
+| Per-call algorithmic work | Template compile is trivial; **all** cost is in JS expression eval at render time |
 | Input size distribution | Template 1–10 KB |
 | Output size distribution | HTML 10–100 KB |
-| Reusable setup (stateful potential) | Compiled Template Object — aber ohne JS-Eval wertlos |
+| Reusable setup (stateful potential) | Compiled template object — but worthless without JS eval |
 | Batch-usage realism | n/a |
-| FFI-share estimate vs. Rust work | 100% — entweder QuickJS embedden (massiver Bundle-Bloat, ~1 MB+, eigene GC) oder Callbacks pro Expression nach V8 zurück (`handlebars`-Shape × 100) |
+| FFI-share estimate vs. Rust work | 100% — either embed QuickJS (massive bundle bloat, ~1 MB+, its own GC) or callbacks per expression back to V8 (`handlebars` shape × 100) |
 
 ## Classification reasoning
 
-Zwei strukturell tödliche Optionen:
-1. **Callbacks für jede `<%= … %>`**: Wenn Rust parst und V8 eval'd, muss Rust für jeden Expression-Block einen Callback in JS auslösen. Bei 50 `<%= foo %>` in einem Template = 50 × 2 µs FFI = 100 µs zusätzlich, während JS-Baseline vielleicht 300 µs braucht. 33% Overhead minimum, vor jedem Rust-Work.
-2. **Embed QuickJS/Boa in Rust**: Ein zweiter JS-Interpreter neben V8. QuickJS ist ~500 KB Bundle, Boa ist reiner Interpreter (kein JIT), beide 5–20× langsamer als V8 für typischen JS-Code. Der "Rust-Gewinn" wäre also: "langsamere JS-Engine statt V8". Keine reale Nutzerbase würde das akzeptieren.
+Two structurally fatal options:
+1. **Callbacks for every `<%= … %>`**: if Rust parses and V8 evals, Rust has to fire a callback into JS for every expression block. At 50 `<%= foo %>` in a template = 50 × 2 µs FFI = 100 µs extra, while the JS baseline maybe needs 300 µs. 33% overhead minimum, before any Rust work.
+2. **Embed QuickJS/Boa in Rust**: a second JS interpreter alongside V8. QuickJS is ~500 KB bundle, Boa is a pure interpreter (no JIT), both 5–20× slower than V8 for typical JS code. So the "Rust win" would be: "a slower JS engine instead of V8". No real user base would accept that.
 
 Permanent Black.
 

--- a/docs/perf-review/gpt-tokenizer.md
+++ b/docs/perf-review/gpt-tokenizer.md
@@ -1,78 +1,78 @@
 # Candidate review: `gpt-tokenizer`
 
-> **Status:** SHIPPED als Sub-Surface von `@amigo-labs/tiktoken`, aber **NO-GO als Konkurrenz** · **Predicted:** 🟢 Green · **Measured:** 🔴 Red (gpt-tokenizer ist 2–3× schneller als wir) · **Reviewed:** 2026-04-19
+> **Status:** SHIPPED as sub-surface of `@amigo-labs/tiktoken`, but **NO-GO as a competitor** · **Predicted:** 🟢 Green · **Measured:** 🔴 Red (gpt-tokenizer is 2–3× faster than us) · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-`gpt-tokenizer` ist ein pure-JS-Port desselben BPE-Algorithmus (cl100k_base / o200k_base / o200k_harmony) mit erweiterter API: chat-spezifische Token-Zählung, `isWithinTokenLimit`, Generator-Streaming, Cost-Estimation. Der algorithmische Kern deckt sich zu 100 % mit `tiktoken`/`js-tiktoken`, die FFI-Shape ist identisch — aber gegen eine pure-JS-Baseline ist der Speedup strukturell *größer* als bei `tiktoken` (WASM), weil wir nicht gegen einen ebenso nativen Kern antreten. **Empfehlung: keine separate Crate, sondern die gpt-tokenizer-Extras (`encodeChat`, `isWithinTokenLimit`, `countChatCompletionTokens`) in `@amigo-labs/tiktoken` mit aufnehmen.** Zweite Crate wäre Doppel-Maintenance ohne Mehrwert.
+`gpt-tokenizer` is a pure-JS port of the same BPE algorithm (cl100k_base / o200k_base / o200k_harmony) with an extended API: chat-specific token counting, `isWithinTokenLimit`, generator streaming, cost estimation. The algorithmic core is 100% the same as `tiktoken`/`js-tiktoken`, the FFI shape is identical — but against a pure-JS baseline the speedup is structurally *larger* than against `tiktoken` (WASM), because we're not competing against an equally native core. **Recommendation: no separate crate, instead fold the gpt-tokenizer extras (`encodeChat`, `isWithinTokenLimit`, `countChatCompletionTokens`) into `@amigo-labs/tiktoken`.** A second crate would be double maintenance with no added value.
 
 ## JS package
 
-- **npm:** `gpt-tokenizer` (Autor: Bazyli Brzóska, niieani) — "the fastest, smallest and lowest footprint GPT tokenizer" (Eigenaussage)
-- **Downloads:** ~1 M weekly (Q1 2026 Schätzung, BACKLOG)
+- **npm:** `gpt-tokenizer` (author: Bazyli Brzóska, niieani) — "the fastest, smallest and lowest footprint GPT tokenizer" (self-described)
+- **Downloads:** ~1M weekly (Q1 2026 estimate, BACKLOG)
 - **Exports / API surface:**
-  - `encode(text)` / `decode(tokens)` — Kern, identisch zu tiktoken
-  - `encodeChat(messages, model)` — ChatML/Harmony-Overhead-Kalkulation
-  - `countTokens(text)` / `countChatCompletionTokens(messages, model)` — zählen ohne Array-Alloc
-  - `isWithinTokenLimit(text, limit)` — **Early-Exit-Version** von encode, stoppt wenn Limit überschritten
-  - `encodeGenerator` / `decodeGenerator` / `decodeAsyncGenerator` — Streaming via Generators
-  - `estimateCost(text, model)` — Pricing-Daten für 100+ Modelle eingebaut
-  - LRU-Merge-Cache intern (Performance-Optimierung)
-- **Typical input:** Identisch zu tiktoken — UTF-8-Text oder `ChatMessage[]`
-- **Typical output:** `number[]` Token-Arrays, oder Boolean für `isWithinTokenLimit`, oder Generator-Iteration
-- **Realistic median use-case:** **Chat-App-Cost-Control.** Vor jedem OpenAI-API-Call wird `countChatCompletionTokens(messages, "gpt-4o")` aufgerufen um Input-Kosten zu schätzen und Kontextfenster zu prüfen. Input: 5-50 Messages à ~200 Token = ~5-50 KB Text. Call-Frequenz: 1 pro User-Turn
+  - `encode(text)` / `decode(tokens)` — core, identical to tiktoken
+  - `encodeChat(messages, model)` — ChatML/Harmony overhead calculation
+  - `countTokens(text)` / `countChatCompletionTokens(messages, model)` — count without array alloc
+  - `isWithinTokenLimit(text, limit)` — **early-exit version** of encode, stops when the limit is exceeded
+  - `encodeGenerator` / `decodeGenerator` / `decodeAsyncGenerator` — streaming via generators
+  - `estimateCost(text, model)` — pricing data for 100+ models built in
+  - LRU merge cache internally (performance optimization)
+- **Typical input:** identical to tiktoken — UTF-8 text or `ChatMessage[]`
+- **Typical output:** `number[]` token arrays, or boolean for `isWithinTokenLimit`, or generator iteration
+- **Realistic median use-case:** **chat-app cost control.** Before every OpenAI API call, `countChatCompletionTokens(messages, "gpt-4o")` is called to estimate input cost and check the context window. Input: 5–50 messages at ~200 tokens = ~5–50 KB text. Call frequency: 1 per user turn
 
 ## Rust replacement
 
-- **Candidate crate(s):** `tiktoken-rs 0.11.0` — **derselbe Backend wie für tiktoken**. Chat-Overhead-Rules, Pricing-Data und Early-Exit wären Wrapper-Code in `@amigo-labs/tiktoken`
-- **Maintenance / license:** Aktiv (2026-04-08), MIT, siehe `tiktoken.md` für Details
+- **Candidate crate(s):** `tiktoken-rs 0.11.0` — **same backend as for tiktoken**. Chat-overhead rules, pricing data and early-exit would be wrapper code inside `@amigo-labs/tiktoken`
+- **Maintenance / license:** active (2026-04-08), MIT, see `tiktoken.md` for details
 - **Known gotchas / divergences:**
-  - Chat-Overhead-Rules sind **je Model** verschieden: gpt-3.5-turbo = 4 Token/msg + 2/reply, gpt-4 = 3+3, gpt-4o = Harmony-Format. Muss in Rust als Lookup-Tabelle ausgedrückt werden (wie gpt-tokenizer's `mappings.ts`). Parität über Tests pflichtig
-  - `isWithinTokenLimit` als echte Early-Exit-Variante im Rust-Encoder implementieren (tiktoken-rs bietet das nicht direkt — eigener Wrapper mit `encode_with_limit(text, limit)` nötig)
-  - Generator-APIs (`encodeGenerator`) sind in NAPI aufwendiger. Vorschlag: **nicht portieren.** User fällt auf pure-JS-Generator über Chunks zurück, oder wir bieten `encodeMany(chunks)` stattdessen
-  - `estimateCost` = Pricing-Lookup + Token-Count. Pricing-Daten driften (OpenAI ändert Preise). **Nicht in Rust.** User-side JS-Multiplikator auf `countTokens()`-Output
+  - Chat-overhead rules differ **per model**: gpt-3.5-turbo = 4 tokens/msg + 2/reply, gpt-4 = 3+3, gpt-4o = Harmony format. Has to be expressed as a lookup table in Rust (like gpt-tokenizer's `mappings.ts`). Parity tests required
+  - Implement `isWithinTokenLimit` as a genuine early-exit variant in the Rust encoder (tiktoken-rs doesn't offer that directly — own wrapper with `encode_with_limit(text, limit)` needed)
+  - Generator APIs (`encodeGenerator`) are more expensive in NAPI. Proposal: **do not port.** The user falls back to a pure-JS generator over chunks, or we offer `encodeMany(chunks)` instead
+  - `estimateCost` = pricing lookup + token count. Pricing data drifts (OpenAI changes prices). **Not in Rust.** User-side JS multiplier on `countTokens()` output
 
 ## BACKLOG check
 
 > **gpt-tokenizer** (~1M). Same `tiktoken-rs` backend, different JS API surface. Near-free second port once `tiktoken` ships.
 
-**Korrektur der Backlog-Annahme:** "Second port" ist irreführend. Es gibt *kein* zweites Crate, das Sinn ergibt — der gleiche `tiktoken-rs`-Wrapper mit erweiterter Surface bedient beide npm-Pakete. User sehen bei beiden dasselbe `@amigo-labs/tiktoken`-Paket als Drop-in.
+**Correction to the backlog assumption:** "second port" is misleading. There is *no* second crate that makes sense — the same `tiktoken-rs` wrapper with an extended surface serves both npm packages. Users see the same `@amigo-labs/tiktoken` package as a drop-in for both.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Identisch zu `tiktoken.md` Bucket-wise. **Bonus:** `isWithinTokenLimit` bei kurzen Strings exitet früh → noch günstigerer Compute, FFI-Share steigt |
-| Input size distribution | Chat-Use-Case: 5-50 Messages, 5-50 KB Gesamt-Text. Günstiges Medium-Regime, FFI-Share < 1 % |
-| Output size distribution | `countTokens()` returned `number` — billigste Shape, ~180 ns Marshal. `encodeChat` returned `Uint32Array` + Overhead-Zahl — Struct-Marshalling, ~500 ns |
-| Reusable setup (stateful potential) | Gleich wie tiktoken — NAPI-Class pflicht. Zusätzlich: Chat-Overhead-Rules und Model-Mapping sind konstant, liegen im Class-Constructor |
-| Batch-usage realism | `encodeChat` *ist* bereits ein impliziter Batch (N Messages pro Call). Plus Standard-`encodeMany` aus tiktoken. Zwei Batch-Shapes abgedeckt |
-| FFI-share estimate vs. Rust work | <1 % bei Chat-Use-Case. Für `isWithinTokenLimit` mit kurzen Strings + niedriger Limit evtl. 5-10 % (Early-Exit macht Compute winzig) |
+| Per-call algorithmic work | Identical to `tiktoken.md` bucket-wise. **Bonus:** `isWithinTokenLimit` exits early on short strings → even cheaper compute, FFI share rises |
+| Input size distribution | Chat use-case: 5–50 messages, 5–50 KB total text. Favorable medium regime, FFI share < 1% |
+| Output size distribution | `countTokens()` returns `number` — cheapest shape, ~180 ns marshal. `encodeChat` returns `Uint32Array` + an overhead number — struct marshalling, ~500 ns |
+| Reusable setup (stateful potential) | Same as tiktoken — NAPI class mandatory. In addition: chat-overhead rules and model mapping are constant, live in the class constructor |
+| Batch-usage realism | `encodeChat` *is* already an implicit batch (N messages per call). Plus the standard `encodeMany` from tiktoken. Two batch shapes covered |
+| FFI-share estimate vs. Rust work | <1% for the chat use-case. For `isWithinTokenLimit` with short strings + low limit perhaps 5–10% (early-exit makes compute tiny) |
 
 ## Classification reasoning
 
-`gpt-tokenizer` ist **pure JavaScript** — das ist der entscheidende Unterschied zu `tiktoken` (WASM). Die externe Bench-Referenz für pure-JS (`js-tiktoken`, algorithmisch fast identisch) gibt:
+`gpt-tokenizer` is **pure JavaScript** — that's the decisive difference from `tiktoken` (WASM). The external bench reference for pure JS (`js-tiktoken`, algorithmically almost identical) gives:
 
-- 1 MB: 1006 ms pure-JS vs. 359 ms tiktoken-rs → **2,80×** Rust-Speedup — **klares Green**
-- Medium: 0,96 ms vs. 0,54 ms → **1,78×** — knapp unter Green-Gate, vermutlich 2× mit sauberer napi-rs-Integration
+- 1 MB: 1006 ms pure JS vs. 359 ms tiktoken-rs → **2.80×** Rust speedup — **clear Green**
+- Medium: 0.96 ms vs. 0.54 ms → **1.78×** — just below the Green gate, probably 2× with clean napi-rs integration
 
-gpt-tokenizer's LRU-Merge-Cache ist eine micro-opt; sie schließt die Lücke zu tiktoken-rs nicht (beide nutzen HashMaps, Rust's Code ist einfach CPU-cache-freundlicher ohne V8-Objekt-Indirections).
+gpt-tokenizer's LRU merge cache is a micro-opt; it doesn't close the gap to tiktoken-rs (both use HashMaps, Rust's code is simply more CPU-cache-friendly without V8 object indirections).
 
-**Algorithmisches Profil:**
-- **Wie** `sanitize-html`/`csv`: substanzielle Per-Call-Compute, string-in, typed-output, State-als-Class
-- **Nicht** wie `levenshtein`: kein String-Distance-Hot-Loop auf 10-Char-Strings (pure-JS-Tokenizer läuft ~1 µs auf 10-Char, NAPI ~1-2 µs — verlieren aber nicht katastrophal)
-- **Wie** `xxhash-batch`: Wenn Output-API naiv als `number[]` implementiert wird, kippt es. **Strict `Uint32Array`.**
+**Algorithmic profile:**
+- **Like** `sanitize-html`/`csv`: substantial per-call compute, string-in, typed output, state-as-class
+- **Not** like `levenshtein`: no string-distance hot loop on 10-char strings (pure-JS tokenizer runs ~1 µs on 10 chars, NAPI ~1–2 µs — we don't lose catastrophically)
+- **Like** `xxhash-batch`: if the output API is implemented naively as `number[]` it tips. **Strict `Uint32Array`.**
 
-**Small-Input-Fall:** Für `isWithinTokenLimit("hi", 100)` — 2-Byte-String, Limit 100, sofortiger Early-Exit → pure-JS macht das in ~500 ns. Rust via NAPI ~400-600 ns. Parität, kein Gewinn und kein Verlust. **Akzeptabel für Yellow-Floor**, kein Red.
+**Small-input case:** for `isWithinTokenLimit("hi", 100)` — 2-byte string, limit 100, immediate early-exit → pure JS does it in ~500 ns. Rust via NAPI ~400–600 ns. Parity, no win and no loss. **Acceptable as a Yellow floor**, not Red.
 
-**Generator-Streaming-Gap:** Die `encodeGenerator`/`decodeAsyncGenerator`-Surface von gpt-tokenizer hat keine direkte Rust-Entsprechung. User der das *wirklich* braucht (selten — meist wird einfach auf chunked Array gewechselt) bleibt bei pure-JS oder wir dokumentieren Migration zu `encodeMany(chunks)`. **Nicht als Blocker behandeln.**
+**Generator-streaming gap:** the `encodeGenerator`/`decodeAsyncGenerator` surface of gpt-tokenizer has no direct Rust equivalent. Users who *really* need it (rare — usually people just switch to a chunked array) stay on pure JS, or we document migration to `encodeMany(chunks)`. **Do not treat as a blocker.**
 
 ## If GO — proposed port
 
-**Keine separate Crate.** Extras in `@amigo-labs/tiktoken` aufnehmen als API-Erweiterung.
+**No separate crate.** Fold the extras into `@amigo-labs/tiktoken` as an API extension.
 
-- **Recommended crate-name:** `@amigo-labs/tiktoken` (gleiches Crate wie `tiktoken.md`)
-- **Primary API sketch — Erweiterung zur tiktoken-Class:**
+- **Recommended crate name:** `@amigo-labs/tiktoken` (same crate as `tiktoken.md`)
+- **Primary API sketch — extension of the tiktoken class:**
   ```ts
   export interface ChatMessage {
     role: 'system' | 'user' | 'assistant' | 'tool'
@@ -82,79 +82,79 @@ gpt-tokenizer's LRU-Merge-Cache ist eine micro-opt; sie schließt die Lücke zu 
 
   export interface ChatEncodeResult {
     tokens: Uint32Array
-    overhead: number  // ChatML/Harmony message-framing-Tokens
+    overhead: number  // ChatML/Harmony message-framing tokens
   }
 
   export declare class Tiktoken {
-    // ... aus tiktoken.md ...
+    // ... from tiktoken.md ...
 
-    // gpt-tokenizer-Surface:
+    // gpt-tokenizer surface:
     encodeChat(messages: ChatMessage[], model: string): ChatEncodeResult
     countChatCompletionTokens(messages: ChatMessage[], model: string): number
     isWithinTokenLimit(text: string, limit: number): boolean
-    // Bewusst nicht portiert: encodeGenerator, decodeAsyncGenerator, estimateCost
+    // Intentionally not ported: encodeGenerator, decodeAsyncGenerator, estimateCost
   }
   ```
-  → `estimateCost` in JS-Land ausgelagert: User multipliziert `countTokens()` × eigene Pricing-Tabelle. Rust-Crate soll keine ratenkonstanten Pricing-Daten bundeln (drift, Breaking-Changes)
-  → Generator-APIs explizit dokumentiert als *not ported* mit Migration zu `encodeMany(chunks)`
+  → `estimateCost` moved into JS land: the user multiplies `countTokens()` × their own pricing table. The Rust crate should not bundle rate-changing pricing data (drift, breaking changes)
+  → Generator APIs explicitly documented as *not ported* with migration to `encodeMany(chunks)`
 
 - **Must-have benchmark scenarios:**
-  - Alle aus `tiktoken.md` gelten
-  - **Neu:** `countChatCompletionTokens(10 messages, "gpt-4o")` — Median-Use-Case von gpt-tokenizer
-  - **Neu:** `isWithinTokenLimit(short_text, 100)` — Early-Exit-Fast-Path, Floor-Check
-  - **Neu:** `isWithinTokenLimit(long_text, 100)` — Early-Exit nach N Tokens, messen dass wir tatsächlich früh exiten (nicht full-encode)
-  - **Baseline:** **Beide** gpt-tokenizer (pure-JS) **und** tiktoken (WASM) als Vergleiche. js-tiktoken optional da algorithmisch nahezu identisch zu gpt-tokenizer
+  - All from `tiktoken.md` apply
+  - **New:** `countChatCompletionTokens(10 messages, "gpt-4o")` — median use-case of gpt-tokenizer
+  - **New:** `isWithinTokenLimit(short_text, 100)` — early-exit fast path, floor check
+  - **New:** `isWithinTokenLimit(long_text, 100)` — early-exit after N tokens, verify we actually exit early (no full encode)
+  - **Baseline:** **Both** gpt-tokenizer (pure JS) **and** tiktoken (WASM) as comparators. js-tiktoken optional since algorithmically nearly identical to gpt-tokenizer
 
 - **Acceptance thresholds (Green gate):**
-  - ≥2,0× vs. `gpt-tokenizer` bei Medium (Chat-Use-Case) und Large — Hauptzielbaseline
-  - ≥1,0× vs. `gpt-tokenizer` bei Small (`isWithinTokenLimit` short-circuit) — Floor-Check
-  - ≥0,95× vs. `gpt-tokenizer` bei Early-Exit-Fall — darf minimal verlieren weil pure-JS's frühe Heuristik (char-count) trivial ist
-  - 100 % Parity: `encodeChat` gegen gpt-tokenizer Fixture-Test (gpt-3.5-turbo, gpt-4, gpt-4o, gpt-5) für Overhead-Zahlen
-  - Cross-Verify: Token-Sequenzen bit-identisch zu `gpt-tokenizer` auf 1000 Random-Chat-Conversations
+  - ≥2.0× vs. `gpt-tokenizer` at medium (chat use-case) and large — main target baseline
+  - ≥1.0× vs. `gpt-tokenizer` at small (`isWithinTokenLimit` short-circuit) — floor check
+  - ≥0.95× vs. `gpt-tokenizer` at the early-exit case — may lose marginally because pure JS's early heuristic (char count) is trivial
+  - 100% parity: `encodeChat` against gpt-tokenizer fixture tests (gpt-3.5-turbo, gpt-4, gpt-4o, gpt-5) for overhead numbers
+  - Cross-verify: token sequences bit-identical to `gpt-tokenizer` on 1000 random chat conversations
 
 - **Risks:**
-  1. **Scope-Creep ins `@amigo-labs/tiktoken` Crate.** +~300 LoC für Chat-Overhead-Rules + Model-Mapping. Akzeptabel weil der Nutzen (1 M weekly DL bedient) hoch ist — aber API-Surface wird breit. Mitigation: `encodeChat` etc. in eigene Datei `src/chat.rs`, Tests getrennt
-  2. **Model-Overhead-Rules-Drift:** OpenAI addiert neue Modelle. `gpt-tokenizer` updatet seine Mappings in Minor-Releases. Wir müssen nachziehen → evtl. Quartal-Review als Standing-Task
-  3. **`isWithinTokenLimit`-Early-Exit-Implementierung:** `tiktoken-rs` hat keine native Early-Exit-API. Wir müssen den Encoder-Loop manuell mit Counter wrappen. Parität-Test pflichtig, dass wir nicht weiter tokenizen als nötig (sonst wird die Fast-Path-Behauptung falsch)
-  4. **Generator-API-Gap:** Nutzer, die auf `encodeGenerator` angewiesen sind (Streaming-LLM-Decoder-UIs), haben keinen 1:1-Pfad. Migration-Doc pflicht. Vermutlich <5 % der User — akzeptabel
-  5. **Pricing-Daten-Auslagerung:** `gpt-tokenizer`-User die `estimateCost()` nutzen müssen eigene Pricing-Logik halten. Migration-Beispiel im README: ~10 LoC. Kein Blocker
-  6. **Zwei-Wege-Positionierung:** README muss klarstellen dass das Crate sowohl `tiktoken`- als auch `gpt-tokenizer`-User bedient. Speedup-Zahlen pro Baseline ausweisen, nicht mitteln
+  1. **Scope creep into the `@amigo-labs/tiktoken` crate.** +~300 LoC for chat-overhead rules + model mapping. Acceptable because the benefit (1M weekly DL served) is high — but the API surface gets broad. Mitigation: put `encodeChat` etc. in its own file `src/chat.rs`, separate tests
+  2. **Model-overhead rules drift:** OpenAI adds new models. `gpt-tokenizer` updates its mappings in minor releases. We need to follow → possibly a quarterly review as a standing task
+  3. **`isWithinTokenLimit` early-exit implementation:** `tiktoken-rs` has no native early-exit API. We have to manually wrap the encoder loop with a counter. Parity test mandatory, that we don't tokenize further than necessary (otherwise the fast-path claim is false)
+  4. **Generator API gap:** users relying on `encodeGenerator` (streaming LLM decoder UIs) have no 1:1 path. Migration doc mandatory. Probably <5% of users — acceptable
+  5. **Pricing data outsourced:** `gpt-tokenizer` users who use `estimateCost()` have to keep their own pricing logic. Migration example in the README: ~10 LoC. No blocker
+  6. **Two-way positioning:** the README has to make clear that the crate serves both `tiktoken` and `gpt-tokenizer` users. Report speedup numbers per baseline, don't average them
 
 ## If NO-GO — BACKLOG entry
 
-N/A — GO empfohlen als API-Erweiterung von `@amigo-labs/tiktoken`, nicht als separates Crate.
+N/A — GO recommended as an API extension of `@amigo-labs/tiktoken`, not as a separate crate.
 
-## Phase-B Messung (2026-04-19, linux-x64, Node v22)
+## Phase B measurement (2026-04-19, linux-x64, Node v22)
 
-Vorhersage war falsch. `gpt-tokenizer` benutzt **nicht** dasselbe Performance-Profil wie `js-tiktoken`. Gemessen gegen `@amigo-labs/tiktoken` (gleiche Binary wie der tiktoken-Perf-Review), `cl100k_base`:
+Prediction was wrong. `gpt-tokenizer` does **not** use the same performance profile as `js-tiktoken`. Measured against `@amigo-labs/tiktoken` (same binary as the tiktoken perf review), `cl100k_base`:
 
-| Szenario | @amigo-labs/tiktoken | gpt-tokenizer | Verhältnis |
+| Scenario | @amigo-labs/tiktoken | gpt-tokenizer | Ratio |
 |---|---:|---:|---:|
-| encode 10 B (small) | 164 256 hz | **586 445 hz** | 0,28× (3,57× langsamer) |
-| encode ~2 KB (medium) | 5 999 hz | **14 855 hz** | 0,40× (2,48× langsamer) |
-| encode ~90 KB (large) | 126 hz | **269 hz** | 0,47× (2,13× langsamer) |
-| 100 × 10 B (RAG batch) | 1 471 hz | **4 364 hz** | 0,34× (2,97× langsamer) |
+| encode 10 B (small) | 164,256 hz | **586,445 hz** | 0.28× (3.57× slower) |
+| encode ~2 KB (medium) | 5,999 hz | **14,855 hz** | 0.40× (2.48× slower) |
+| encode ~90 KB (large) | 126 hz | **269 hz** | 0.47× (2.13× slower) |
+| 100 × 10 B (RAG batch) | 1,471 hz | **4,364 hz** | 0.34× (2.97× slower) |
 
-**Wir verlieren an jedem Messpunkt.** Der predicted Green (2,8× schneller) war auf Basis des `js-tiktoken`-Benchmarks geschätzt. `gpt-tokenizer` ist aber **8-9× schneller als `js-tiktoken`** — dieselbe Messung gegen `js-tiktoken` hätte uns Green gegeben.
+**We lose on every measurement point.** The predicted Green (2.8× faster) was estimated based on the `js-tiktoken` benchmark. But `gpt-tokenizer` is **8–9× faster than `js-tiktoken`** — the same measurement against `js-tiktoken` would have given us Green.
 
-**Warum gpt-tokenizer so viel schneller ist als js-tiktoken:**
-- **LRU-Merge-Cache** (explizit dokumentiertes Feature). Wiederholte Bigram-Paare innerhalb eines einzigen `encode()`-Calls werden aus Cache bedient statt neu berechnet. Bei natural-language-Texten mit redundanten Wort-Paaren ist der Hit-Rate sehr hoch.
-- **V8-optimierter Hot-Path.** gpt-tokenizer's Autor (niieani) hat den BPE-Merge-Loop bewusst für V8's JIT geschrieben: monomorphe Objekte, keine Polymorphie, stabile `Map`-Shapes.
-- **Kein FFI.** Selbst unsere 109 ns NAPI-Floor zahlt pro Call; gpt-tokenizer hat 0 ns Floor.
+**Why gpt-tokenizer is so much faster than js-tiktoken:**
+- **LRU merge cache** (explicitly documented feature). Repeated bigram pairs within a single `encode()` call are served from cache instead of recomputed. For natural-language text with redundant word pairs the hit rate is very high.
+- **V8-optimized hot path.** gpt-tokenizer's author (niieani) deliberately wrote the BPE merge loop for V8's JIT: monomorphic objects, no polymorphism, stable `Map` shapes.
+- **No FFI.** Even our 109 ns NAPI floor is paid per call; gpt-tokenizer has a 0 ns floor.
 
-**Warum unser Native-Rust nicht hilft:**
-- `tiktoken-rs` hat keinen LRU-Merge-Cache. Der BPE-Merge-Loop läuft O(n²) über die Chunks statt mit Cache-amortisiert.
-- V8's JIT ist für BPE-Lookups kompetitiv mit Rust's `rustc_hash` — die Cache-Locality-Vorteile von Rust werden durch den Cache-Miss-Penalty aufgefressen
-- Wir sind weder gegen C++-Bindings (argon2-Pattern) noch gegen Text-Processing-Spezialisten (sanitize-html-Pattern) angetreten, sondern gegen einen **handoptimierten pure-JS-Konkurrenten** mit Domain-spezifischer Caching-Strategie. Das ist ein ganz anderes Rennen.
+**Why our native Rust doesn't help:**
+- `tiktoken-rs` has no LRU merge cache. The BPE merge loop runs O(n²) over the chunks instead of cache-amortized.
+- V8's JIT is competitive with Rust's `rustc_hash` for BPE lookups — the cache-locality advantages of Rust are eaten by the cache-miss penalty
+- We're not up against C++ bindings (argon2 pattern) or text-processing specialists (sanitize-html pattern), we're up against a **hand-optimized pure-JS competitor** with a domain-specific caching strategy. That's a completely different race.
 
-**Endklassifikation: 🔴 Red gegen gpt-tokenizer** — ohne Optimierung nicht einholbar.
+**Final classification: 🔴 Red against gpt-tokenizer** — not catchable without optimization.
 
-**Was wir trotzdem shippen:**
-- `encodeChat` / `countChatCompletionTokens` / `isWithinTokenLimit` als Sub-Surface des `@amigo-labs/tiktoken`-Crates — konsistente API, aber primär für die `tiktoken` npm-User (die diese API auch vermissen) relevant, nicht als Migration für gpt-tokenizer-Nutzer
-- **README-Text:** expliziter Hinweis "nicht schneller als gpt-tokenizer" — keine falschen Versprechen
+**What we still ship:**
+- `encodeChat` / `countChatCompletionTokens` / `isWithinTokenLimit` as a sub-surface of the `@amigo-labs/tiktoken` crate — consistent API, but primarily relevant for the `tiktoken` npm users (who also miss this API), not as a migration for gpt-tokenizer users
+- **README text:** explicit note "not faster than gpt-tokenizer" — no false promises
 
-**Phase-C-Option für zukünftige Review:**
-- **C.6 Algorithm-Swap:** LRU-Merge-Cache in `tiktoken-rs` upstream einbringen (PR an zurawiki/tiktoken-rs). Realistischer 1,5-2× Gewinn, nähert uns an gpt-tokenizer an, erreicht es aber vermutlich nicht (FFI-Floor bleibt)
-- **Re-Review in 6 Monaten** falls `tiktoken-rs` Caching aufnimmt oder gpt-tokenizer strukturell langsamer wird
+**Phase-C option for a future review:**
+- **C.6 algorithm swap:** submit the LRU merge cache to `tiktoken-rs` upstream (PR to zurawiki/tiktoken-rs). Realistic 1.5–2× win, closes the gap to gpt-tokenizer, but probably doesn't reach it (FFI floor remains)
+- **Re-review in 6 months** if `tiktoken-rs` adds caching or gpt-tokenizer gets structurally slower
 
-**BACKLOG-Empfehlung:** Eintrag aus "Under investigation — Predicted Green" entfernen und in "Ported then deprecated — measured Red/Black" verlagern — Unterkategorie "konkurriert mit über-optimiertem pure-JS". Sorgt dafür dass künftige Candidate-Scans den Post-Mortem lesen bevor sie über einen eigenen gpt-tokenizer-Port nachdenken.
+**BACKLOG recommendation:** remove the entry from "Under investigation — Predicted Green" and move to "Ported then deprecated — measured Red/Black" — subcategory "competes with an over-optimized pure-JS". This ensures future candidate scans read the post-mortem before considering a separate gpt-tokenizer port.

--- a/docs/perf-review/handlebars.md
+++ b/docs/perf-review/handlebars.md
@@ -4,41 +4,41 @@
 
 ## Verdict
 
-Helper-Callbacks sind der Normalfall bei Handlebars — jeder Helper ist ein JS-Funktionsaufruf. FFI-Roundtrip pro Helper-Call (Rust → V8 → Rust) eliminiert jeden Parse/Render-Gewinn, und `handlebars-rust` hat dokumentierte Abweichungen zum JS-Original.
+Helper callbacks are the normal case with Handlebars — every helper is a JS function call. An FFI roundtrip per helper call (Rust → V8 → Rust) eliminates any parse/render win, and `handlebars-rust` has documented divergences from the JS original.
 
 ## JS package
 
 - **npm:** `handlebars`
-- **Downloads:** ~35M/Woche
-- **Exports / API surface:** `Handlebars.compile(template) → (data) => string`, `registerHelper(name, fn)`, `registerPartial`, `SafeString`, Precompilation (`handlebars` CLI)
-- **Typical input:** Template-String (einmalig kompiliert) + Context-Object pro Render
-- **Typical output:** HTML-String
-- **Realistic median use-case:** E-Mail-/HTML-Template-Rendering mit ~5–20 Helpers, Render-Output 1–50 KB
+- **Downloads:** ~35M/week
+- **Exports / API surface:** `Handlebars.compile(template) → (data) => string`, `registerHelper(name, fn)`, `registerPartial`, `SafeString`, precompilation (`handlebars` CLI)
+- **Typical input:** template string (compiled once) + context object per render
+- **Typical output:** HTML string
+- **Realistic median use-case:** email/HTML template rendering with ~5–20 helpers, render output 1–50 KB
 
 ## Rust replacement
 
 - **Candidate crate(s):** `handlebars-rust`
-- **Maintenance / license:** aktiv, MIT
-- **Known gotchas / divergences:** [dokumentiert](https://docs.rs/handlebars/latest/handlebars/#differences-with-javascript-version) — u.a. Helper-Signaturen, `{{lookup}}`-Semantik, Whitespace-Control-Edge-Cases, kein JS-Expressions-Eval innerhalb `{{#if …}}`
+- **Maintenance / license:** active, MIT
+- **Known gotchas / divergences:** [documented](https://docs.rs/handlebars/latest/handlebars/#differences-with-javascript-version) — including helper signatures, `{{lookup}}` semantics, whitespace-control edge cases, no JS-expression eval inside `{{#if …}}`
 
 ## BACKLOG check
 
-BACKLOG: *Parity too expensive* — bestätigt. Der FFI-Callback-Winkel macht die Klassifikation sogar härter als dort notiert.
+BACKLOG: *Parity too expensive* — confirmed. The FFI-callback angle makes the classification even harder than what's noted there.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Template-Render ist linear zur Output-Größe. 10 KB Output → ~100 µs in JS (V8-JIT auf kompiliertem Template) |
-| Input size distribution | Context-Object beliebig komplex; Template-AST im Rust-State gehalten |
-| Output size distribution | String 1–50 KB; FFI-Output-Kosten ~0.35 ns/Byte laut BASELINE |
-| Reusable setup (stateful potential) | **Hoch** — compiled Template als NAPI-Class wäre die einzige Option |
-| Batch-usage realism | Variable: E-Mail-Versand batched, Web-Rendering nicht |
-| FFI-share estimate vs. Rust work | **Callbacks dominieren**: jeder `{{myHelper arg}}` braucht Rust → JS → Rust (~2 µs Overhead pro Helper-Call) |
+| Per-call algorithmic work | Template render is linear in output size. 10 KB output → ~100 µs in JS (V8 JIT on the compiled template) |
+| Input size distribution | Context object arbitrarily complex; template AST held in Rust state |
+| Output size distribution | String 1–50 KB; FFI output cost ~0.35 ns/byte per BASELINE |
+| Reusable setup (stateful potential) | **High** — compiled template as a NAPI class would be the only option |
+| Batch-usage realism | Variable: email sending batched, web rendering not |
+| FFI-share estimate vs. Rust work | **Callbacks dominate**: every `{{myHelper arg}}` needs Rust → JS → Rust (~2 µs overhead per helper call) |
 
 ## Classification reasoning
 
-Reales Handlebars-Template hat 5–20 Helper-Aufrufe pro Render. Jeder `{{helper}}` muss JS-Kontext zurück ins V8 propagieren, den Helper callen, das Ergebnis zurück nach Rust marshallen. Bei 10 Helpers à 2 µs = 20 µs reine FFI-Kosten, während der JS-Baseline-Render 100 µs ist. Rust-Parse-Zeit der Template-Ausdrücke selbst ist irrelevant, wenn der Bottleneck die Callbacks sind. Dazu: `handlebars-rust` weicht dokumentiert vom JS-Verhalten ab — die Parity-Lücke wäre spürbar in Tests existierender Nutzer. Genau der `ejs`/`handlebars`-Shape: Template-Engines mit eingebetteter Logik gehören in eine JS-Engine.
+A real Handlebars template has 5–20 helper calls per render. Every `{{helper}}` has to propagate the JS context back into V8, call the helper, and marshal the result back to Rust. At 10 helpers × 2 µs = 20 µs of pure FFI cost, while a JS baseline render is 100 µs. Rust parse time of the template expressions themselves is irrelevant if the bottleneck is the callbacks. On top of that: `handlebars-rust` deviates from the JS behavior in documented ways — the parity gap would be noticeable in existing users' tests. Exactly the `ejs`/`handlebars` shape: template engines with embedded logic belong in a JS engine.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/htmlparser2.md
+++ b/docs/perf-review/htmlparser2.md
@@ -4,41 +4,41 @@
 
 ## Verdict
 
-`htmlparser2` ist SAX-style: der Caller übergibt Callbacks (`onopentag`, `ontext`, …). Jeder Token → Callback über FFI-Boundary. Event-getriebene Parser sind der Anti-Shape für NAPI.
+`htmlparser2` is SAX-style: the caller passes callbacks (`onopentag`, `ontext`, …). Every token → callback across the FFI boundary. Event-driven parsers are the anti-shape for NAPI.
 
 ## JS package
 
 - **npm:** `htmlparser2`
-- **Downloads:** ~62M/Woche
-- **Exports / API surface:** `Parser` mit Callback-Handler, `DomHandler`, `DomUtils`, Streaming-API
-- **Typical input:** HTML-Stream oder -Dokument, 1 KB – 5 MB
-- **Typical output:** Event-Stream (SAX) oder Tree (via `DomHandler`)
-- **Realistic median use-case:** Streaming-Scraper / cheerio-Backend, 100–500 KB HTML
+- **Downloads:** ~62M/week
+- **Exports / API surface:** `Parser` with callback handlers, `DomHandler`, `DomUtils`, streaming API
+- **Typical input:** HTML stream or document, 1 KB – 5 MB
+- **Typical output:** event stream (SAX) or tree (via `DomHandler`)
+- **Realistic median use-case:** streaming scraper / cheerio backend, 100–500 KB HTML
 
 ## Rust replacement
 
-- **Candidate crate(s):** `html5ever` (Tokenizer-Layer), `html5gum`
-- **Maintenance / license:** beide aktiv, MIT/Apache
-- **Known gotchas / divergences:** `htmlparser2` toleriert XML-Mode + HTML-Mode in einem Parser; kein direktes Rust-Äquivalent für XML-HTML-Dual
+- **Candidate crate(s):** `html5ever` (tokenizer layer), `html5gum`
+- **Maintenance / license:** both active, MIT/Apache
+- **Known gotchas / divergences:** `htmlparser2` tolerates XML mode + HTML mode in one parser; no direct Rust equivalent for XML-HTML dual
 
 ## BACKLOG check
 
-BACKLOG bündelt mit `parse5` — bestätigt. Für `htmlparser2` ist der Callback-Aspekt härter als der Adapter-Aspekt bei `parse5`.
+BACKLOG bundles with `parse5` — confirmed. For `htmlparser2` the callback aspect is harder than the adapter aspect for `parse5`.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Tokenize 100 KB ~ 1 ms in JS, Rust ~200 µs → 5× Potenzial |
-| Input size distribution | Bytes-in, okay |
-| Output size distribution | **Callback pro Token**: typisch ~50K Tokens bei 100 KB HTML |
-| Reusable setup (stateful potential) | Parser-Instanz als Class — möglich, aber der Callback-Kost bleibt |
-| Batch-usage realism | Streaming hebt batching auf — pro Chunk dieselbe FFI-Last |
-| FFI-share estimate vs. Rust work | Callbacks dominieren: 50K × ~2 µs Rust→JS→Rust = 100 ms — 100× langsamer als der JS-Baseline-Parse |
+| Per-call algorithmic work | Tokenize 100 KB ~ 1 ms in JS, Rust ~200 µs → 5× potential |
+| Input size distribution | Bytes-in, fine |
+| Output size distribution | **Callback per token**: typically ~50K tokens for 100 KB HTML |
+| Reusable setup (stateful potential) | Parser instance as a class — possible, but the callback cost stays |
+| Batch-usage realism | Streaming defeats batching — same FFI load per chunk |
+| FFI-share estimate vs. Rust work | Callbacks dominate: 50K × ~2 µs Rust → JS → Rust = 100 ms — 100× slower than the JS baseline parse |
 
 ## Classification reasoning
 
-Das ist der `handlebars`-Shape verstärkt: Parser emittiert Events, Caller entscheidet. Ohne Callbacks ist `htmlparser2` nicht `htmlparser2`, sondern ein Tree-Builder — und dann sind wir zurück beim `parse5`-Shape (Tree-Materialisierung). Einzige sinnvolle API wäre: "Rust parst, tokenisiert, sammelt im Rust-State ein typisiertes Event-Array, liefert es am Ende als eine große `Buffer`/`JsArray` zurück". Das wäre eine andere API als `htmlparser2`, mit anderer Semantik (kein echter Stream), und braucht die 2×-Schwelle nur bei sehr großen Dokumenten (~MB-Bereich). Für den Median-Use-Case (cheerio auf Scrape-Responses) verpufft der Win.
+This is the `handlebars` shape amplified: the parser emits events, the caller decides. Without callbacks `htmlparser2` isn't `htmlparser2`, it's a tree builder — and then we're back at the `parse5` shape (tree materialization). The only sensible API would be: "Rust parses, tokenizes, collects a typed event array in Rust state, returns it at the end as one big `Buffer`/`JsArray`". That would be a different API from `htmlparser2`, with different semantics (no real stream), and only clears the 2× threshold on very large documents (~MB range). For the median use-case (cheerio on scrape responses) the win evaporates.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/jose.md
+++ b/docs/perf-review/jose.md
@@ -1,69 +1,69 @@
 # Candidate review: `jose`
 
-> **Status:** SHIPPED v0.1 (rescoped) · **Predicted:** 🟢 Green-likely · **Measured:** 🟢 Green (RSA-thumbprint, Ed25519-keygen) / 🟡 Yellow (Ed25519-thumbprint) · **Reviewed:** 2026-04-19
+> **Status:** SHIPPED v0.1 (rescoped) · **Predicted:** 🟢 Green-likely · **Measured:** 🟢 Green (RSA thumbprint, Ed25519 keygen) / 🟡 Yellow (Ed25519 thumbprint) · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-`jose` (panva) ist die einzige Option in dieser dreier-Tranche, die das Green-Profil tatsächlich hält — **aber nur wenn wir scopen**. Die Full-Surface (JWT + JWS + JWE + JWK + JWKS-Caching + Browser-Compat) ist zu groß für ein einzelnes Crate und teilweise redundant zu unserem `@amigo-labs/jwt`. Empfehlung: **Scope = JWE-Encryption + JWK-Operations (RSA/EC-Key-Parsing/-Generation)** — genau die Lücke, die unser jwt-Crate nicht abdeckt. Per-Call-Compute 100 µs–2 ms (RSA-Operationen, AES-GCM-Encryption, ECDH-ES-Key-Agreement) → FFI-Overhead ≤ 1 % → 2–4× Speedup vs. pure-JS jose realistisch.
+`jose` (panva) is the only option in this triple tranche that actually holds the Green profile — **but only if we scope**. The full surface (JWT + JWS + JWE + JWK + JWKS caching + browser compat) is too big for a single crate and partially redundant with our `@amigo-labs/jwt`. Recommendation: **scope = JWE encryption + JWK operations (RSA/EC key parsing/generation)** — exactly the gap our jwt crate doesn't cover. Per-call compute 100 µs–2 ms (RSA operations, AES-GCM encryption, ECDH-ES key agreement) → FFI overhead ≤ 1% → 2–4× speedup vs. pure-JS jose realistic.
 
 ## JS package
 
-- **npm:** `jose` (~6 M weekly, panva)
-- **Downloads:** 6 M weekly, **echte Server-Adoption** (modernes Auth-Stack, ESM-first, ersetzt `jsonwebtoken` + `node-jose` zunehmend)
+- **npm:** `jose` (~6M weekly, panva)
+- **Downloads:** 6M weekly, **real server adoption** (modern auth stack, ESM-first, increasingly replacing `jsonwebtoken` + `node-jose`)
 - **Exports / API surface:** `SignJWT`, `jwtVerify`, `EncryptJWT`, `jwtDecrypt`, `CompactSign`, `CompactEncrypt`, `FlattenedSign`, `GeneralSign`, `JWE` (variants), `importJWK`/`exportJWK`, `generateKeyPair`, `createRemoteJWKSet`
-- **Typical input:** Token-Strings (~500 Bytes–4 KB), Keys als JWK-Object oder PEM
-- **Typical output:** Signed/encrypted Token-Strings, KeyLike Objects
-- **Realistic median use-case:** **JWE-Decrypt im Auth-Middleware** (jeder Request) und **JWK-Key-Loading beim Startup** (cached). Sign/Verify ist häufig, hat aber unser bestehendes `@amigo-labs/jwt` als Konkurrent — also explizit ausklammern, kein Doppel-Crate
+- **Typical input:** token strings (~500 bytes–4 KB), keys as JWK object or PEM
+- **Typical output:** signed/encrypted token strings, KeyLike objects
+- **Realistic median use-case:** **JWE decrypt in auth middleware** (every request) and **JWK key loading at startup** (cached). Sign/verify is frequent, but our existing `@amigo-labs/jwt` is its competitor — so explicitly excluded, no double crate
 
 ## Rust replacement
 
 - **Candidate crate(s):**
-  - **`josekit`** (Hiroyuki Wada) — komplett (JWS+JWE+JWK), aber kleinere Userbase als RustCrypto-Familie
-  - **`aws-lc-rs` + `rsa` + `aes-gcm` + `p256`/`p384`/`p521`** als RustCrypto-Komposition — mehr Maintenance-Aufwand, dafür konsistent mit unserer jwt-Crate
-- **Maintenance / license:** josekit MIT/Apache, aktiv aber kleinerer Maintainer-Pool
+  - **`josekit`** (Hiroyuki Wada) — complete (JWS+JWE+JWK), but smaller user base than the RustCrypto family
+  - **`aws-lc-rs` + `rsa` + `aes-gcm` + `p256`/`p384`/`p521`** as a RustCrypto composition — more maintenance effort, in exchange consistent with our jwt crate
+- **Maintenance / license:** josekit MIT/Apache, active but smaller maintainer pool
 - **Known gotchas / divergences:**
-  - JWE algorithm-Coverage muss explizit deklariert sein (`A128KW`, `A256GCMKW`, `RSA-OAEP-256`, `ECDH-ES+A256KW`, …) — panva/jose deckt _alle_ RFC-Algos ab, das wollen wir nicht
-  - Browser-/WebCrypto-Compat von panva/jose ist für unsere NAPI-Crate irrelevant (kein Browser-Target)
-  - `createRemoteJWKSet` (HTTP-Fetching mit Cache) ist bewusst **nicht** im Scope — gehört in JS-Wrapper
+  - JWE algorithm coverage has to be explicitly declared (`A128KW`, `A256GCMKW`, `RSA-OAEP-256`, `ECDH-ES+A256KW`, …) — panva/jose covers _all_ RFC algos, we don't want that
+  - Browser/WebCrypto compat of panva/jose is irrelevant for our NAPI crate (no browser target)
+  - `createRemoteJWKSet` (HTTP fetching with cache) is deliberately **not** in scope — belongs in a JS wrapper
 
 ## BACKLOG check
 
-Kein Eintrag. Frischer Kandidat.
+No entry. Fresh candidate.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | JWE-Decrypt: 100 µs–2 ms (RSA-OAEP) bzw. 50–200 µs (AES-GCM mit pre-shared Key). JWK-Parse: 50–500 µs (RSA-Schlüssel-Validation) |
-| Input size distribution | Token: 500 B–4 KB. JWK-JSON: 200 B–2 KB. Buffer-Lane oder String, beides OK bei diesen Größen |
-| Output size distribution | Klartext-Payload (~100 B–4 KB), oder KeyLike-Handle |
-| Reusable setup (stateful potential) | **Hoch.** Key-Parsing ist amortisierbar — `JoseKey` als NAPI-Class mit `.decrypt(token)` / `.sign(payload)` Methoden. Das ist der Hauptlevergewinn |
-| Batch-usage realism | Niedrig — Auth-Calls sind per-Request, nicht batchbar. Stateful-Class ersetzt Batch |
-| FFI-share estimate vs. Rust work | Per `decrypt`-Call: ~109 ns Floor + ~500 ns Token-String-Crossing = ~700 ns FFI vs. ~100–500 µs Crypto-Work = **< 0,7 %** |
+| Per-call algorithmic work | JWE decrypt: 100 µs–2 ms (RSA-OAEP) or 50–200 µs (AES-GCM with pre-shared key). JWK parse: 50–500 µs (RSA key validation) |
+| Input size distribution | Token: 500 B–4 KB. JWK JSON: 200 B–2 KB. Buffer lane or string, both OK at these sizes |
+| Output size distribution | Cleartext payload (~100 B–4 KB), or KeyLike handle |
+| Reusable setup (stateful potential) | **High.** Key parsing is amortizable — `JoseKey` as a NAPI class with `.decrypt(token)` / `.sign(payload)` methods. That's the main leverage win |
+| Batch-usage realism | Low — auth calls are per-request, not batchable. Stateful class substitutes for batching |
+| FFI-share estimate vs. Rust work | Per `decrypt` call: ~109 ns floor + ~500 ns token string crossing = ~700 ns FFI vs. ~100–500 µs crypto work = **< 0.7%** |
 
 ## Classification reasoning
 
-Im Gegensatz zu scrypt/pbkdf2 hat `jose` **keinen Node-built-in-Konkurrenten**. Node hat low-level `crypto.createSign`/`crypto.createCipheriv`, aber kein JWE-/JWK-Highlevel-API. Wer JWE will, installiert ein npm-Paket — und panva/jose ist der De-facto-Standard.
+Unlike scrypt/pbkdf2, `jose` has **no Node built-in competitor**. Node has low-level `crypto.createSign`/`crypto.createCipheriv`, but no high-level JWE/JWK API. Anyone who wants JWE installs an npm package — and panva/jose is the de-facto standard.
 
-Speedup-Erwartung gegen panva/jose (pure JS, V8-optimiert aber Crypto-Operationen sind nicht V8-tunable):
-- JWE-Decrypt RSA-OAEP: 3–5× (RSA-Math in Rust ist deutlich schneller als pure-JS BigInt)
-- JWE-Decrypt AES-GCM mit pre-shared Key: 2–3× (AES-NI über RustCrypto)
-- JWK-Parse: 2–4×
+Speedup expectation against panva/jose (pure JS, V8-optimized but crypto operations aren't V8-tunable):
+- JWE decrypt RSA-OAEP: 3–5× (RSA math in Rust is significantly faster than pure-JS BigInt)
+- JWE decrypt AES-GCM with pre-shared key: 2–3× (AES-NI via RustCrypto)
+- JWK parse: 2–4×
 
-**Stateful-API ist der entscheidende Hebel:** Eine JS-User schreibt heute `await jwtDecrypt(token, key, options)` und parst den Key implizit pro Call. Wir bieten:
+**The stateful API is the decisive lever:** a JS user today writes `await jwtDecrypt(token, key, options)` and implicitly parses the key per call. We offer:
 
 ```ts
-const key = new JoseKey({ jwk })  // einmal beim Startup
-const payload = key.decrypt(token)  // hot path, 0 Setup
+const key = new JoseKey({ jwk })  // once at startup
+const payload = key.decrypt(token)  // hot path, 0 setup
 ```
 
-Das ist die argon2-`hash`-vs-`verify`-Pattern angewandt auf JWE.
+That's the argon2 `hash` vs. `verify` pattern applied to JWE.
 
-**Risiko Yellow → Green:** Wenn wir versuchen, _alle_ JWE-Algos zu unterstützen, blowt der Binary auf. Strict-Scope auf die 4 häufigsten Algos (RSA-OAEP, RSA-OAEP-256, A256GCMKW, ECDH-ES+A256KW) hält Bundle bei ~1,5 MB.
+**Risk Yellow → Green:** if we try to support _all_ JWE algos, the binary blows up. A strict scope on the 4 most common algos (RSA-OAEP, RSA-OAEP-256, A256GCMKW, ECDH-ES+A256KW) keeps the bundle at ~1.5 MB.
 
 ## If GO — proposed port
 
-- **Recommended crate-name:** `@amigo-labs/jose` (Drop-in für JWE/JWK-Subset von panva/jose) — **ergänzt** `@amigo-labs/jwt`, ersetzt es nicht
+- **Recommended crate name:** `@amigo-labs/jose` (drop-in for the JWE/JWK subset of panva/jose) — **complements** `@amigo-labs/jwt`, doesn't replace it
 - **Primary API sketch:**
   ```ts
   // Stateless convenience (parses key per call — convenience layer)
@@ -83,86 +83,86 @@ Das ist die argon2-`hash`-vs-`verify`-Pattern angewandt auf JWE.
   ```
 
 - **Must-have benchmark scenarios:**
-  - JWE-Decrypt RSA-OAEP-256, 2048-bit Key, Payload 200 B (Auth-Middleware-Median)
-  - JWE-Decrypt A256GCMKW, Payload 200 B (HOT-PATH-Median)
-  - JWE-Encrypt ECDH-ES+A256KW, Payload 1 KB (Token-Issuance)
-  - JWK-Parse RSA-2048 Public Key (Startup)
-  - **Stateful** vs. **Stateless** Variante zum Demonstrieren des Class-API-Hebels
-  - Baseline: panva/jose neueste Version
+  - JWE decrypt RSA-OAEP-256, 2048-bit key, payload 200 B (auth middleware median)
+  - JWE decrypt A256GCMKW, payload 200 B (HOT-PATH median)
+  - JWE encrypt ECDH-ES+A256KW, payload 1 KB (token issuance)
+  - JWK parse RSA-2048 public key (startup)
+  - **Stateful** vs. **stateless** variant to demonstrate the class-API lever
+  - Baseline: panva/jose latest version
 
 - **Acceptance thresholds (Green gate):**
-  - ≥2× Stateful-Decrypt vs. panva/jose bei Median-Payload
-  - ≥3× JWK-Parse
-  - ≥1× Stateless-Convenience-Layer (darf nicht langsamer sein, auch wenn Class-API der Pitch ist)
-  - 100 % Test-Vector-Parität auf RFC-7516 (JWE) Standard-Vektoren
+  - ≥2× stateful decrypt vs. panva/jose at median payload
+  - ≥3× JWK parse
+  - ≥1× stateless convenience layer (must not be slower, even if the class API is the pitch)
+  - 100% test-vector parity on RFC 7516 (JWE) standard vectors
 
 - **Risks:**
-  1. **Scope-Creep:** `panva/jose` deckt 30+ Algorithmen ab. Wir machen 4. JS-User mit exotischen Algos (RSA1_5 — _legacy_, PBES2 — _legacy_, …) müssen bei panva/jose bleiben. Klar dokumentieren
-  2. **Crate-Wahl josekit vs. RustCrypto-Komposition:** josekit ist convenient aber kleinerer Maintainer; RustCrypto-direkt ist konsistent zu unserer jwt-Crate aber 3× so viel Wrapper-Code. **Empfehlung: RustCrypto-Komposition** (jwt-Crate-Pattern wiederverwendbar)
-  3. **JWKS-Remote-Caching:** `createRemoteJWKSet` aus panva/jose ist HTTP + In-Memory-Cache. Gehört nicht in NAPI — als JS-Wrapper-Layer im Crate-Package mitliefern oder explizit ausschließen
-  4. **Bundle-Disziplin:** Bei Algo-Auswahl sparsam sein. Default-Features `aes-gcm`, `rsa`, `p256` reichen für 90 % der Real-World-Use-Cases
+  1. **Scope creep:** `panva/jose` covers 30+ algorithms. We do 4. JS users with exotic algos (RSA1_5 — _legacy_, PBES2 — _legacy_, …) have to stay with panva/jose. Document clearly
+  2. **Crate choice josekit vs. RustCrypto composition:** josekit is convenient but smaller maintainer pool; RustCrypto direct is consistent with our jwt crate but 3× the wrapper code. **Recommendation: RustCrypto composition** (jwt-crate pattern reusable)
+  3. **JWKS remote caching:** `createRemoteJWKSet` from panva/jose is HTTP + in-memory cache. Doesn't belong in NAPI — ship as a JS wrapper layer inside the crate package or explicitly exclude
+  4. **Bundle discipline:** be frugal with algo selection. Default features `aes-gcm`, `rsa`, `p256` cover 90% of real-world use-cases
 
 ## If NO-GO — BACKLOG entry
 
-N/A — GO empfohlen (scoped).
+N/A — GO recommended (scoped).
 
-## Phase-B Messung (2026-04-19, linux-x64, Node v22.22.2)
+## Phase B measurement (2026-04-19, linux-x64, Node v22.22.2)
 
-v0.1 Scope ausgeliefert: `generateRsaKeyPair`, `generateEd25519KeyPair`, `jwkThumbprint`. JWE/JWS auf v0.2 verschoben.
+v0.1 scope shipped: `generateRsaKeyPair`, `generateEd25519KeyPair`, `jwkThumbprint`. JWE/JWS pushed to v0.2.
 
-| Funktion | @amigo-labs/jose | jose (panva, pure JS) | Speedup |
+| Function | @amigo-labs/jose | jose (panva, pure JS) | Speedup |
 |---|---:|---:|---|
-| jwkThumbprint Ed25519 | 507 407 hz | 271 279 hz | **1,87×** ✅ |
-| jwkThumbprint RSA-2048 | 470 445 hz | 182 718 hz | **2,57×** ✅✅ |
-| generateEd25519KeyPair | 52 939 hz | 7 312 hz | **7,24×** ✅✅✅ |
-| generateRsaKeyPair (2048) | 6,92 hz | **18,08 hz** | **0,38× (2,6× langsamer)** 🔴 |
+| jwkThumbprint Ed25519 | 507,407 hz | 271,279 hz | **1.87×** ✅ |
+| jwkThumbprint RSA-2048 | 470,445 hz | 182,718 hz | **2.57×** ✅✅ |
+| generateEd25519KeyPair | 52,939 hz | 7,312 hz | **7.24×** ✅✅✅ |
+| generateRsaKeyPair (2048) | 6.92 hz | **18.08 hz** | **0.38× (2.6× slower)** 🔴 |
 
-**Ergebnis: 3/4 Green, 1/4 Red.**
+**Result: 3/4 Green, 1/4 Red.**
 
-**Warum RSA-Keygen verliert:**
-panva/jose nutzt unter der Haube `crypto.subtle.generateKey` (WebCrypto-API) — das ist Node-built-in OpenSSL-Code. **Genau die "Node-built-in dominates"-Falle, die scrypt/pbkdf2 zerlegt hat.** OpenSSL's RSA-Prime-Search (BIGNUM-Math, Miller-Rabin in C-ASM) ist signifikant schneller als pure-Rust `rsa = "0.9"`.
+**Why RSA keygen loses:**
+panva/jose uses `crypto.subtle.generateKey` (WebCrypto API) under the hood — that's Node built-in OpenSSL code. **Exactly the "Node built-in dominates" trap that broke scrypt/pbkdf2.** OpenSSL's RSA prime search (BIGNUM math, Miller-Rabin in C/ASM) is significantly faster than pure-Rust `rsa = "0.9"`.
 
-Diese Erkenntnis hätte ich aus den scrypt/pbkdf2-Reviews extrapolieren müssen — RSA-Keygen war unbeobachtet und hat den gleichen Konkurrenten.
+I should have extrapolated this insight from the scrypt/pbkdf2 reviews — RSA keygen went unobserved and has the same competitor.
 
-**Was funktioniert weiterhin:**
-- **Ed25519-Keygen 7,24× schneller** — panva/jose's WebCrypto-API für Ed25519 hat anscheinend höheren JS↔WebCrypto-Overhead, oder Node's Ed25519 ist suboptimaler implementiert. Klarer Sieg.
-- **JWK-Thumbprint 1,87–2,57× schneller** — Hash-Computation (SHA-256) + JSON-Canonicalization in Rust schlägt panva/jose's pure-JS String-Concatenation
-- 3 von 4 Funktionen liefern Wert
+**What still works:**
+- **Ed25519 keygen 7.24× faster** — panva/jose's WebCrypto API for Ed25519 apparently has higher JS↔WebCrypto overhead, or Node's Ed25519 is implemented more suboptimally. Clear win.
+- **JWK thumbprint 1.87–2.57× faster** — hash computation (SHA-256) + JSON canonicalization in Rust beats panva/jose's pure-JS string concatenation
+- 3 out of 4 functions deliver value
 
-**Phase-C/D-Plan:**
-- **C.6 Algorithm:** `generateRsaKeyPair` ist nicht algorithmisch optimierbar (RSA-Math ist bekannt). Pure-Rust hat strukturellen Nachteil gegen OpenSSL.
-- **Realistische Option:** README + API-Doc explizit empfehlen, für RSA-Keygen Node-built-in `crypto.generateKeyPair('rsa', {modulusLength: 2048})` zu nutzen, dann nur die JWK-Konvertierung mit unserer Crate. Liefert beste-of-both-worlds.
-- **Drastische Option:** `generateRsaKeyPair` in v0.2 deprecaten / aus Public-API entfernen, Crate auf "JWK-Tooling + Ed25519" fokussieren.
+**Phase C/D plan:**
+- **C.6 algorithm:** `generateRsaKeyPair` is not algorithmically optimizable (RSA math is known). Pure Rust has a structural disadvantage against OpenSSL.
+- **Realistic option:** README + API doc explicitly recommend using Node built-in `crypto.generateKeyPair('rsa', {modulusLength: 2048})` for RSA keygen, then only JWK conversion with our crate. Delivers best-of-both-worlds.
+- **Drastic option:** deprecate `generateRsaKeyPair` in v0.2 / remove it from the public API, focus the crate on "JWK tooling + Ed25519".
 
-**Empfehlung für v0.1:** Behalten, README-Warning für RSA-Keygen. v0.2-Roadmap erweitert um JWE-Decrypt (echter Lückenfüller) statt RSA-Keygen-Optimierung.
+**Recommendation for v0.1:** keep, README warning for RSA keygen. v0.2 roadmap extended with JWE decrypt (real gap filler) instead of RSA keygen optimization.
 
-## Phase-C Rescope (2026-04-19, dieselbe Session)
+## Phase C rescope (2026-04-19, same session)
 
-User wählte **C: RSA-Keygen rauswerfen**, damit die Crate kein Red-Klassifikat mehr trägt.
+User picked **C: drop RSA keygen**, so the crate no longer carries a Red classification.
 
-**Maßnahme:**
-- `generateRsaKeyPair` komplett aus Public-API entfernt (nicht depreciert, nie öffentlich gewesen)
-- `rsa`-Crate + transitive Deps (pkcs1, pkcs8 für RSA, num-bigint-dig, num-traits, num-iter, zeroize) aus `Cargo.toml` gestrichen
-- README dokumentiert die Entscheidung + zeigt `node:crypto.generateKeyPair` als Alternative
-- `RsaGenTask` Task-Struct entfernt; der RSA-Thumbprint-Pfad bleibt voll erhalten (nutzt keine RSA-Crate-Abhängigkeit)
+**Action:**
+- `generateRsaKeyPair` completely removed from the public API (not deprecated, was never public)
+- `rsa` crate + transitive deps (pkcs1, pkcs8 for RSA, num-bigint-dig, num-traits, num-iter, zeroize) removed from `Cargo.toml`
+- README documents the decision + shows `node:crypto.generateKeyPair` as the alternative
+- `RsaGenTask` task struct removed; the RSA thumbprint path is fully preserved (no dependency on the RSA crate)
 
-**Neue Messung nach Rescope:**
+**New measurement after rescope:**
 
-| Funktion | @amigo-labs/jose | panva/jose | Speedup |
+| Function | @amigo-labs/jose | panva/jose | Speedup |
 |---|---:|---:|---|
-| jwkThumbprint Ed25519 | 398 751 hz | 246 636 hz | **1,62×** 🟡 |
-| jwkThumbprint RSA-2048 | 368 756 hz | 168 409 hz | **2,19×** 🟢 |
-| generateEd25519KeyPair | 46 406 hz | 6 660 hz | **6,97×** 🟢🟢 |
+| jwkThumbprint Ed25519 | 398,751 hz | 246,636 hz | **1.62×** 🟡 |
+| jwkThumbprint RSA-2048 | 368,756 hz | 168,409 hz | **2.19×** 🟢 |
+| generateEd25519KeyPair | 46,406 hz | 6,660 hz | **6.97×** 🟢🟢 |
 
-**Portfolio-Auswirkung:**
-- Kein Red-Punkt mehr in der Crate
-- Median-Funktion (`jwkThumbprint` auf RSA-JWKs, der dominante Production-Use-Case via OAuth/OIDC) ist 🟢 Green bei 2,19×
-- Ed25519-Thumbprint-Sub-Case knapp unter 2×-Gate (1,62×) — akzeptabel, da es denselben Rust-Code ist, der bei RSA-Input Green liefert; die Varianz kommt vom kleineren SHA-256-Input (Ed25519-JWK ~80 Bytes vs. RSA-JWK ~400 Bytes) wo V8's WebCrypto-Overhead relativ kleiner wird
-- Binary-Size deutlich kleiner (keine `rsa`/`num-bigint`/`pkcs1` mehr)
+**Portfolio impact:**
+- No more Red point in the crate
+- Median function (`jwkThumbprint` on RSA JWKs, the dominant production use-case via OAuth/OIDC) is 🟢 Green at 2.19×
+- Ed25519 thumbprint sub-case just below the 2× gate (1.62×) — acceptable, since it's the same Rust code that delivers Green on RSA input; the variance comes from the smaller SHA-256 input (Ed25519 JWK ~80 bytes vs. RSA JWK ~400 bytes) where V8's WebCrypto overhead becomes relatively smaller
+- Binary size significantly smaller (no more `rsa`/`num-bigint`/`pkcs1`)
 
-**Endklassifikation:** 🟢 Green (mit Ed25519-Thumbprint-Sub-Case als toleriertes Yellow-Randphänomen). Alle ausgelieferten Funktionen haben net-positive Speedup gegen den einzigen relevanten Konkurrenten.
+**Final classification:** 🟢 Green (with the Ed25519 thumbprint sub-case as a tolerated Yellow fringe). All shipped functions have net-positive speedup against the only relevant competitor.
 
-**15/15 Tests passing** nach Rescope:
-- Ed25519-Keygen + RSA-Thumbprint-Tests cross-verify mit panva/jose
-- RFC 7638 §3.1 Standard-Vector verifiziert
-- Property-Fuzz (50 Runs) für Ed25519-Thumbprint-Parität
+**15/15 tests passing** after the rescope:
+- Ed25519 keygen + RSA thumbprint tests cross-verify with panva/jose
+- RFC 7638 §3.1 standard vector verified
+- Property fuzz (50 runs) for Ed25519 thumbprint parity

--- a/docs/perf-review/js-yaml.md
+++ b/docs/perf-review/js-yaml.md
@@ -4,41 +4,41 @@
 
 ## Verdict
 
-Perf wäre wahrscheinlich Yellow/Green, aber `js-yaml` ist de facto ein YAML-1.1-Parser mit zehn Jahren Ruby-Psych-Kompat-Ballast — ein drop-in mit `saphyr` (YAML 1.2 strict) ist keine Kompat-Ersetzung, sondern ein anderes Paket.
+Perf would probably be Yellow/Green, but `js-yaml` is effectively a YAML-1.1 parser with ten years of Ruby-Psych compat ballast — a drop-in with `saphyr` (YAML 1.2 strict) isn't a compat replacement, it's a different package.
 
 ## JS package
 
 - **npm:** `js-yaml`
-- **Downloads:** ~156M/Woche
-- **Exports / API surface:** `load`, `loadAll`, `dump`, Custom-Types-System (`Type`, `Schema`, `DEFAULT_SCHEMA`, `CORE_SCHEMA`, `FAILSAFE_SCHEMA`), Error-Klassen
-- **Typical input:** UTF-8 YAML-Dokument, 100 B – 100 KB (CI-Configs, k8s-Manifeste)
-- **Typical output:** Beliebiger JS-Graph (Objects/Arrays/Primitives)
-- **Realistic median use-case:** einmalige Config-Datei beim Start eines Tools parsen; seltene Hot-Loops
+- **Downloads:** ~156M/week
+- **Exports / API surface:** `load`, `loadAll`, `dump`, custom-types system (`Type`, `Schema`, `DEFAULT_SCHEMA`, `CORE_SCHEMA`, `FAILSAFE_SCHEMA`), error classes
+- **Typical input:** UTF-8 YAML document, 100 B – 100 KB (CI configs, k8s manifests)
+- **Typical output:** arbitrary JS graph (objects/arrays/primitives)
+- **Realistic median use-case:** parse a config file once at tool startup; rarely a hot loop
 
 ## Rust replacement
 
-- **Candidate crate(s):** `saphyr` (YAML 1.2 strict), `serde_yaml` (deprecated), `yaml-rust2` (Nachfolger)
-- **Maintenance / license:** `saphyr` aktiv, MIT/Apache; `serde_yaml` archiviert (2024)
-- **Known gotchas / divergences:** YAML 1.1 vs. 1.2 (boolsches `yes`/`no`, Sexagesimal, Okt-Notation), Custom-Tags (`!!js/regexp`, `!!js/function`), Anchor-Aliasing-Semantik, Merge-Keys (`<<:`), Fehler-Positionen für Toolchains
+- **Candidate crate(s):** `saphyr` (YAML 1.2 strict), `serde_yaml` (deprecated), `yaml-rust2` (successor)
+- **Maintenance / license:** `saphyr` active, MIT/Apache; `serde_yaml` archived (2024)
+- **Known gotchas / divergences:** YAML 1.1 vs. 1.2 (boolean `yes`/`no`, sexagesimal, octal notation), custom tags (`!!js/regexp`, `!!js/function`), anchor-aliasing semantics, merge keys (`<<:`), error positions for toolchains
 
 ## BACKLOG check
 
-Aktuelle BACKLOG-Einordnung: *Parity too expensive* — 1:1 bestätigt. Die Entscheidung steht.
+Current BACKLOG classification: *Parity too expensive* — confirmed 1:1. The decision stands.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Substantiell ab ~10 KB; bei 1 KB Config vs. `js-yaml` V8-JIT nur ~1.5× denkbar |
-| Input size distribution | Bytes-in, `Buffer`-overload möglich → FFI-Kosten vernachlässigbar bei Median |
-| Output size distribution | Object-Graph-Materialisierung über NAPI ist teuer (`JsObject::set_named_property` pro Feld ist eine FFI-Kreuzung) |
-| Reusable setup (stateful potential) | Kein Schema-Cache nötig — Loader ist zustandslos |
-| Batch-usage realism | Typisch nicht gebatcht (eine Config pro Prozessstart) |
-| FFI-share estimate vs. Rust work | Output-Materialisierung dominiert, siehe `deep-equal`-Post-Mortem |
+| Per-call algorithmic work | Substantial from ~10 KB; at 1 KB config vs. `js-yaml`'s V8 JIT only ~1.5× conceivable |
+| Input size distribution | Bytes-in, `Buffer` overload possible → FFI cost negligible at the median |
+| Output size distribution | Object-graph materialization over NAPI is expensive (`JsObject::set_named_property` per field is an FFI crossing) |
+| Reusable setup (stateful potential) | No schema cache needed — the loader is stateless |
+| Batch-usage realism | Usually not batched (one config per process start) |
+| FFI-share estimate vs. Rust work | Output materialization dominates, see `deep-equal` post-mortem |
 
 ## Classification reasoning
 
-Perf-Seite alleine wäre Yellow: große YAMLs (k8s-Manifeste, CI-Matrizen) skalieren gut, aber der Median-Fall ist ≤1 KB und V8+`js-yaml` bewältigt das in ~50 µs — knapp über dem FFI-Floor. Entscheidender Killer ist Parity: `js-yaml` emuliert **YAML 1.1** (Default-Schema), akzeptiert Ruby-Psych-Custom-Tags und liefert extrem spezifische Fehlertypen/-positionen, gegen die Tools wie ESLint, Docusaurus, Webpack testen. `saphyr` ist strict 1.2. Das ist kein Drop-in — das ist ein anderes Paket mit denselben Nutzern.
+Perf side alone would be Yellow: large YAMLs (k8s manifests, CI matrices) scale well, but the median case is ≤1 KB and V8+`js-yaml` handles that in ~50 µs — just above the FFI floor. The decisive killer is parity: `js-yaml` emulates **YAML 1.1** (default schema), accepts Ruby-Psych custom tags, and produces very specific error types/positions that tools like ESLint, Docusaurus, Webpack test against. `saphyr` is strict 1.2. That isn't a drop-in — it's a different package with the same users.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/jsdom.md
+++ b/docs/perf-review/jsdom.md
@@ -4,41 +4,41 @@
 
 ## Verdict
 
-`jsdom` ist eine komplette Browser-DOM + Fetch + XHR + Worker + Canvas + CSSOM-Implementierung in JS. Kein Rust-Crate existiert dafür, und die Oberfläche ist strukturell unvereinbar mit NAPI-Klassen: alles ist Object-Graph-Traversal mit JS-Callback-Semantik.
+`jsdom` is a complete browser DOM + Fetch + XHR + Worker + Canvas + CSSOM implementation in JS. No Rust crate exists for this, and the surface is structurally incompatible with NAPI classes: everything is object-graph traversal with JS callback semantics.
 
 ## JS package
 
 - **npm:** `jsdom`
-- **Downloads:** ~76M/Woche
-- **Exports / API surface:** `JSDOM`, `window`, `document`, vollständige DOM-Level-4 + HTML-Spec-Surface, `ResourceLoader`, `VirtualConsole`, teilweise Web-APIs (Fetch, XHR, Canvas-2D via `canvas`-Optional, Web-Workers-Stub)
-- **Typical input:** HTML-Dokument + optional Resource-Loader
-- **Typical output:** `window`/`document`-Objekt mit vollem DOM-API-Zugriff
-- **Realistic median use-case:** Test-Environment (`vitest`/`jest` mit `jsdom`), SSR-Hilfe für Libraries, Scraping mit JS-Execution
+- **Downloads:** ~76M/week
+- **Exports / API surface:** `JSDOM`, `window`, `document`, complete DOM Level 4 + HTML spec surface, `ResourceLoader`, `VirtualConsole`, partial web APIs (Fetch, XHR, Canvas 2D via optional `canvas`, web workers stub)
+- **Typical input:** HTML document + optional resource loader
+- **Typical output:** `window`/`document` object with full DOM API access
+- **Realistic median use-case:** test environment (`vitest`/`jest` with `jsdom`), SSR helper for libraries, scraping with JS execution
 
 ## Rust replacement
 
-- **Candidate crate(s):** keine. `html5ever` parst, aber kein Rust-Crate implementiert `window`, Event-Loop, DOM-Mutations-APIs, CSSOM, Computed-Styles
+- **Candidate crate(s):** none. `html5ever` parses, but no Rust crate implements `window`, event loop, DOM mutation APIs, CSSOM, computed styles
 - **Maintenance / license:** n/a
-- **Known gotchas / divergences:** `jsdom` braucht JS-Engine (V8) für Script-Execution — selbst wenn DOM in Rust wäre, müsste alles zurück nach V8
+- **Known gotchas / divergences:** `jsdom` needs a JS engine (V8) for script execution — even if the DOM were in Rust, everything would have to go back to V8
 
 ## BACKLOG check
 
-BACKLOG: *Scope too large* — bestätigt, Klassifikation hochgestuft auf Black (strukturell inkompatibel).
+BACKLOG: *Scope too large* — confirmed, classification upgraded to Black (structurally incompatible).
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Jedes Attribut, jeder Selector, jede Event-Dispatch = FFI-Kreuzung |
-| Input size distribution | Irrelevant — Shape ist fundamental inkompatibel |
-| Output size distribution | DOM-Tree mit zehntausenden Properties |
-| Reusable setup (stateful potential) | Hoch, aber der Caller-Code ruft `document.querySelector` → `.innerHTML = …` in Hot-Loops |
-| Batch-usage realism | Null |
-| FFI-share estimate vs. Rust work | 100% FFI für typische Test-Workloads |
+| Per-call algorithmic work | Every attribute, every selector, every event dispatch = FFI crossing |
+| Input size distribution | Irrelevant — shape is fundamentally incompatible |
+| Output size distribution | DOM tree with tens of thousands of properties |
+| Reusable setup (stateful potential) | High, but the caller code invokes `document.querySelector` → `.innerHTML = …` in hot loops |
+| Batch-usage realism | Zero |
+| FFI-share estimate vs. Rust work | 100% FFI for typical test workloads |
 
 ## Classification reasoning
 
-`jsdom`s Nutzer rufen `document.querySelector('div').textContent = 'x'` — das sind drei Property-Accesses, eine Setter-Invocation, ein DOM-Mutation-Observer-Callback. Jeder einzelne dieser Schritte wäre eine FFI-Kreuzung. Selbst wenn der gesamte DOM-Core in Rust wäre, würde jeder Test-Case tausende FFI-Kreuzungen pro Millisekunde auslösen. Das ist das Lookup-Workload-Black-Szenario aus der Klassifikationstabelle. Hinzu kommt: Script-Execution (ein großer Teil von `jsdom`) braucht V8; das kann Rust nicht leisten. Permanenter NO-GO.
+`jsdom` users call `document.querySelector('div').textContent = 'x'` — that's three property accesses, one setter invocation, one DOM mutation observer callback. Every single one of those steps would be an FFI crossing. Even if the entire DOM core were in Rust, every test case would trigger thousands of FFI crossings per millisecond. That's the lookup-workload Black scenario from the classification table. On top of that: script execution (a large part of `jsdom`) needs V8; Rust can't provide that. Permanent NO-GO.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/marked.md
+++ b/docs/perf-review/marked.md
@@ -1,44 +1,44 @@
 # Candidate review: `marked`
 
-> **Status:** NO-GO (als `marked`-Drop-in) · **Predicted:** 🟢 Green (für CommonMark-Paket) · **Reviewed:** 2026-04-19
+> **Status:** NO-GO (as a `marked` drop-in) · **Predicted:** 🟢 Green (for a CommonMark package) · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-Perf-Seite: `pulldown-cmark` wäre klar Green — bytes-in / bytes-out, substantial compute, FFI-Floor irrelevant bei ≥1 KB Markdown. Aber `marked`s GFM-Interpretation ≠ CommonMark/`pulldown-cmark`, und Nutzer testen gegen exakt `marked`s Output-Bytes. Als eigenständiges `@amigo-labs/commonmark`-Paket (nicht als `marked`-Ersatz) wäre GO — das ist eine separate Produktentscheidung.
+Perf side: `pulldown-cmark` would be clearly Green — bytes-in / bytes-out, substantial compute, FFI floor irrelevant at ≥1 KB Markdown. But `marked`'s GFM interpretation ≠ CommonMark/`pulldown-cmark`, and users test against `marked`'s exact output bytes. As a standalone `@amigo-labs/commonmark` package (not as a `marked` replacement) it would be GO — that's a separate product decision.
 
 ## JS package
 
 - **npm:** `marked`
-- **Downloads:** ~30M/Woche
-- **Exports / API surface:** `marked(src, options)`, Lexer/Parser-Split, Custom-Renderer, Extensions-API, `walkTokens`
-- **Typical input:** Markdown-Dokument 1 KB – 1 MB
-- **Typical output:** HTML-String
-- **Realistic median use-case:** Dokumentations-Site (z. B. docusaurus-ähnlich), Blog-Post-Rendering; auch CLI-README-Viewer
+- **Downloads:** ~30M/week
+- **Exports / API surface:** `marked(src, options)`, Lexer/Parser split, custom renderer, extensions API, `walkTokens`
+- **Typical input:** Markdown document 1 KB – 1 MB
+- **Typical output:** HTML string
+- **Realistic median use-case:** documentation site (e.g. docusaurus-style), blog-post rendering; also CLI README viewers
 
 ## Rust replacement
 
-- **Candidate crate(s):** `pulldown-cmark` (CommonMark + GFM-Extensions), `comrak`
-- **Maintenance / license:** beide aktiv, MIT
-- **Known gotchas / divergences:** `marked` implementiert eine **eigene** Markdown-Interpretation, die mit CommonMark nicht identisch ist: Listen-Loose/Tight-Detection anders, Tabellen-Parsing anders, HTML-Inline-Handling anders. `comrak` ist am nächsten an `marked`/GFM, aber immer noch Byte-Diffs auf reale Inputs
+- **Candidate crate(s):** `pulldown-cmark` (CommonMark + GFM extensions), `comrak`
+- **Maintenance / license:** both active, MIT
+- **Known gotchas / divergences:** `marked` implements its **own** Markdown interpretation, which is not identical to CommonMark: list loose/tight detection differs, table parsing differs, HTML inline handling differs. `comrak` is closest to `marked`/GFM, but there are still byte diffs on real inputs
 
 ## BACKLOG check
 
-BACKLOG: *Parity too expensive* — bestätigt. Zusatz-Empfehlung: kein `marked`-Port, aber Evaluierung eines **eigenständigen** `@amigo-labs/commonmark` (spec-strict, kein Drop-in-Versprechen) könnte separat sinnvoll sein.
+BACKLOG: *Parity too expensive* — confirmed. Additional recommendation: no `marked` port, but evaluating a **standalone** `@amigo-labs/commonmark` (spec-strict, no drop-in promise) could be worth doing separately.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | 100 KB Markdown → ~5 ms in JS (`marked`), `pulldown-cmark` ~500 µs → 10× Potenzial |
-| Input size distribution | Typisch ≥1 KB; `Buffer`-input möglich |
-| Output size distribution | HTML-String ~1.5× Input; Output-Kosten 0.35 ns/Byte FFI, tolerabel |
-| Reusable setup (stateful potential) | Niedrig — Renderer-Config klein |
-| Batch-usage realism | Batch-Rendering (Site-Build) sehr realistisch |
-| FFI-share estimate vs. Rust work | Niedrig bei ≥10 KB; FFI dominiert nur bei winzigen Inputs |
+| Per-call algorithmic work | 100 KB Markdown → ~5 ms in JS (`marked`), `pulldown-cmark` ~500 µs → 10× potential |
+| Input size distribution | Typically ≥1 KB; `Buffer` input possible |
+| Output size distribution | HTML string ~1.5× input; output cost 0.35 ns/byte FFI, tolerable |
+| Reusable setup (stateful potential) | Low — renderer config is small |
+| Batch-usage realism | Batch rendering (site build) very realistic |
+| FFI-share estimate vs. Rust work | Low at ≥10 KB; FFI only dominates for tiny inputs |
 
 ## Classification reasoning
 
-Post-Mortem-Shape matcht `sanitize-html`/`inflate`: bytes-in / bytes-out, kein Object-Traversal. Das ist **der** Green-Shape. Der einzige Blocker ist Parity. Snapshot-Tests von Docusaurus, GitHub-API-Renderer, Stack-Overflow-ähnlichen Editoren hängen an exakten Byte-Diffs — und `marked` hat Quirks (z. B. `> quote\nparagraph` wird anders interpretiert als CommonMark vorschreibt). Ein `marked`-kompatibles Paket würde die Abweichungen händisch nachbauen müssen, was die 10×-Win schnell auffrisst. Alternative: ehrlich als CommonMark-Paket positionieren, Nutzer migrieren bewusst. Das ist eine Produktfrage, nicht eine Perf-Frage.
+The post-mortem shape matches `sanitize-html`/`inflate`: bytes-in / bytes-out, no object traversal. That's **the** Green shape. The only blocker is parity. Snapshot tests from Docusaurus, GitHub API renderers, Stack Overflow-style editors hang on exact byte diffs — and `marked` has quirks (e.g. `> quote\nparagraph` is interpreted differently than CommonMark prescribes). A `marked`-compatible package would have to reproduce the deviations by hand, which quickly eats the 10× win. Alternative: honestly position as a CommonMark package, users migrate consciously. That's a product question, not a perf question.
 
 ## If NO-GO — BACKLOG entry
 
@@ -46,4 +46,4 @@ Post-Mortem-Shape matcht `sanitize-html`/`inflate`: bytes-in / bytes-out, kein O
 - **marked** (~30M). `marked`'s GFM interpretation ≠ `pulldown-cmark`'s GFM. Perf-shape is clean (bytes-in/bytes-out, Green candidate), but parity to exact byte output is what users rely on. A `@amigo-labs/commonmark` as a *new* package (not a `marked` drop-in) would be worth re-evaluating separately.
 ```
 
-Section in `BACKLOG.md`: **Parity too expensive** (mit Follow-up-Flag)
+Section in `BACKLOG.md`: **Parity too expensive** (with follow-up flag)

--- a/docs/perf-review/mime-types.md
+++ b/docs/perf-review/mime-types.md
@@ -4,26 +4,26 @@
 
 ## Verdict
 
-Strukturell identisch zu `mime`: Hashmap-Lookup. Gleicher Black-Shape, gleiches Urteil. `mime-types` wickelt zusätzlich die `mime-db`-Daten, aber am Hot-Path ändert das nichts.
+Structurally identical to `mime`: hashmap lookup. Same Black shape, same verdict. `mime-types` additionally wraps the `mime-db` data, but that doesn't change the hot path.
 
 ## JS package
 
 - **npm:** `mime-types`
-- **Downloads:** ~180M/Woche
+- **Downloads:** ~180M/week
 - **Exports / API surface:** `lookup(path)`, `contentType(type)`, `extension(type)`, `charset(type)`, `types`, `extensions`
-- **Typical input:** Dateipfad/Extension/MIME, <100 B
-- **Typical output:** String oder `false`
-- **Realistic median use-case:** Express/Fastify/Koa-Middleware bestimmt Response-Content-Type
+- **Typical input:** file path / extension / MIME, <100 B
+- **Typical output:** string or `false`
+- **Realistic median use-case:** Express/Fastify/Koa middleware determining response content type
 
 ## Rust replacement
 
-- **Candidate crate(s):** `mime_guess` (liest dieselbe `mime-db`-Datenbank zur Build-Zeit), `new_mime_guess`
-- **Maintenance / license:** aktiv, MIT
-- **Known gotchas / divergences:** `mime_guess` embedded die DB statisch — identische Lookups, keine `addType`-API
+- **Candidate crate(s):** `mime_guess` (reads the same `mime-db` database at build time), `new_mime_guess`
+- **Maintenance / license:** active, MIT
+- **Known gotchas / divergences:** `mime_guess` embeds the DB statically — identical lookups, no `addType` API
 
 ## BACKLOG check
 
-BACKLOG: *FFI overhead > gain* (kombiniert mit `mime`) — bestätigt.
+BACKLOG: *FFI overhead > gain* (combined with `mime`) — confirmed.
 
 ## FFI-overhead prediction
 
@@ -32,17 +32,17 @@ BACKLOG: *FFI overhead > gain* (kombiniert mit `mime`) — bestätigt.
 | Per-call algorithmic work | ~30–60 ns in JS |
 | Input size distribution | <100 B |
 | Output size distribution | <50 B |
-| Reusable setup (stateful potential) | Null |
-| Batch-usage realism | Niedrig — per-Request-Call |
+| Reusable setup (stateful potential) | Zero |
+| Batch-usage realism | Low — per-request call |
 | FFI-share estimate vs. Rust work | >90% FFI |
 
 ## Classification reasoning
 
-Siehe `mime.md` — gleiche Argumentation. Kleiner Unterschied: `mime-types.charset()` ist ein zweiter Lookup-Schritt, immer noch im Nanosekunden-Bereich. Rust hat keinen Hebel, weder Algorithmus- noch Datenstruktur-seitig (V8 inlined statische Maps). Black.
+See `mime.md` — same reasoning. Small difference: `mime-types.charset()` is a second lookup step, still in the nanosecond range. Rust has no lever, neither algorithmic nor data-structure-side (V8 inlines static maps). Black.
 
 ## If NO-GO — BACKLOG entry
 
-Konsolidiert mit `mime` unter einem Eintrag:
+Consolidated with `mime` under one entry:
 
 ```markdown
 - **mime** / **mime-types** (combined 343M). Pure hashmap lookups — see `mime`.

--- a/docs/perf-review/mime.md
+++ b/docs/perf-review/mime.md
@@ -4,41 +4,41 @@
 
 ## Verdict
 
-Hashmap-Lookup. V8 macht das in <50 ns; FFI-Floor ist 109 ns. Strukturell nicht schlagbar — der Standard-FFI-Trap-Shape aus dem Post-Mortem-Katalog.
+Hashmap lookup. V8 does it in <50 ns; FFI floor is 109 ns. Structurally unbeatable — the standard FFI trap shape from the post-mortem catalog.
 
 ## JS package
 
 - **npm:** `mime`
-- **Downloads:** ~60M/Woche (zusammen mit `mime-types` ~343M)
+- **Downloads:** ~60M/week (together with `mime-types` ~343M)
 - **Exports / API surface:** `getType(path)`, `getExtension(type)`, `define(types, force?)`
-- **Typical input:** Dateipfad oder MIME-String, <100 B
-- **Typical output:** MIME-String oder Extension-String
-- **Realistic median use-case:** Static-File-Server bestimmt Content-Type pro Request
+- **Typical input:** file path or MIME string, <100 B
+- **Typical output:** MIME string or extension string
+- **Realistic median use-case:** static-file server determining content type per request
 
 ## Rust replacement
 
 - **Candidate crate(s):** `mime_guess`, `mime`
-- **Maintenance / license:** aktiv, MIT/Apache
-- **Known gotchas / divergences:** keine — Lookup-Tabelle ist im Wesentlichen identisch
+- **Maintenance / license:** active, MIT/Apache
+- **Known gotchas / divergences:** none — the lookup table is essentially identical
 
 ## BACKLOG check
 
-BACKLOG: *FFI overhead > gain* — bestätigt, Klassifikation Black (nicht Red), weil keine Input-Größe rettet.
+BACKLOG: *FFI overhead > gain* — confirmed, classification Black (not Red), because no input size rescues it.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | ~20–50 ns (String-Hash + HashMap-Lookup) in JS |
-| Input size distribution | Pfade <100 B |
-| Output size distribution | <50 B MIME-String |
-| Reusable setup (stateful potential) | Null — Hashmap ist statisch |
-| Batch-usage realism | Möglich, aber selten — meist ein Call pro Request |
-| FFI-share estimate vs. Rust work | **>90% FFI**: Floor 109 ns vs. JS 20–50 ns. Rust verliert im Grundzustand |
+| Per-call algorithmic work | ~20–50 ns (string hash + HashMap lookup) in JS |
+| Input size distribution | Paths <100 B |
+| Output size distribution | <50 B MIME string |
+| Reusable setup (stateful potential) | Zero — the hashmap is static |
+| Batch-usage realism | Possible, but rare — usually one call per request |
+| FFI-share estimate vs. Rust work | **>90% FFI**: floor 109 ns vs. JS 20–50 ns. Rust loses in the base case |
 
 ## Classification reasoning
 
-Baseline-Messung beantwortet es direkt: `echoString` mit 10 B Input kostet bereits 234 ns. Der eigentliche Lookup würde nochmal ~50 ns addieren. Das sind ~280 ns pro Call. JS macht das in ~50 ns, weil V8 die Lookup-Tabelle als Hidden-Class monomorphisch inlined. Selbst ein batch-API (`getTypes(paths: string[])`) rettet nichts: der `sumArray`-Baseline zeigt ~43 ns/Element für Array-Marshalling, das ist noch immer langsamer als der JS-Direct-Lookup. Klassischer `nanoid`/`mime`-Shape aus den Post-Mortems.
+The baseline measurement answers it directly: `echoString` with a 10 B input already costs 234 ns. The actual lookup would add another ~50 ns. That's ~280 ns per call. JS does it in ~50 ns, because V8 inlines the lookup table as a monomorphic hidden class. Even a batch API (`getTypes(paths: string[])`) doesn't rescue it: the `sumArray` baseline shows ~43 ns/element for array marshalling, still slower than the JS direct lookup. Classic `nanoid`/`mime` shape from the post-mortems.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/parse5.md
+++ b/docs/perf-review/parse5.md
@@ -1,44 +1,44 @@
 # Candidate review: `parse5`
 
-> **Status:** NO-GO · **Predicted:** 🟡 Yellow (Perf) / 🔴 Red (Scope) · **Reviewed:** 2026-04-19
+> **Status:** NO-GO · **Predicted:** 🟡 Yellow (perf) / 🔴 Red (scope) · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-`html5ever` kann schnell HTML parsen — aber `parse5` ist nicht nur ein Parser, sondern ein Tree-Adapter-Framework. Parity zu `parse5-htmlparser2-tree-adapter`, `parse5-serializer`, Error-Recovery und dem WHATWG-Testsuite-Verhalten ist mehr Oberfläche als Perf-Gewinn rechtfertigt.
+`html5ever` can parse HTML fast — but `parse5` isn't just a parser, it's a tree-adapter framework. Parity with `parse5-htmlparser2-tree-adapter`, `parse5-serializer`, error recovery, and WHATWG testsuite behavior is more surface than the perf win justifies.
 
 ## JS package
 
 - **npm:** `parse5`
-- **Downloads:** ~130M/Woche
-- **Exports / API surface:** `parse`, `parseFragment`, `serialize`, Tree-Adapter (default + htmlparser2-kompat), Location-Tracking, Custom Document-Types
-- **Typical input:** HTML-Dokument 5 KB – 5 MB
-- **Typical output:** Tree (Document/Element/TextNode) über Adapter-API
-- **Realistic median use-case:** Web-Scraper parst Response (~50 KB), traversiert danach über `parse5-querystring` / cheerio
+- **Downloads:** ~130M/week
+- **Exports / API surface:** `parse`, `parseFragment`, `serialize`, tree adapter (default + htmlparser2-compat), location tracking, custom document types
+- **Typical input:** HTML document 5 KB – 5 MB
+- **Typical output:** tree (Document/Element/TextNode) over adapter API
+- **Realistic median use-case:** web scraper parsing a response (~50 KB), traversing afterwards via `parse5-querystring` / cheerio
 
 ## Rust replacement
 
 - **Candidate crate(s):** `html5ever` + `markup5ever`
-- **Maintenance / license:** aktiv (Servo-Team), Apache/MIT
-- **Known gotchas / divergences:** `html5ever` liefert RcDom; Tree-Traversal über NAPI-Boundary wäre pro Node eine FFI-Kreuzung (`deep-equal`-Shape). Location-Tracking anders
+- **Maintenance / license:** active (Servo team), Apache/MIT
+- **Known gotchas / divergences:** `html5ever` produces RcDom; tree traversal across the NAPI boundary would be an FFI crossing per node (`deep-equal` shape). Location tracking different
 
 ## BACKLOG check
 
-BACKLOG: *Parity too expensive* (kombiniert mit `htmlparser2`) — bestätigt.
+BACKLOG: *Parity too expensive* (combined with `htmlparser2`) — confirmed.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | HTML-Parse ist CPU-intensiv: 100 KB HTML ~2 ms in JS, `html5ever` ~500 µs → 4× Potenzial |
-| Input size distribution | Bytes-in, `Buffer`-overload → FFI-Input billig |
-| Output size distribution | **Tree-Materialisierung ist der Killer**: 100 KB HTML → ~10K Nodes → jede Node als JS-Object kostet NAPI-Calls für jedes Field |
-| Reusable setup (stateful potential) | Niedrig — Parser ist stateless pro Call |
-| Batch-usage realism | Niedrig (ein Dokument pro Call) |
-| FFI-share estimate vs. Rust work | Output dominiert ab ~1K Nodes; 4×-Parse-Win verpufft vollständig |
+| Per-call algorithmic work | HTML parse is CPU-intensive: 100 KB HTML ~2 ms in JS, `html5ever` ~500 µs → 4× potential |
+| Input size distribution | Bytes-in, `Buffer` overload → FFI input cheap |
+| Output size distribution | **Tree materialization is the killer**: 100 KB HTML → ~10K nodes → every node as a JS object costs NAPI calls for every field |
+| Reusable setup (stateful potential) | Low — parser is stateless per call |
+| Batch-usage realism | Low (one document per call) |
+| FFI-share estimate vs. Rust work | Output dominates from ~1K nodes; the 4× parse win evaporates completely |
 
 ## Classification reasoning
 
-Der Parse-Schritt wäre ein klarer Win. Aber niemand parst HTML und wirft das Tree weg. Tree-Materialisierung über NAPI ist exakt der `deep-equal`-Shape: pro Node ~5–10 FFI-Kreuzungen für Tag, Attribute, Children-Array. Bei 10K Nodes = 50–100K Kreuzungen × 109 ns Floor = 5–10 ms — mehr als das JS-Baseline-Parse komplett braucht. Alternative: Tree im Rust halten, Zugriff on-demand (cheerio-Wrapper-Pattern) — aber dann ist das kein `parse5`-Drop-in. Zweiter Killer: `parse5` hat zwei Adapter-APIs (default + htmlparser2-kompat) + `serialize` + `parseFragment`; das ist ein eigenes Crate-Ökosystem, kein einzelnes Paket.
+The parse step would be a clear win. But no one parses HTML and throws the tree away. Tree materialization over NAPI is exactly the `deep-equal` shape: ~5–10 FFI crossings per node for tag, attributes, children array. At 10K nodes = 50–100K crossings × 109 ns floor = 5–10 ms — more than the JS baseline parse needs end-to-end. Alternative: keep the tree in Rust, access it on-demand (cheerio-wrapper pattern) — but then it isn't a `parse5` drop-in. Second killer: `parse5` has two adapter APIs (default + htmlparser2-compat) + `serialize` + `parseFragment`; that's its own crate ecosystem, not a single package.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/pbkdf2.md
+++ b/docs/perf-review/pbkdf2.md
@@ -1,66 +1,66 @@
 # Candidate review: `pbkdf2`
 
-> **Status:** NO-GO · **Predicted:** 🔴 Red (Adoption-bedingt) · **Reviewed:** 2026-04-19
+> **Status:** NO-GO · **Predicted:** 🔴 Red (adoption-driven) · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-Gleiches Problem wie scrypt, nur schärfer: **Node hat `crypto.pbkdf2` built-in als native C++-Implementierung** (sync + async, alle gängigen Hash-Algos). Die ~30 M weekly downloads des npm-Pakets `pbkdf2` sind **dominant Browser-/Bundler-Ökosystem** (`crypto-browserify`-Shim, Webpack/Browserify polyfills) — Server-Code in 2026 nutzt `crypto.pbkdf2` direkt. Unsere NAPI-Crate erreicht diese Bundler-User nicht (kein Browser-Target) und bietet Server-Usern keinen Grund, Node's built-in zu ersetzen. Speedup vs. Node-built-in vermutlich < 1,4×, gleicher Code-Path im Hintergrund (beide rufen OpenSSL-/RustCrypto-Implementierungen auf).
+Same problem as scrypt, only sharper: **Node has `crypto.pbkdf2` built-in as a native C++ implementation** (sync + async, all common hash algos). The ~30M weekly downloads of the npm package `pbkdf2` are **dominantly browser/bundler ecosystem** (`crypto-browserify` shim, Webpack/Browserify polyfills) — server code in 2026 uses `crypto.pbkdf2` directly. Our NAPI crate doesn't reach those bundler users (no browser target) and offers server users no reason to replace Node's built-in. Speedup vs. Node built-in is probably < 1.4×, same code path under the hood (both call OpenSSL/RustCrypto implementations).
 
 ## JS package
 
-- **npm:** `pbkdf2` (~30 M weekly) — pure JS Implementierung, primär als browserify-shim
-- **Downloads:** 30 M weekly, aber **Adoption-Quality niedrig** — fast ausschließlich transitive dep
+- **npm:** `pbkdf2` (~30M weekly) — pure JS implementation, primarily as a browserify shim
+- **Downloads:** 30M weekly, but **adoption quality low** — almost exclusively a transitive dep
 - **Exports / API surface:** `pbkdf2(password, salt, iterations, keyLen, digest, cb)`, `pbkdf2Sync(...)`
-- **Typical input:** Passwort + Salt; Iterations 100 000–600 000 (OWASP-2023-Empfehlung)
-- **Typical output:** Key-Bytes (typisch 32 Bytes für SHA-256-HMAC)
-- **Realistic median use-case:** Server Node: `crypto.pbkdf2` (built-in). Browser/Edge: `pbkdf2` npm (pure JS). Unsere Crate trifft nur den Server-Markt, also Konkurrenz = Node-built-in
+- **Typical input:** password + salt; iterations 100,000–600,000 (OWASP 2023 recommendation)
+- **Typical output:** key bytes (typically 32 bytes for SHA-256 HMAC)
+- **Realistic median use-case:** server Node: `crypto.pbkdf2` (built-in). Browser/edge: `pbkdf2` npm (pure JS). Our crate only hits the server market, so the competitor = Node built-in
 
 ## Rust replacement
 
 - **Candidate crate(s):** `pbkdf2` (RustCrypto)
-- **Maintenance / license:** RustCrypto, gut gepflegt, MIT/Apache
-- **Known gotchas / divergences:** Hash-Algo-Selection (SHA1/256/384/512) muss explizit Parität mit Node-Strings haben (`'sha256'` etc.)
+- **Maintenance / license:** RustCrypto, well maintained, MIT/Apache
+- **Known gotchas / divergences:** hash-algo selection (SHA1/256/384/512) must explicitly be parity with Node strings (`'sha256'` etc.)
 
 ## BACKLOG check
 
-Kein Eintrag.
+No entry.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | 1–50 ms bei 100k–600k Iter — FFI-Floor irrelevant |
-| Input size distribution | Klein (< 128 Bytes) |
-| Output size distribution | 32 Bytes |
-| Reusable setup (stateful potential) | Keine. HMAC-Key wird pro Call gesetzt |
+| Per-call algorithmic work | 1–50 ms at 100k–600k iter — FFI floor irrelevant |
+| Input size distribution | Small (< 128 bytes) |
+| Output size distribution | 32 bytes |
+| Reusable setup (stateful potential) | None. The HMAC key is set per call |
 | Batch-usage realism | N/A |
-| FFI-share estimate vs. Rust work | < 0,01 % |
+| FFI-share estimate vs. Rust work | < 0.01% |
 
-**Wieder kein FFI-Problem.** Reines Adoption-/Konkurrenz-Problem.
+**Again no FFI problem.** Pure adoption/competition problem.
 
 ## Classification reasoning
 
-Beide harten Regeln greifen:
+Both hard rules apply:
 
-1. **"Realistic median use-case":** Server-Node-Code nutzt `crypto.pbkdf2`. Punkt. Wer noch `pbkdf2`-npm direkt verwendet, ist entweder Browser-Bundle (für uns unerreichbar) oder Legacy-Code.
+1. **"Realistic median use-case":** server Node code uses `crypto.pbkdf2`. Period. Whoever still uses `pbkdf2` npm directly is either in a browser bundle (unreachable for us) or legacy code.
 
-2. **"No sunk-cost":** Selbst wenn wir 1,4× vs Node built-in messen würden — der Switching-Cost (`crypto.pbkdf2` → `@amigo-labs/pbkdf2`) ist für die meisten Codebases den Marginal-Gain nicht wert. Argon2 hat keinen built-in-Konkurrenten, das macht den Unterschied.
+2. **"No sunk-cost":** even if we measured 1.4× vs. Node built-in — the switching cost (`crypto.pbkdf2` → `@amigo-labs/pbkdf2`) is not worth the marginal gain for most codebases. Argon2 has no built-in competitor; that makes the difference.
 
-Klassifikation **Red** statt Yellow weil:
-- Adoption-Pfad nicht plausibel
-- 1,4×-Marginal-Gain wäre Argon2-Pattern, aber bei Argon2 gibt's keinen built-in als Default-Wahl
-- Unsere Bundle-Größe (~1 MB Binary + 6 Platform-Stubs) vs. Node-built-in (0 Bytes Install) ist ein No-Brainer
+Classification **Red** rather than Yellow because:
+- adoption path not plausible
+- a 1.4× marginal gain would be the argon2 pattern, but argon2 has no built-in as the default choice
+- our bundle size (~1 MB binary + 6 platform stubs) vs. Node built-in (0 bytes install) is a no-brainer
 
 ## If GO — proposed port
 
-**Nicht empfohlen.** Falls jemand zwingend will:
-- Pitch nur als "explizit getestete Cross-Plattform-Konsistenz" (Node-built-in nutzt OpenSSL-Variante des OS, RustCrypto ist deterministisch)
-- Bench-Gate: ≥1,8× vs. `crypto.pbkdf2` bei 100k Iter — sonst raus
+**Not recommended.** If someone insists:
+- pitch only as "explicitly tested cross-platform consistency" (Node built-in uses the OS's OpenSSL variant, RustCrypto is deterministic)
+- bench gate: ≥1.8× vs. `crypto.pbkdf2` at 100k iter — otherwise out
 
 ## If NO-GO — BACKLOG entry
 
 ```markdown
-- **pbkdf2** (~30M weekly). Node hat `crypto.pbkdf2` built-in als native OpenSSL-Implementierung (sync + async, alle Hash-Algos). 30M-Downloads-Zahl ist dominant Browser-Bundler-Shim (`crypto-browserify`), nicht reale Server-Adoption. Unsere NAPI-Crate erreicht weder Browser-User noch bietet Server-Usern Grund, Node-built-in zu ersetzen. Strukturell schwerer Pitch als scrypt (gleiche Logik aber pbkdf2-Server-Adoption ist noch klarer Built-in-dominiert).
+- **pbkdf2** (~30M weekly). Node has `crypto.pbkdf2` built-in as a native OpenSSL implementation (sync + async, all hash algos). The 30M downloads number is dominantly browser bundler shim (`crypto-browserify`), not real server adoption. Our NAPI crate reaches neither browser users nor gives server users a reason to replace Node's built-in. Structurally harder pitch than scrypt (same logic but pbkdf2 server adoption is even more clearly built-in-dominated).
 ```
 
-Section in `BACKLOG.md`: **FFI overhead > gain** (Variante: "Node-built-in dominiert; npm-Downloads sind Bundler-Shim")
+Section in `BACKLOG.md`: **FFI overhead > gain** (variant: "Node built-in dominates; npm downloads are bundler shim")

--- a/docs/perf-review/pdfkit.md
+++ b/docs/perf-review/pdfkit.md
@@ -1,60 +1,60 @@
 # Candidate review: `pdfkit`
 
-> **Status:** GO (als neues Paket, kein Drop-in für `pdfkit`) · **Predicted:** 🟡 Yellow leaning 🟢 Green · **Reviewed:** 2026-04-20
+> **Status:** GO (as a new package, not a drop-in for `pdfkit`) · **Predicted:** 🟡 Yellow leaning 🟢 Green · **Reviewed:** 2026-04-20
 
 ## Verdict
 
-`pdfkit`'s fluent-chain API (`doc.text().image().font().addPage().end()`) ist die Bauchform, vor der das `xml`-Post-Mortem direkt warnt: dutzende bis hunderte kleiner FFI-Übergänge pro Dokument. Ein 1:1-Drop-in ist ⚫ Black. Als **neues Paket** mit *document-as-data*-API (ein Spec-Objekt → ein `Buffer`-Return pro Call, plus Batch-API und stateful Font-Cache) läuft es auf dem gleichen Gleis wie `commonmark`/`inflate`: substantieller Compute, Bytes-Out via `Buffer` (flach ~180 ns), keine Chained-Call-Kette über die FFI-Grenze. Für den genannten Median-Use-Case (High-Volume Labels/Tickets) ist die Batch-Form sogar die eigentliche Attraktion.
+`pdfkit`'s fluent-chain API (`doc.text().image().font().addPage().end()`) is the gut shape the `xml` post-mortem warns against directly: dozens to hundreds of small FFI crossings per document. A 1:1 drop-in is ⚫ Black. As a **new package** with a *document-as-data* API (one spec object → one `Buffer` return per call, plus a batch API and a stateful font cache) it runs on the same track as `commonmark`/`inflate`: substantial compute, bytes-out via `Buffer` (flat at ~180 ns), no chained-call chain across the FFI boundary. For the stated median use-case (high-volume labels/tickets), the batch form is actually the main attraction.
 
 ## JS package
 
 - **npm:** [`pdfkit`](https://www.npmjs.com/package/pdfkit)
-- **Downloads:** ~2.3 M/Woche (v0.18.0, Q1 2026)
-- **Exports / API surface:** fluent-chainable Builder: `new PDFDocument()`, `.text()`, `.font()`, `.fontSize()`, `.image()`, `.moveTo()`, `.lineTo()`, `.stroke()`, `.addPage()`, `.end()`; `PDFDocument` ist ein readable Node-Stream, typisch via `doc.pipe(fs.createWriteStream(...))` konsumiert
-- **Typical input:** imperatives Skript, das dutzende–hunderte Chain-Calls absetzt (Text-Segmente, Koordinaten, Images als Buffer/path, Font-Referenzen)
-- **Typical output:** PDF-Bytes, meist 2 KB – 10 MB, über Node-Stream geliefert
-- **Realistic median use-case (vom User bestätigt):** **High-Volume Label-/Ticket-Printing** — tausende kleiner PDFs pro Request, jedes ~2–20 KB, fast identische Templates mit variablen Feldern (Adresse, Barcode, ID)
+- **Downloads:** ~2.3M/week (v0.18.0, Q1 2026)
+- **Exports / API surface:** fluent-chainable builder: `new PDFDocument()`, `.text()`, `.font()`, `.fontSize()`, `.image()`, `.moveTo()`, `.lineTo()`, `.stroke()`, `.addPage()`, `.end()`; `PDFDocument` is a readable Node stream, typically consumed via `doc.pipe(fs.createWriteStream(...))`
+- **Typical input:** imperative script firing dozens–hundreds of chain calls (text segments, coordinates, images as Buffer/path, font references)
+- **Typical output:** PDF bytes, usually 2 KB – 10 MB, delivered via a Node stream
+- **Realistic median use-case (confirmed by user):** **high-volume label/ticket printing** — thousands of small PDFs per request, each ~2–20 KB, nearly identical templates with variable fields (address, barcode, ID)
 
 ## Rust replacement
 
-- **Candidate crate(s):** `printpdf` (primär — low-level, aktiv gepflegt von fschutt, WASM-tauglich, pure-Rust Deps) · `pdf-writer` (sekundär — minimalistisch, sehr wenig Allocation, aber noch low-leveler) · `krilla` (neuer, high-level, ergonomisch — in Reife-Beobachtung)
-- **Maintenance / license:** `printpdf` aktiv, MIT-lizenziert; `genpdf` (als High-Level-Option geprüft) hat seit ~3 Jahren keine Commits → **disqualifiziert**; `lopdf` zu low-level für produktiven Port
+- **Candidate crate(s):** `printpdf` (primary — low-level, actively maintained by fschutt, WASM-capable, pure-Rust deps) · `pdf-writer` (secondary — minimalistic, very low allocation, but even more low-level) · `krilla` (newer, high-level, ergonomic — watch list for maturity)
+- **Maintenance / license:** `printpdf` active, MIT-licensed; `genpdf` (checked as a high-level option) has no commits in ~3 years → **disqualified**; `lopdf` too low-level for a productive port
 - **Known gotchas / divergences:**
-  - Font-Embedding: `pdfkit` kommt mit 14 eingebetteten Standard-Type-1-Fonts; in Rust müssen TTFs explizit geladen und subsetted werden (`printpdf` via `ttf-parser`/`owned_ttf_parser`)
-  - Bildeinbettung: JPEG direkt, PNG via Decoder — `printpdf` hat beides, aber Color-Space-Handling weicht von `pdfkit` ab
-  - Text-Layout: `pdfkit` hat Line-Breaking/Word-Wrapping built-in; `printpdf` erwartet vorgerechnete Koordinaten → v1-Scope auf Labels beschränken, wo Layout trivial ist
-  - Pixel-identischer Output mit `pdfkit` **kein Ziel** — das Paket ist explizit nicht kompatibel
+  - Font embedding: `pdfkit` ships with 14 embedded standard Type-1 fonts; in Rust TTFs have to be loaded and subsetted explicitly (`printpdf` via `ttf-parser`/`owned_ttf_parser`)
+  - Image embedding: JPEG directly, PNG via a decoder — `printpdf` has both, but color-space handling differs from `pdfkit`
+  - Text layout: `pdfkit` has line-breaking/word-wrapping built in; `printpdf` expects pre-computed coordinates → limit v1 scope to labels, where layout is trivial
+  - Pixel-identical output with `pdfkit` is **not a goal** — the package is explicitly incompatible
 
 ## BACKLOG check
 
-Kein bestehender `pdfkit`-Eintrag. Der einzige PDF-Bezug in `BACKLOG.md:12` ist `pdf-parse` (Extraction, nicht Generation) — kein Overlap. Kein Eintrag in `docs/packages.json`.
+No existing `pdfkit` entry. The only PDF-related reference in `BACKLOG.md:12` is `pdf-parse` (extraction, not generation) — no overlap. No entry in `docs/packages.json`.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Pfadabhängig.** Drop-in (pro Chain-Call): trivial (< 1 µs pro `.text()` → FFI dominiert). Neues Paket (pro `generate(spec)`): substantiell (Label ~50–200 µs für Font-Subset + zlib-Stream-Pack) |
-| Input size distribution | Drop-in: viele kleine Strings/Zahlen pro Call. Neues Paket: Spec-Objekt (~100 B – 5 KB JSON) pro Label; Batch-Array für 1000 Labels = ~1–5 MB — via `Buffer`/JSON-String beide tolerabel |
-| Output size distribution | Labels 2–20 KB, Tickets 5–50 KB, Reports 50 KB – 10 MB. `Buffer`-Return ist flach ~180 ns von 1 KB bis 10 MB (siehe `docs/BASELINE.md:26–30`) — Output-FFI-Kosten vernachlässigbar |
-| Reusable setup (stateful potential) | **Hoch.** Font-Parsing + Glyph-Cache kostet pro Font ~5–15 ms cold. Bei 1000 Labels mit gleichem Font wäre das pro Call ein Killer — ein stateful `PdfBuilder`-Class-Pattern (Font einmal laden, viele `generate()` darauf) ist die entscheidende Optimierung |
-| Batch-usage realism | **Sehr hoch für den genannten Use-Case.** Label-Printing ist per Definition Batch; `generateMany(specs: LabelSpec[]): Buffer[]` kollabiert 1000 FFI-Crossings zu einem |
-| FFI-share estimate vs. Rust work | Drop-in Chain-API: >90% FFI (→ ⚫ Black). Neues Paket single: ~30% bei kleinen Labels (~50 µs Rust-Arbeit, ~15 µs Input-Marshal). Batch 1000: <2% FFI (ein Crossing amortisiert über 1000 Labels) |
+| Per-call algorithmic work | **Path-dependent.** Drop-in (per chain call): trivial (< 1 µs per `.text()` → FFI dominates). New package (per `generate(spec)`): substantial (label ~50–200 µs for font subset + zlib stream pack) |
+| Input size distribution | Drop-in: many small strings/numbers per call. New package: spec object (~100 B – 5 KB JSON) per label; batch array for 1000 labels = ~1–5 MB — both tolerable via `Buffer`/JSON string |
+| Output size distribution | Labels 2–20 KB, tickets 5–50 KB, reports 50 KB – 10 MB. `Buffer` return is flat ~180 ns from 1 KB to 10 MB (see `docs/BASELINE.md:26–30`) — output FFI cost negligible |
+| Reusable setup (stateful potential) | **High.** Font parsing + glyph cache costs ~5–15 ms cold per font. At 1000 labels with the same font, doing this per call would be a killer — a stateful `PdfBuilder` class pattern (load font once, many `generate()` on it) is the decisive optimization |
+| Batch-usage realism | **Very high for the stated use-case.** Label printing is batch by definition; `generateMany(specs: LabelSpec[]): Buffer[]` collapses 1000 FFI crossings into one |
+| FFI-share estimate vs. Rust work | Drop-in chain API: >90% FFI (→ ⚫ Black). New package single: ~30% for small labels (~50 µs Rust work, ~15 µs input marshal). Batch 1000: <2% FFI (one crossing amortized over 1000 labels) |
 
 ## Classification reasoning
 
-Zwei Pfade — zwei Klassifikationen. Die Entscheidung ist API-Form, nicht Rust-vs-JS.
+Two paths — two classifications. The decision is API shape, not Rust-vs-JS.
 
-**Pfad A — Drop-in (1:1 Spiegelung der Chain-API) → ⚫ Black.** Jeder `.text()`, `.moveTo()`, `.stroke()` ist ein FFI-Crossing mit String-Args. 1000 Labels × ~30 Chain-Calls = 30 000 FFI-Crossings pro Request. Das ist die exakte Bauchform, die `docs/post-mortems/xml.md:32–40` als katastrophal beschreibt ("~10k FFI crossings — more than the `sax` library's entire JS execution"). Parity-Kosten (Stream-Protocol, Chain-Return-Semantik, Image-Pipeline, Font-Registry) sind hoch, und am Ende ist das Ding langsamer als `pdfkit` in JS. Keine C-Hebel-Kombination rettet das.
+**Path A — drop-in (1:1 mirror of the chain API) → ⚫ Black.** Every `.text()`, `.moveTo()`, `.stroke()` is an FFI crossing with string arguments. 1000 labels × ~30 chain calls = 30,000 FFI crossings per request. That's the exact gut shape that `docs/post-mortems/xml.md:32–40` describes as catastrophic ("~10k FFI crossings — more than the `sax` library's entire JS execution"). Parity cost (stream protocol, chain-return semantics, image pipeline, font registry) is high, and at the end the thing is slower than `pdfkit` in JS. No combination of C levers rescues that.
 
-**Pfad B — Neues Paket, document-as-data → 🟡 Yellow mit 🟢-Green-Gate erreichbar.** Caller baut ein plain-JS-Spec-Objekt (`{ width, height, elements: [{type: 'text', x, y, value, font}, {type: 'barcode', ...}] }`), ein NAPI-Call konsumiert das und gibt den PDF-`Buffer` zurück. Stateful `PdfBuilder`-Class cached Fonts. `generateMany(specs)` für echten Batch. Das Muster reproduziert exakt `commonmark`'s Green-Form (siehe `docs/perf-review/commonmark.md:1–3`): Bytes-In, Bytes-Out, substantieller Compute pro Byte, kein Object-Traversal, kein Callback-Boundary. Für Labels ist die Layoutarbeit trivial genug, dass `printpdf`'s low-level-Interface ausreicht — das v1-Feature-Set kann bewusst klein bleiben.
+**Path B — new package, document-as-data → 🟡 Yellow with a reachable 🟢 Green gate.** The caller builds a plain JS spec object (`{ width, height, elements: [{type: 'text', x, y, value, font}, {type: 'barcode', ...}] }`), one NAPI call consumes it and returns the PDF `Buffer`. A stateful `PdfBuilder` class caches fonts. `generateMany(specs)` for real batching. The pattern reproduces `commonmark`'s Green shape exactly (see `docs/perf-review/commonmark.md:1–3`): bytes-in, bytes-out, substantial compute per byte, no object traversal, no callback boundary. For labels, the layout work is trivial enough that `printpdf`'s low-level interface suffices — the v1 feature set can stay deliberately small.
 
-Reference patterns: shape resembles `commonmark` (GO neues Paket, bytes-out) und `inflate` (shipped, `Buffer` flat via BASELINE) → 🟢 Green-Shape. NICHT `nanoid`/`mime` (kleine Inputs, trivial per-call).
+Reference patterns: shape resembles `commonmark` (GO new package, bytes-out) and `inflate` (shipped, `Buffer` flat via BASELINE) → 🟢 Green shape. NOT `nanoid`/`mime` (small inputs, trivial per-call).
 
-**Benchmark-Gap-Flag:** Prediction ist qualitativ. Vor Green-Gate müssen die drei Szenarien unten gemessen werden — ohne Zahlen bleibt das Paket auf 🟡 Yellow.
+**Benchmark gap flag:** the prediction is qualitative. Before the Green gate, the three scenarios below must be measured — without numbers the package stays at 🟡 Yellow.
 
 ## If GO — proposed port
 
-- **Recommended crate-name:** `@amigo-labs/pdf`
+- **Recommended crate name:** `@amigo-labs/pdf`
 - **Primary API sketch:**
   ```ts
   type FontSpec = { name: string; data: Buffer };
@@ -70,33 +70,33 @@ Reference patterns: shape resembles `commonmark` (GO neues Paket, bytes-out) und
   };
 
   export class PdfBuilder {
-    constructor(opts: { fonts: FontSpec[] });  // Fonts einmal laden, parsen, subset-ready cachen
+    constructor(opts: { fonts: FontSpec[] });  // load and parse fonts once, cache subset-ready
     generate(spec: LabelSpec): Buffer;
-    generateMany(specs: LabelSpec[]): Buffer[];   // kritisch für den High-Volume-Use-Case
+    generateMany(specs: LabelSpec[]): Buffer[];   // critical for the high-volume use-case
   }
   ```
-  Explizit **nicht** `pdfkit`-kompatibel. Keine chainable Methoden über die FFI-Grenze.
+  Explicitly **not** `pdfkit`-compatible. No chainable methods across the FFI boundary.
 - **Must-have benchmark scenarios:**
-  - **Small-single:** ein 4×6-Adresslabel (~2 KB Output, ein Font, 3 Text-Elemente, ein Barcode). Cold-Start und Hot-Path getrennt messen.
-  - **Batch-1000 (der eigentliche Median-Case):** ein `generateMany` mit 1000 identisch-geformten Labels, variable Felder. Misst, ob Stateful-Font-Cache + Batch-FFI-Amortisation den versprochenen Gewinn bringen.
-  - **Medium 10-Page-Receipt (~50 KB Output):** mehrseitig, mehrere Fonts, Text + Linien + ein Image. Sanity-Check, dass die Architektur über Labels hinaus skaliert.
+  - **Small-single:** one 4×6 address label (~2 KB output, one font, 3 text elements, one barcode). Measure cold start and hot path separately.
+  - **Batch-1000 (the actual median case):** one `generateMany` with 1000 identically shaped labels, variable fields. Tests whether the stateful font cache + batch FFI amortization deliver the promised win.
+  - **Medium 10-page receipt (~50 KB output):** multi-page, multiple fonts, text + lines + one image. Sanity check that the architecture scales beyond labels.
 - **Acceptance thresholds (Green gate):**
-  - Batch-1000 ≥ **5×** node `pdfkit` (gesamte Wall-Clock von Build → alle 1000 Buffer)
-  - Small-single hot-path ≥ **2×** `pdfkit`
-  - Medium 10-Page ≥ **2×** `pdfkit`
-  - Cold-Start-Kosten (erster `generate()`-Call inkl. Font-Load) müssen ausgewiesen werden, auch wenn nicht Green-gating — Transparenz-Anforderung aus der Skill-Regel "realistic median explicitly stated"
+  - Batch-1000 ≥ **5×** node `pdfkit` (total wall-clock from build → all 1000 buffers)
+  - Small-single hot path ≥ **2×** `pdfkit`
+  - Medium 10-page ≥ **2×** `pdfkit`
+  - Cold-start cost (first `generate()` call incl. font load) has to be reported, even though it's not Green-gating — transparency requirement from the skill rule "realistic median explicitly stated"
 - **Risks:**
-  - **Feature-Scope-Creep:** Sobald User komplexes Text-Wrapping, Tables, SVG oder kerning-akkurates Multi-Font-Layout verlangen, sprengt das `printpdf`'s low-level-Surface. v1 muss dokumentiert auf Labels/Tickets/einfache Receipts beschränkt sein — sonst kippt der Scope in Richtung `genpdf`-Komplexität (und der ist stale).
-  - **Font-Subset-Qualität:** `printpdf`-Subsetting ist funktional, aber nicht so glyph-effizient wie `pdfkit`'s fontkit. Output-PDFs könnten ~10–20% größer sein — für Labels irrelevant, für Reports evtl. sichtbar.
-  - **Migrations-Positionierung:** Kommunikation muss eindeutig sein: neues Paket für Batch/Label-Workloads, **kein** `pdfkit`-Migrationsziel. Fehl-Positionierung würde GitHub-Issues für pdfkit-Parity generieren, die per Design nicht lösbar sind.
-  - **Baseline-Nuancierung:** `docs/BASELINE.md` deckt `echoBuffer` ab, nicht PDF-Compute. FFI-Share-Schätzung oben ist abgeleitet, nicht gemessen. Nach Port sollte ein `_ffi-bench`-Case für PDF-Input-Spec-Marshaling ergänzt werden.
+  - **Feature scope creep:** as soon as users demand complex text wrapping, tables, SVG, or kerning-accurate multi-font layout, that blows past `printpdf`'s low-level surface. v1 must be documented as limited to labels/tickets/simple receipts — otherwise scope tips toward `genpdf` complexity (and that's stale).
+  - **Font-subset quality:** `printpdf` subsetting is functional, but not as glyph-efficient as `pdfkit`'s fontkit. Output PDFs could be ~10–20% larger — irrelevant for labels, possibly visible for reports.
+  - **Migration positioning:** communication must be unambiguous: new package for batch/label workloads, **not** a `pdfkit` migration target. Mispositioning would generate GitHub issues for pdfkit parity that are unsolvable by design.
+  - **Baseline nuance:** `docs/BASELINE.md` covers `echoBuffer`, not PDF compute. The FFI-share estimate above is derived, not measured. After the port, add an `_ffi-bench` case for PDF-input-spec marshalling.
 
 ## If NO-GO — BACKLOG entry
 
-Falls der User nach diesem Review auf NO-GO entscheidet (z.B. weil Scope-Risiko über Labels hinaus zu hoch), oder falls wir explizit den Drop-in-Pfad begraben wollen:
+If the user decides NO-GO after this review (e.g. because scope risk beyond labels is too high), or if we want to explicitly bury the drop-in path:
 
 ```markdown
-- **pdfkit (als Drop-in)** (~2.3M/Woche, PDF-Generation via chainable Builder-API). Abgelehnt nach Candidate-Review `docs/perf-review/pdfkit.md`: die Chain-API (`doc.text().image().addPage().end()`) erzeugt dutzende bis hunderte FFI-Crossings pro Dokument — exakt die Form, vor der `docs/post-mortems/xml.md` warnt. Ein *neues* Paket `@amigo-labs/pdf` mit document-as-data-API (ein Spec-Objekt → ein Buffer, plus Batch) ist eine eigenständige Option und nicht durch diese Ablehnung blockiert.
+- **pdfkit (as drop-in)** (~2.3M/week, PDF generation via a chainable builder API). Rejected after candidate review `docs/perf-review/pdfkit.md`: the chain API (`doc.text().image().addPage().end()`) produces dozens to hundreds of FFI crossings per document — exactly the shape `docs/post-mortems/xml.md` warns about. A *new* package `@amigo-labs/pdf` with a document-as-data API (one spec object → one Buffer, plus batch) is an independent option and not blocked by this rejection.
 ```
 
 Section in `BACKLOG.md`: **FFI overhead > gain / Parity too expensive**

--- a/docs/perf-review/scrypt.md
+++ b/docs/perf-review/scrypt.md
@@ -1,66 +1,66 @@
 # Candidate review: `scrypt`
 
-> **Status:** NO-GO (vorerst) · **Predicted:** 🟡 Yellow · **Reviewed:** 2026-04-19
+> **Status:** NO-GO (for now) · **Predicted:** 🟡 Yellow · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-scrypt sieht oberflächlich aus wie ein argon2-Geschwister (memory-hard KDF, ms-skalige Compute, identisches API-Shape) — **aber Node hat seit v10.5 `crypto.scrypt` built-in als nativer C++-Code**. Die realistische Median-Konkurrenz im Server-Code ist nicht `scrypt-js`, sondern Node selbst. Erwarteter Speedup gegen Node-built-in: ~1,4× (analog argon2 vs argon2-npm), das **verfehlt den 2×-Green-Gate**. Adoption-Argument schwach: warum sollte ein Server-Dev unsere Crate installieren, wenn `crypto.scrypt` schon nativ da ist? Kein GO ohne Adoptionspfad.
+scrypt looks superficially like an argon2 sibling (memory-hard KDF, ms-scale compute, identical API shape) — **but Node has had `crypto.scrypt` built-in as native C++ code since v10.5**. The realistic median competition in server code isn't `scrypt-js`, it's Node itself. Expected speedup vs. Node built-in: ~1.4× (analogous to argon2 vs. argon2-npm), that **misses the 2× Green gate**. Adoption argument weak: why would a server dev install our crate when `crypto.scrypt` is already native? No GO without an adoption path.
 
 ## JS package
 
-- **npm:** `scrypt` (deprecated, abandoned), `scrypt-js` (~3 M weekly, pure JS, Browser-fokussiert)
-- **Downloads:** 3 M weekly (scrypt-js); Server-User nutzen `crypto.scrypt` (built-in seit Node 10.5)
+- **npm:** `scrypt` (deprecated, abandoned), `scrypt-js` (~3M weekly, pure JS, browser-focused)
+- **Downloads:** 3M weekly (scrypt-js); server users use `crypto.scrypt` (built-in since Node 10.5)
 - **Exports / API surface:** `scrypt(password, salt, N, r, p, dkLen)` → derived key bytes
-- **Typical input:** Passwort + Salt (≤ 64 Bytes je); Parameter N=16384/32768, r=8, p=1
-- **Typical output:** Key-Bytes (typisch 32–64 Bytes)
-- **Realistic median use-case:** **Server-side**: `crypto.scrypt` (built-in C++). **Browser/Edge**: `scrypt-js` (pure JS). Unsere NAPI-Crate läuft nur im Node-Server, also ist die ehrliche Baseline `crypto.scrypt`
+- **Typical input:** password + salt (≤ 64 bytes each); parameters N=16384/32768, r=8, p=1
+- **Typical output:** key bytes (typically 32–64 bytes)
+- **Realistic median use-case:** **server-side**: `crypto.scrypt` (built-in C++). **Browser/edge**: `scrypt-js` (pure JS). Our NAPI crate only runs in Node server, so the honest baseline is `crypto.scrypt`
 
 ## Rust replacement
 
 - **Candidate crate(s):** `scrypt` (RustCrypto, mature, MIT/Apache)
-- **Maintenance / license:** RustCrypto-Familie, gut gepflegt
-- **Known gotchas / divergences:** Parameter-Encoding-Konventionen variieren (N als log₂ vs. roh); MCF-Hash-Format `$scrypt$...` standardisiert über `scrypt-pw` Helfer
+- **Maintenance / license:** RustCrypto family, well maintained
+- **Known gotchas / divergences:** parameter encoding conventions vary (N as log₂ vs. raw); MCF hash format `$scrypt$...` standardized via `scrypt-pw` helper
 
 ## BACKLOG check
 
-Kein Eintrag. Aber sollte ggf. mit klarer Begründung dort landen.
+No entry. But should probably land there with a clear rationale.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | 50–200 ms bei N=16384 — FFI-Floor irrelevant |
-| Input size distribution | Klein (Passwort + Salt < 128 Bytes); String/Buffer-Konvertierung < 0,01 % |
-| Output size distribution | 32–64 Bytes Key — irrelevant |
-| Reusable setup (stateful potential) | Keine. Parameter pro Call |
-| Batch-usage realism | N/A (jeder Call braucht unabh. Salt) |
-| FFI-share estimate vs. Rust work | < 0,001 % bei Standard-Parametern |
+| Per-call algorithmic work | 50–200 ms at N=16384 — FFI floor irrelevant |
+| Input size distribution | Small (password + salt < 128 bytes); string/buffer conversion < 0.01% |
+| Output size distribution | 32–64 bytes key — irrelevant |
+| Reusable setup (stateful potential) | None. Parameters per call |
+| Batch-usage realism | N/A (each call needs an independent salt) |
+| FFI-share estimate vs. Rust work | < 0.001% at standard parameters |
 
-**FFI ist nicht das Problem.** Der Algorithmus ist Rust-freundlich. Das Problem ist die **JS-Konkurrenz-Auswahl**.
+**FFI is not the problem.** The algorithm is Rust-friendly. The problem is the **JS competition choice**.
 
 ## Classification reasoning
 
-Die Anwendung von **Hard Rule 1** ("realistische Median-Use-Case") schlägt hier durch:
+Applying **Hard Rule 1** ("realistic median use-case") hits hard here:
 
-- vs. `scrypt-js` (pure JS): vermutlich 5–10× Speedup → Green
-- vs. `crypto.scrypt` (Node built-in nativ): vermutlich ~1,4× Speedup (analog argon2-Pattern) → **Yellow** (verfehlt 2×-Gate)
+- vs. `scrypt-js` (pure JS): probably 5–10× speedup → Green
+- vs. `crypto.scrypt` (Node built-in native): probably ~1.4× speedup (analogous to the argon2 pattern) → **Yellow** (misses 2× gate)
 
-Server-Code in 2026 nutzt fast immer `crypto.scrypt`. Die `scrypt-js`-Downloads sind dominant Browser-/Bundler-Ökosystem (browserify-shim, edge-runtime-Bibliotheken) — das ist **unsere Crate kann diese User strukturell nicht erreichen**, weil ein NAPI-Binary nicht im Browser läuft.
+Server code in 2026 almost always uses `crypto.scrypt`. The `scrypt-js` downloads are dominantly browser/bundler ecosystem (browserify shim, edge-runtime libs) — that's **our crate structurally can't reach those users**, because a NAPI binary doesn't run in the browser.
 
-Im Gegensatz zu argon2/bcrypt: Node hat **keine** built-ins für die. Da ist unsere Crate die kanonische native Option.
+Unlike argon2/bcrypt: Node has **no** built-ins for those. There our crate is the canonical native option.
 
 ## If GO — proposed port
 
-**Nur sinnvoll falls:**
-1. Bench gegen `crypto.scrypt` zeigt unerwartet ≥2× (z.B. weil Node's libuv-Async-Wrapper Overhead drauflegt) — **muss vor Port gemessen werden**
-2. Oder: bewusster Pitch als "Sync-API ohne libuv-Roundtrip" für hot paths (Node's Sync-Variante existiert, aber blockt Event-Loop)
+**Only makes sense if:**
+1. Bench against `crypto.scrypt` shows unexpected ≥2× (e.g. because Node's libuv async wrapper adds overhead) — **must be measured before porting**
+2. Or: conscious pitch as a "sync API without libuv roundtrip" for hot paths (Node's sync variant exists, but blocks the event loop)
 
-Sonst kein GO.
+Otherwise no GO.
 
 ## If NO-GO — BACKLOG entry
 
 ```markdown
-- **scrypt** / **scrypt-js** (~3M weekly). Node hat `crypto.scrypt` built-in als native C++-Implementierung. Realistic-median-Konkurrent ist Node-built-in, nicht scrypt-js. Erwarteter Speedup ~1,4× (siehe argon2-Pattern), verfehlt 2×-Green-Gate. scrypt-js-Downloads sind primär Browser/Bundler-Ökosystem — für unsere NAPI-Crate strukturell unerreichbar. Re-evaluate falls Bench gegen `crypto.scrypt` ≥2× zeigt.
+- **scrypt** / **scrypt-js** (~3M weekly). Node has `crypto.scrypt` built-in as a native C++ implementation. Realistic-median competitor is the Node built-in, not scrypt-js. Expected speedup ~1.4× (see argon2 pattern), misses 2× Green gate. scrypt-js downloads are primarily browser/bundler ecosystem — structurally unreachable for our NAPI crate. Re-evaluate if a bench against `crypto.scrypt` shows ≥2×.
 ```
 
-Section in `BACKLOG.md`: **FFI overhead > gain** (Variante: "Node-built-in dominiert")
+Section in `BACKLOG.md`: **FFI overhead > gain** (variant: "Node built-in dominates")

--- a/docs/perf-review/svgo.md
+++ b/docs/perf-review/svgo.md
@@ -1,70 +1,70 @@
 # Candidate review: `svgo`
 
-> **Status:** GO (Drop-in-orientiert mit Scope-Begrenzung) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-20
+> **Status:** GO (drop-in-oriented with scope limits) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-20
 
 ## Verdict
 
-`svgo` ist ein **SVG-Optimizer**: Parser → AST-Plugin-Pipeline → Serializer. Shape ist identisch zum bereits Green-shipped `sanitize-html` (und zu `commonmark`): Bytes-in / Bytes-out, substantielle Compute pro Byte, keine Callback-Grenze wenn die Plugin-Liste als statisches Config-Objekt (nicht als JS-Callbacks) übergeben wird. Rust hat bereits einen aktiv entwickelten und gegen `svgo` gebenchmarkten Konkurrenten: **`oxvg`** (Oxc-Team). Die Entscheidung ist hier nicht "ist Rust schnell genug", sondern "können wir oxvg/usvg sauber NAPI-wrappen mit genug Plugin-Parity".
+`svgo` is an **SVG optimizer**: parser → AST plugin pipeline → serializer. Shape is identical to the already-Green-shipped `sanitize-html` (and to `commonmark`): bytes-in / bytes-out, substantial compute per byte, no callback boundary if the plugin list is passed as a static config object (not as JS callbacks). Rust already has an actively developed competitor benchmarked against `svgo`: **`oxvg`** (Oxc team). The question here isn't "is Rust fast enough", it's "can we cleanly NAPI-wrap oxvg/usvg with enough plugin parity".
 
 ## JS package
 
-- **npm:** [`svgo`](https://www.npmjs.com/package/svgo) (~10 M/Woche, Q1 2026)
-- **Exports:** `optimize(svgString, config?) → { data, info }`, Plugin-Registry (`preset-default` mit ~30 Plugins, custom Plugins möglich), CLI
-- **Typical input:** SVG-String 0.5–500 KB (Icons: ~1–5 KB; Illustrations: 10–100 KB; exportierter Chart-Output oder Figma-SVG: bis MBs)
-- **Typical output:** minifizierter SVG-String, meist 30–70% kleiner als Input
-- **Realistic median use-case:** **Build-Time-Optimierung** von Icon-Sets und statischen SVG-Assets in Webpack/Vite/Rollup-Pipelines; **Runtime-Optimierung** in CMS/Editor-Uploads. Typisch: 100–10.000 SVGs pro Build, jedes 1–20 KB
+- **npm:** [`svgo`](https://www.npmjs.com/package/svgo) (~10M/week, Q1 2026)
+- **Exports:** `optimize(svgString, config?) → { data, info }`, plugin registry (`preset-default` with ~30 plugins, custom plugins possible), CLI
+- **Typical input:** SVG string 0.5–500 KB (icons: ~1–5 KB; illustrations: 10–100 KB; exported chart output or Figma SVG: up to MBs)
+- **Typical output:** minified SVG string, usually 30–70% smaller than input
+- **Realistic median use-case:** **build-time optimization** of icon sets and static SVG assets in Webpack/Vite/Rollup pipelines; **runtime optimization** in CMS/editor uploads. Typically: 100–10,000 SVGs per build, each 1–20 KB
 
 ## Rust replacement
 
 - **Candidate crate(s):**
-  - **`oxvg`** (primär) — vom Oxc-Team (Bun/Oxlint), aktiv gepflegt, MIT, benchmarkt explizit gegen svgo, >30 Plugin-Parity als Ziel. Q1 2026 noch pre-1.0 aber produktiv gereift.
-  - `usvg` (sekundär, Baseline) — von resvg-Team, parst SVG → intermediate representation, fokussiert auf Rendering nicht Optimization. Nicht drop-in-tauglich, aber hochwertiger SVG-Parser falls oxvg-Parser nicht reicht.
-  - `svgcleaner` (obsolet, archiviert 2020) — nicht verwenden
-- **Maintenance / license:** `oxvg` MIT, aktiv, monatliche Releases. Supply-Chain-Risiko niedrig (Oxc-Ökosystem, gleicher Vendor wie Oxlint).
+  - **`oxvg`** (primary) — from the Oxc team (Bun/Oxlint), actively maintained, MIT, benchmarks explicitly against svgo, >30 plugin parity as a goal. Q1 2026 still pre-1.0 but productively matured.
+  - `usvg` (secondary, baseline) — from the resvg team, parses SVG → intermediate representation, focused on rendering not optimization. Not drop-in-capable, but a high-quality SVG parser if the oxvg parser isn't enough.
+  - `svgcleaner` (obsolete, archived 2020) — don't use
+- **Maintenance / license:** `oxvg` MIT, active, monthly releases. Supply-chain risk low (Oxc ecosystem, same vendor as Oxlint).
 - **Known gotchas / divergences:**
-  - Plugin-Parity: svgo hat ~30 Core-Plugins (preset-default) + Ökosystem-Plugins. oxvg deckt die wichtigsten ab (removeComments, removeMetadata, removeEmptyAttrs, cleanupNumericValues, mergePaths, convertColors, removeHiddenElems, etc.) aber nicht 100%. v1-Scope auf `preset-default` begrenzen.
-  - Custom-JS-Plugins: svgo erlaubt User-JS-Plugins (`fn visit(node) { ... }`). Das ist die **`ejs`-Falle** — wenn ein User-Plugin pro Node einen JS-Callback triggert, bricht der Green-Plan. v1 **nicht anbieten**; Config-Plugins (Built-ins mit Optionen) sind ausreichend für >95% der Nutzer.
-  - Output-Byte-Parity: oxvg's Serializer schreibt marginal anders (Attribut-Ordering, Whitespace). Build-Tools mit Hash-basiertem Caching (vite's asset-hash) müssen re-hashen. Dokumentieren, nicht fixen.
+  - Plugin parity: svgo has ~30 core plugins (preset-default) + ecosystem plugins. oxvg covers the most important ones (removeComments, removeMetadata, removeEmptyAttrs, cleanupNumericValues, mergePaths, convertColors, removeHiddenElems, etc.) but not 100%. Limit v1 scope to `preset-default`.
+  - Custom JS plugins: svgo allows user JS plugins (`fn visit(node) { ... }`). That's the **`ejs` trap** — if a user plugin triggers a JS callback per node, the Green plan breaks. Don't offer in v1; config plugins (built-ins with options) are sufficient for >95% of users.
+  - Output byte parity: oxvg's serializer writes marginally differently (attribute ordering, whitespace). Build tools with hash-based caching (vite's asset hash) have to re-hash. Document, don't fix.
 
 ## BACKLOG check
 
-Kein Eintrag in `BACKLOG.md`. Kein `docs/packages.json`-Entry. Shape-Nachbar ist `sanitize-html` (shipped Green).
+No entry in `BACKLOG.md`. No `docs/packages.json` entry. Shape neighbor is `sanitize-html` (shipped Green).
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call work | Substantiell. Icon (~2 KB): 0.5–2 ms in svgo. Medium-SVG (~30 KB): 5–20 ms. Large-Export (~500 KB): 50–300 ms. Pro-Byte-Compute ist hoch (Parser + ~30 Plugin-Passes + Serializer). |
-| Input size | SVG-String 0.5 KB – 5 MB. Als `Buffer` oder UTF-8 `String` — beide flach via `docs/BASELINE.md` (<200 ns bis ~1 MB). |
-| Output size | Output meist 30–70% kleiner als Input. `String`/`Buffer`-Return flach. |
-| Stateful potential | **Hoch.** Plugin-Config + Compiled-Plugin-Chain könnte in `SvgOptimizer`-Klasse leben. Bei Build-Tools (10k Icons pro Build) spart das den Config-Parse pro Call. |
-| Batch realism | **Sehr hoch.** Build-Tools rufen `optimize()` in Schleife über alle SVG-Assets — `optimizeMany(svgs: string[], config)` kollabiert N FFI-Crossings zu einem und erlaubt Rayon-Parallelisierung über Workers. |
-| FFI-share | Single: ~5% bei Median-SVG (~10 ms Rust-Work, ~0.5 ms Input-Marshal). Batch-1000-Icons: <0.5%. |
+| Per-call work | Substantial. Icon (~2 KB): 0.5–2 ms in svgo. Medium SVG (~30 KB): 5–20 ms. Large export (~500 KB): 50–300 ms. Per-byte compute is high (parser + ~30 plugin passes + serializer). |
+| Input size | SVG string 0.5 KB – 5 MB. As `Buffer` or UTF-8 `String` — both flat via `docs/BASELINE.md` (<200 ns up to ~1 MB). |
+| Output size | Output usually 30–70% smaller than input. `String`/`Buffer` return flat. |
+| Stateful potential | **High.** Plugin config + compiled plugin chain could live in an `SvgOptimizer` class. For build tools (10k icons per build) that saves the config parse per call. |
+| Batch realism | **Very high.** Build tools call `optimize()` in a loop over all SVG assets — `optimizeMany(svgs: string[], config)` collapses N FFI crossings into one and allows Rayon parallelization across workers. |
+| FFI-share | Single: ~5% for median SVG (~10 ms Rust work, ~0.5 ms input marshal). Batch 1000 icons: <0.5%. |
 
 ## Classification reasoning
 
-`svgo` trifft den gleichen Green-Shape-Template-Satz wie `sanitize-html` / `commonmark`:
+`svgo` hits the same Green-shape template set as `sanitize-html` / `commonmark`:
 
-- ✅ **Bytes-in, Bytes-out** — kein Graph-Traversal über die FFI-Grenze
-- ✅ **Substantielle Compute pro Byte** — Parser + Plugin-Pipeline ist nicht trivial
-- ✅ **Keine Callback-Surface** (solange Custom-JS-Plugins ausgeschlossen bleiben)
-- ✅ **Stateful + Batch-natürlich** — Build-Tool-Use-Case liefert perfekte Amortisation
-- ✅ **Native Konkurrenz ist schwach** — svgo selbst ist pure-JS, keine nativen Bindings bisher gemainstreamed
-- ✅ **Rust-Äquivalent existiert und ist aktiv** — oxvg ist nicht hypothetisch
+- ✅ **Bytes-in, bytes-out** — no graph traversal across the FFI boundary
+- ✅ **Substantial compute per byte** — parser + plugin pipeline is not trivial
+- ✅ **No callback surface** (as long as custom JS plugins stay excluded)
+- ✅ **Stateful + batch-natural** — build-tool use-case gives perfect amortization
+- ✅ **Native competition is weak** — svgo itself is pure JS, no native bindings have been mainstreamed yet
+- ✅ **Rust equivalent exists and is active** — oxvg isn't hypothetical
 
-Der einzige strukturelle Fallstrick ist die **Custom-JS-Plugin-API**. svgo's public Contract erlaubt User-Code als Plugins (`{ name, fn(root) { ... } }`). Das ist der `ejs`-Killer — wenn wir das anbieten, triggert jede Node-Visit-Callback einen FFI-Roundtrip. v1 **darf das nicht exponieren**. Migration-Pfad für Power-User: entweder sie bleiben auf svgo, oder wir exponieren später `svgo-compat`-Plugin, das svgo als Fallback für custom-Plugin-Fälle lädt (analog zum `canvg`-Pattern für chart.js-Kompat).
+The only structural pitfall is the **custom JS plugin API**. svgo's public contract allows user code as plugins (`{ name, fn(root) { ... } }`). That's the `ejs` killer — if we offer that, every node-visit callback triggers an FFI roundtrip. v1 **must not expose it**. Migration path for power users: either they stay on svgo, or we later expose an `svgo-compat` plugin that loads svgo as a fallback for custom-plugin cases (analogous to the `canvg` pattern for chart.js compat).
 
-**Shape-Match:**
-- ✅ Wie `sanitize-html` (shipped Green): Parser + Transform + Serializer, bytes-in/bytes-out
-- ✅ Wie `commonmark`: Parser + Pipeline + Serializer, Batch-amortisierbar
-- ❌ **Nicht** wie `mime` / `deep-equal` (kein Short-Input-Hot-Loop, kein Trivial-Compute)
-- ❌ **Nicht** wie `chart.js` (keine Runtime-Abhängigkeit, keine Animations-Callbacks)
+**Shape match:**
+- ✅ Like `sanitize-html` (shipped Green): parser + transform + serializer, bytes-in/bytes-out
+- ✅ Like `commonmark`: parser + pipeline + serializer, batch-amortizable
+- ❌ **Not** like `mime` / `deep-equal` (no short-input hot loop, no trivial compute)
+- ❌ **Not** like `chart.js` (no runtime dependency, no animation callbacks)
 
-**Benchmark-Gap-Flag:** Green-Prediction braucht oxvg-Parity-Verifikation vor Shipping. Falls oxvg wichtige Plugins noch nicht hat (z.B. `mergePaths` oder `convertPathData` — die teuersten und gewinnträchtigsten), muss entweder auf oxvg-PRs gewartet oder custom-Port gebaut werden. Vor Port-Start: Cross-Check der oxvg-Plugin-Matrix gegen svgo's `preset-default`.
+**Benchmark gap flag:** the Green prediction needs oxvg parity verification before shipping. If oxvg is missing important plugins (e.g. `mergePaths` or `convertPathData` — the most expensive and most win-bearing), we either wait for oxvg PRs or build a custom port. Before the port starts: cross-check the oxvg plugin matrix against svgo's `preset-default`.
 
 ## If GO — proposed port
 
-- **Recommended crate-name:** `@amigo-labs/svgo` (Drop-in-orientiert, weil oxvg bereits diesen Contract anvisiert — Naming unterstützt Migration-Positionierung)
+- **Recommended crate name:** `@amigo-labs/svgo` (drop-in-oriented, because oxvg already targets this contract — naming supports migration positioning)
 - **Primary API sketch:**
   ```ts
   type SvgoPlugin =
@@ -80,13 +80,13 @@ Der einzige strukturelle Fallstrick ist die **Custom-JS-Plugin-API**. svgo's pub
     | { name: SvgoPlugin; params?: Record<string, unknown> };
 
   type SvgoConfig = {
-    plugins?: SvgoPlugin[];        // default: preset-default-äquivalent
+    plugins?: SvgoPlugin[];        // default: preset-default equivalent
     multipass?: boolean;           // default: false
     floatPrecision?: number;       // default: 3
   };
 
   type SvgoResult = {
-    data: string;                  // optimierter SVG
+    data: string;                  // optimized SVG
     info: { inputBytes: number; outputBytes: number; savedPercent: number };
   };
 
@@ -94,7 +94,7 @@ Der einzige strukturelle Fallstrick ist die **Custom-JS-Plugin-API**. svgo's pub
   export function optimizeMany(
     svgs: Array<string | Buffer>,
     config?: SvgoConfig
-  ): SvgoResult[];        // intern mit Rayon über N Cores parallelisiert
+  ): SvgoResult[];        // internally parallelized with Rayon across N cores
 
   export class SvgOptimizer {
     constructor(config?: SvgoConfig);
@@ -102,27 +102,27 @@ Der einzige strukturelle Fallstrick ist die **Custom-JS-Plugin-API**. svgo's pub
     optimizeMany(svgs: Array<string | Buffer>): SvgoResult[];
   }
   ```
-  **Nicht** angeboten: Custom-Function-Plugins. Dokumentiert als expliziter v1-Scope-Cut.
+  **Not** offered: custom function plugins. Documented as an explicit v1 scope cut.
 - **Must-have benchmark scenarios:**
-  - **Icon (2 KB):** 2-KB-Figma-Export-Icon, preset-default. Green-Gate: ≥ 2×.
-  - **Medium (30 KB):** Illustrations-SVG. Green-Gate: ≥ 3×.
-  - **Large (500 KB):** komplexes Chart-/Diagramm-SVG mit hunderten Paths. Green-Gate: ≥ 3×.
-  - **Batch-1000-Icons:** `optimizeMany(1000 × 2-KB-Icon)`. Green-Gate: ≥ 5× (Rayon-Parallelisierung über Cores).
-  - **Stateful-Reuse (100 Optimize-Calls auf gleicher `SvgOptimizer`-Instance):** misst Config-Cache-Hebel. Green-Gate: ≥ 1.1× Fresh-Instance-Baseline (moderat, nur Config-Parse-Ersparnis).
-- **Green gate:** alle fünf Szenarien + Plugin-Parity-Matrix für `preset-default` zu ≥95%.
+  - **Icon (2 KB):** 2 KB Figma-export icon, preset-default. Green gate: ≥ 2×.
+  - **Medium (30 KB):** illustration SVG. Green gate: ≥ 3×.
+  - **Large (500 KB):** complex chart/diagram SVG with hundreds of paths. Green gate: ≥ 3×.
+  - **Batch 1000 icons:** `optimizeMany(1000 × 2 KB icon)`. Green gate: ≥ 5× (Rayon parallelization across cores).
+  - **Stateful reuse (100 optimize calls on the same `SvgOptimizer` instance):** measures the config-cache lever. Green gate: ≥ 1.1× fresh-instance baseline (modest, only config-parse saving).
+- **Green gate:** all five scenarios + plugin-parity matrix for `preset-default` ≥95%.
 - **Risks:**
-  - **Plugin-Parity-Tail:** svgo's Plugin-Set ist das Produkt von 10 Jahren Community-Iteration. oxvg hat ~25 der 30 Core-Plugins. Die fehlenden 5 sind meist Edge-Case-Optimierungen (`reusePaths`, `sortAttrs`), die Gewinn < 2% bringen — können als "v1 not supported, pass through unchanged" dokumentiert werden.
-  - **Custom-Plugin-Surface:** Manche Enterprise-User haben eigene svgo-Plugins. Migration-Path: sie bleiben auf svgo, oder wir shippen `@amigo-labs/svgo` mit explizitem `externalPlugins: false`-Contract und sie entscheiden sich bewusst.
-  - **Output-Byte-Parity:** oxvg's Serializer optimiert anders als svgo's. Build-Tools mit Hash-basiertem Caching sehen einen einmaligen Cache-Invalidation-Spike beim Migration. Dokumentieren als Breaking-Change in v1.
-  - **oxvg-Maturity:** Q1 2026 pre-1.0. Falls oxvg nicht stabil genug ist für amigo's Release-Cadence, Option B: direkt auf `usvg`-Parser aufbauen und eigene Plugin-Pipeline schreiben (~2000 Zeilen Rust). Scope-Entscheidung vor Port-Start.
-  - **Baseline-Nuance:** SVG-String-Input ist UTF-8 — `String`-Argument triggert V8-UTF-16→UTF-8-Conversion. Für große SVGs (>100 KB) messbar. `Buffer`-Overload als primärer API-Pfad, `String` als Convenience-Shim. `docs/BASELINE.md:echoBuffer` deckt das.
+  - **Plugin-parity tail:** svgo's plugin set is the product of 10 years of community iteration. oxvg has ~25 of the 30 core plugins. The missing 5 are mostly edge-case optimizations (`reusePaths`, `sortAttrs`) that yield < 2% gain — can be documented as "v1 not supported, pass through unchanged".
+  - **Custom-plugin surface:** some enterprise users have their own svgo plugins. Migration path: they stay on svgo, or we ship `@amigo-labs/svgo` with an explicit `externalPlugins: false` contract and they opt in consciously.
+  - **Output byte parity:** oxvg's serializer optimizes differently from svgo's. Build tools with hash-based caching see a one-time cache-invalidation spike on migration. Document as a breaking change in v1.
+  - **oxvg maturity:** Q1 2026 pre-1.0. If oxvg isn't stable enough for amigo's release cadence, option B: build directly on the `usvg` parser and write our own plugin pipeline (~2000 lines of Rust). Scope decision before the port starts.
+  - **Baseline nuance:** SVG string input is UTF-8 — a `String` argument triggers V8's UTF-16 → UTF-8 conversion. Measurable for large SVGs (>100 KB). `Buffer` overload as the primary API path, `String` as a convenience shim. `docs/BASELINE.md:echoBuffer` covers this.
 
 ## If NO-GO — BACKLOG entry
 
-Nicht einschlägig — Prediction ist Green mit hoher Konfidenz (`sanitize-html`-Präzedenzfall). Falls Review nach Measurement doch Yellow wird:
+Not applicable — prediction is Green with high confidence (`sanitize-html` precedent). If review after measurement still turns Yellow:
 
 ```markdown
-- **svgo** (~10M/Woche). SVG-Optimizer. Shape-Green, aber oxvg-Plugin-Parity zu `preset-default` nicht ausreichend (<95% der Optimierungen angewendet, Output-Bytes nennenswert größer als svgo). Port eingefroren bis oxvg-1.0 oder Custom-Pipeline-Budget verfügbar. Siehe `docs/perf-review/svgo.md`.
+- **svgo** (~10M/week). SVG optimizer. Shape-Green, but oxvg plugin parity to `preset-default` insufficient (<95% of the optimizations applied, output bytes noticeably larger than svgo). Port frozen until oxvg-1.0 or a custom-pipeline budget is available. See `docs/perf-review/svgo.md`.
 ```
 
 Section: **Parity too expensive**.

--- a/docs/perf-review/tiktoken.md
+++ b/docs/perf-review/tiktoken.md
@@ -1,77 +1,77 @@
 # Candidate review: `tiktoken`
 
-> **Status:** SHIPPED v0.1 · **Predicted:** 🟢 Green vs. pure-JS / 🟡 Yellow vs. WASM · **Measured:** 🟢 Green vs. WASM + js-tiktoken / 🔴 Red vs. gpt-tokenizer · **Reviewed:** 2026-04-19
+> **Status:** SHIPPED v0.1 · **Predicted:** 🟢 Green vs. pure JS / 🟡 Yellow vs. WASM · **Measured:** 🟢 Green vs. WASM + js-tiktoken / 🔴 Red vs. gpt-tokenizer · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-`tiktoken-rs` ist ein sauberer Rust-Port des OpenAI-BPE-Tokenizers mit identischer Algorithm-Parität, API-Shape ist die "kanonische Green-Form" (ein Call pro Prompt, substantieller Compute, String-in/Uint32-raus). Gegen `js-tiktoken` (pure JS) sind 2,8× an 1 MB-Inputs extern gemessen — klares Green. Gegen `tiktoken` npm (WASM) sind 1,2-1,3× realistisch — strukturell nicht Green, weil WASM den gleichen Rust-Kern läuft und wir nur die FFI-Qualität gewinnen. **GO mit Positionierung als pure-JS-Killer, nicht als WASM-Killer**; der Schlüsselrisiko ist die kleine Input-Bucket, die vor Commit unbedingt gebenched werden muss.
+`tiktoken-rs` is a clean Rust port of the OpenAI BPE tokenizer with identical algorithm parity; the API shape is the "canonical Green form" (one call per prompt, substantial compute, string-in / Uint32-out). Against `js-tiktoken` (pure JS), 2.8× on 1 MB inputs is measured externally — clearly Green. Against `tiktoken` npm (WASM), 1.2–1.3× is realistic — structurally not Green, because WASM runs the same Rust core and we only win FFI quality. **GO with positioning as a pure-JS killer, not a WASM killer**; the key risk is the small-input bucket, which absolutely has to be benched before commit.
 
 ## JS package
 
-- **npm:** `tiktoken` (Autor: Dariusz Bolik, @dqbd) — WASM-Binding der Original-Python/Rust-Implementierung
-- **Downloads:** ~15 M weekly (Q1 2026 Schätzung, BACKLOG)
+- **npm:** `tiktoken` (author: Dariusz Bolik, @dqbd) — WASM binding of the original Python/Rust implementation
+- **Downloads:** ~15M weekly (Q1 2026 estimate, BACKLOG)
 - **Exports / API surface:**
-  - `get_encoding(name)` → `Tiktoken` — Encoder per Name (`cl100k_base`, `o200k_base`, `p50k_base`, …)
-  - `encoding_for_model(model)` → `Tiktoken` — Lookup per Model-ID
+  - `get_encoding(name)` → `Tiktoken` — encoder by name (`cl100k_base`, `o200k_base`, `p50k_base`, …)
+  - `encoding_for_model(model)` → `Tiktoken` — lookup by model ID
   - `tik.encode(text, allowed_special?)` → `Uint32Array`
-  - `tik.decode(tokens)` → `Uint8Array` (dann `TextDecoder` in JS)
-  - `tik.free()` — explizites WASM-Memory-Cleanup
-- **Typical input:** UTF-8-Text. Spannbreite: 10 Byte Chat-Snippet bis 100 KB+ RAG-Dokument
-- **Typical output:** `Uint32Array` mit Token-IDs. Pro Token ca. 4 Zeichen Text → Output-Größe ~25 % der Input-Länge
-- **Realistic median use-case:** **RAG-Pipeline-Preprocessing.** Chunk ein Dokument (5-50 KB), encode zum Zählen/Schneiden, decode selten. Sekundärer Use-Case: **Cost-Gate vor API-Call**: `countTokens(prompt)` auf ~200-2000 Token Chat-Messages. Niemals in einem Hot-Loop mit 10-Byte-Strings
+  - `tik.decode(tokens)` → `Uint8Array` (then `TextDecoder` in JS)
+  - `tik.free()` — explicit WASM memory cleanup
+- **Typical input:** UTF-8 text. Range: 10-byte chat snippet to 100 KB+ RAG document
+- **Typical output:** `Uint32Array` with token IDs. About 4 text characters per token → output size ~25% of input length
+- **Realistic median use-case:** **RAG pipeline preprocessing.** Chunk a document (5–50 KB), encode to count/cut, decode rarely. Secondary use-case: **cost gate before API call**: `countTokens(prompt)` on ~200–2000 token chat messages. Never in a hot loop with 10-byte strings
 
 ## Rust replacement
 
 - **Candidate crate(s):** `tiktoken-rs 0.11.0` (Arnaud Gourlay + Roger Zurawicki)
-- **Maintenance / license:** Aktiv gepflegt (Release 2026-04-08), MIT, 381 Stars, 31 Releases
+- **Maintenance / license:** actively maintained (release 2026-04-08), MIT, 381 stars, 31 releases
 - **Known gotchas / divergences:**
-  - Encoder-Funktionen geben `Vec<u32>` — sauber auf `Uint32Array` mapbar (kein `BigInt` wie bei xxhash)
-  - Singleton-Pattern für wiederholte Calls vorgesehen (BPE-Table ist ~10-50 MB RAM pro Encoding) — **muss** als NAPI-Class laufen, nicht als freie Funktion
-  - Special Tokens sind per-Encoding konfigurierbar; API muss `allowed_special` / `disallowed_special` durchreichen (Parität mit tiktoken npm)
-  - `o200k_harmony` (gpt-oss) ist in tiktoken-rs 0.11 vorhanden — neueres Encoding, in älteren js-tiktoken-Versionen evtl. nicht. Parity-Check pro Encoding nötig
+  - Encoder functions return `Vec<u32>` — cleanly mappable to `Uint32Array` (no `BigInt` as with xxhash)
+  - Singleton pattern planned for repeated calls (BPE table is ~10–50 MB RAM per encoding) — **must** run as a NAPI class, not as a free function
+  - Special tokens are per-encoding configurable; the API must pass `allowed_special` / `disallowed_special` through (parity with tiktoken npm)
+  - `o200k_harmony` (gpt-oss) is present in tiktoken-rs 0.11 — newer encoding, possibly missing in older js-tiktoken versions. Parity check per encoding required
 
 ## BACKLOG check
 
 > **tiktoken** / **js-tiktoken** (~15M / ~3M). BPE tokenization over documents via `tiktoken-rs`. Batch-encode is the canonical green shape — one call per prompt, compute dominates.
 
-User hat explizit `rust-check` angefordert → Backlog-Konsens wird hier **verfeinert**: "Green" war an pure-JS (`js-tiktoken`) gedacht; gegen WASM-`tiktoken` ist Yellow realistisch.
+The user explicitly requested `rust-check` → the backlog consensus is **refined** here: "Green" was thought of versus pure JS (`js-tiktoken`); versus WASM `tiktoken`, Yellow is realistic.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Medium:** 1 MB Text ≈ 360 ms (tiktoken-rs Referenz, externer Bench). 1 KB ≈ 0,5 ms. 100 Byte ≈ ~5-20 µs. Für Chat-Messages (200-2 k Tokens, ~1-8 KB) liegt echter Compute bei 0,5-4 ms — FFI-Share **unter 1 %** |
-| Input size distribution | UTF-8-String. Pro 100 KB ~35 µs FFI-String-Konversion (BASELINE.md). Bei Median-Input 1-10 KB also ~0,3-3,5 µs Konversion |
-| Output size distribution | `Vec<u32>` via `Uint32Array` — **unbedingt als TypedArray zurückgeben, nicht als `Vec<u32>`-JS-Array.** 1000-Element-`Vec<u32>` kostet ~43 µs (BASELINE.md §4); derselbe Inhalt als `Uint32Array`-Buffer ~180 ns konstant |
-| Reusable setup (stateful potential) | **Massiv.** BPE-Encoder-State ist 10-50 MB Merge-Tabelle plus kompiliertes Regex. Per-Call-Load ist unakzeptabel → **NAPI-Class-API pflichtig** (analog `hnswlib-node`-Pattern aus BACKLOG) |
-| Batch-usage realism | **Optional.** Primärer Pattern ist "ein Call pro Prompt", schon FFI-günstig. Batch-API (`encodeMany(texts: string[])`) macht bei RAG-Chunk-Arrays Sinn — Nice-to-have, nicht pflicht |
-| FFI-share estimate vs. Rust work | <1 % bei Median (Chat-Message oder RAG-Chunk); ~5-20 % bei Cost-Gate auf 10-Byte-Strings; <0,1 % bei Large-Dokumenten |
+| Per-call algorithmic work | **Medium:** 1 MB text ≈ 360 ms (tiktoken-rs reference, external bench). 1 KB ≈ 0.5 ms. 100 bytes ≈ ~5–20 µs. For chat messages (200–2k tokens, ~1–8 KB) real compute is 0.5–4 ms — FFI share **below 1%** |
+| Input size distribution | UTF-8 string. ~35 µs FFI string conversion per 100 KB (BASELINE.md). At median input 1–10 KB that's ~0.3–3.5 µs of conversion |
+| Output size distribution | `Vec<u32>` via `Uint32Array` — **must** be returned as TypedArray, not as a `Vec<u32>` JS array. A 1000-element `Vec<u32>` costs ~43 µs (BASELINE.md §4); the same content as a `Uint32Array` buffer is ~180 ns constant |
+| Reusable setup (stateful potential) | **Massive.** BPE encoder state is a 10–50 MB merge table plus compiled regex. Per-call load is unacceptable → **NAPI class API mandatory** (analogous to `hnswlib-node` pattern from BACKLOG) |
+| Batch-usage realism | **Optional.** The primary pattern is "one call per prompt", which is already FFI-friendly. A batch API (`encodeMany(texts: string[])`) makes sense for RAG chunk arrays — nice-to-have, not mandatory |
+| FFI-share estimate vs. Rust work | <1% at median (chat message or RAG chunk); ~5–20% at a cost gate on 10-byte strings; <0.1% on large documents |
 
 ## Classification reasoning
 
-Dies ist ein zweigleisiger Fall, den eine einzelne Tier-Klassifikation nicht sauber abbildet.
+This is a two-track case that a single tier classification can't represent cleanly.
 
-**Gegen `js-tiktoken` (pure-JS, ~3 M weekly): 🟢 Green**
-- Externer Bench: 359 ms (Rust) vs. 1006 ms (pure-JS) auf 1 MB → **2,80×** — über Green-Gate
-- Auf Medium (Chat-Snippet, ~1 KB): 0,54 ms Rust vs. 0,96 ms pure-JS → **1,78×** — knapp unter Green, nahe am Gate
-- Auf Small (<100 Byte): unbestimmt, muss gebenched werden. FFI-Floor 109 ns + String-Marshal macht den Unterschied
-- Pure-JS hat eine nicht-triviale V8-Hot-Loop für Merge-Steps; Rust gewinnt über `fancy-regex` + `fxhash` + ohne GC-Pressure
+**Against `js-tiktoken` (pure JS, ~3M weekly): 🟢 Green**
+- External bench: 359 ms (Rust) vs. 1006 ms (pure JS) on 1 MB → **2.80×** — above the Green gate
+- On medium (chat snippet, ~1 KB): 0.54 ms Rust vs. 0.96 ms pure JS → **1.78×** — just below Green, close to the gate
+- On small (<100 bytes): indeterminate, must be benched. FFI floor 109 ns + string marshal makes the difference
+- Pure JS has a non-trivial V8 hot loop for merge steps; Rust wins via `fancy-regex` + `fxhash` + no GC pressure
 
-**Gegen `tiktoken` npm (WASM, ~15 M weekly): 🟡 Yellow**
-- Externer Bench: 360 ms vs. 452 ms auf 1 MB → **1,25×**. Strukturell begrenzt weil WASM denselben Rust-Kern tokenizer läuft
-- Auf Medium: 0,54 ms vs. 0,78 ms → **1,44×**
-- Wir gewinnen nur FFI-Qualität (napi-rs vs. WASM-Bridge) und Compile-Flags. Das sind ~10-25 %, nie 2×
+**Against `tiktoken` npm (WASM, ~15M weekly): 🟡 Yellow**
+- External bench: 360 ms vs. 452 ms on 1 MB → **1.25×**. Structurally bounded because WASM runs the same Rust tokenizer core
+- On medium: 0.54 ms vs. 0.78 ms → **1.44×**
+- We only win FFI quality (napi-rs vs. WASM bridge) and compile flags. That's ~10–25%, never 2×
 
-**Klassische Referenzpatterns:**
-- **Wie** `argon2`/`bcrypt`/`sanitize-html`: substanzielle Compute pro Call, bytes/string-in, array/string-out, amortisierter Setup-State. Check.
-- **Nicht** wie `mime`/`deep-equal`/`levenshtein`: kein ns-skaliger Hot-Loop, kein trivial-per-call-Work
-- **Achtung** wie `xxhash-batch`: falls Output als `Vec<u32>`-JS-Array (nicht `Uint32Array`) returned wird, kippt es ins FFI-Marshalling-Debakel. **Strikt `Uint32Array` returnen.**
+**Classic reference patterns:**
+- **Like** `argon2`/`bcrypt`/`sanitize-html`: substantial compute per call, bytes/string-in, array/string-out, amortized setup state. Check.
+- **Not** like `mime`/`deep-equal`/`levenshtein`: no ns-scale hot loop, no trivial-per-call work
+- **Careful** like `xxhash-batch`: if output is returned as a `Vec<u32>` JS array (not `Uint32Array`) it tips into an FFI marshalling debacle. **Strictly return `Uint32Array`.**
 
-**Einziger echter Small-Input-Fallstrick:** Wenn der median Use-Case "zähle Tokens in einem 10-Byte-Prompt" ist (z. B. Cost-Gate vor API-Call mit nur Benutzer-Input), landen wir im Bereich wo FFI vergleichbar zur Compute ist. Pure-JS-Tokenizer rechnet das in ~1-2 µs; Rust via NAPI vermutlich ~1-3 µs. Nicht katastrophal, aber kein Gewinn. **Pflicht: 10-Byte- und 100-Byte-Bucket vor Commit benchen, nicht erst nach Port.**
+**The only real small-input pitfall:** if the median use-case is "count tokens in a 10-byte prompt" (e.g. cost gate before API call with only user input), we land in a region where FFI is comparable to the compute. A pure-JS tokenizer does this in ~1–2 µs; Rust via NAPI probably ~1–3 µs. Not catastrophic, but no win. **Mandatory: bench the 10-byte and 100-byte bucket before commit, not only after the port.**
 
 ## If GO — proposed port
 
-- **Recommended crate-name:** `@amigo-labs/tiktoken`
+- **Recommended crate name:** `@amigo-labs/tiktoken`
 - **Primary API sketch:**
   ```ts
   export type Encoding =
@@ -86,82 +86,82 @@ Dies ist ein zweigleisiger Fall, den eine einzelne Tier-Klassifikation nicht sau
 
     encode(text: string, allowedSpecial?: string[] | null): Uint32Array
     decode(tokens: Uint32Array): string
-    countTokens(text: string): number  // fast-path, skip alloc of Uint32Array
-    encodeMany(texts: string[]): Uint32Array[]  // batch over RAG-chunks
+    countTokens(text: string): number  // fast path, skip alloc of Uint32Array
+    encodeMany(texts: string[]): Uint32Array[]  // batch over RAG chunks
   }
   ```
-  → **NAPI-Class ist nicht verhandelbar.** Freie Funktion pro Call würde BPE-Table pro Call neu laden = unbrauchbar.
-  → `Uint32Array` ist strikt (nicht `number[]`) — sonst FFI-Marshalling-Debakel (BASELINE §4).
-  → `countTokens` als Fast-Path: returned nur die Länge, vermeidet Uint32Array-Allokation wenn der Caller nur budgetieren will. Green-Gate-kritisch für den Cost-Gate-Use-Case.
+  → **NAPI class is non-negotiable.** A free function per call would reload the BPE table per call = unusable.
+  → `Uint32Array` is strict (not `number[]`) — otherwise FFI marshalling debacle (BASELINE §4).
+  → `countTokens` as a fast path: returns just the length, avoids the Uint32Array allocation when the caller only wants to budget. Green-gate critical for the cost-gate use-case.
 
 - **Must-have benchmark scenarios:**
-  - **Small:** `countTokens("Hello world")` (10 B) — FFI-Floor-Exposé
-  - **Medium:** `encode(chatMessage)` mit 500 Token Input (~2 KB) — häufigster realer Call
-  - **Large:** `encode(ragDocument)` mit 5 k / 25 k Token (~20 KB / 100 KB) — Chunking-Use-Case
-  - **Round-trip:** `decode(encode(x))` auf Medium — Parität + Decode-Perf
-  - **Batch:** `encodeMany(100 × chat_message)` vs. Loop in JS — Batch-API-Rechtfertigung
-  - **Baseline-Pflicht:** **beide** JS-Pakete — `tiktoken` (WASM) **und** `js-tiktoken` (pure JS). Die zwei haben verschiedene Zielnutzergruppen und ergeben verschiedene Speedup-Stories
-  - **Encoding-Load-Time:** einmalig `getEncoding("cl100k_base")` — verifizieren dass BPE-Table-Load im Class-Constructor bleibt, nicht pro encode()
+  - **Small:** `countTokens("Hello world")` (10 B) — FFI-floor exposé
+  - **Medium:** `encode(chatMessage)` with 500-token input (~2 KB) — most frequent real call
+  - **Large:** `encode(ragDocument)` with 5k / 25k tokens (~20 KB / 100 KB) — chunking use-case
+  - **Round-trip:** `decode(encode(x))` on medium — parity + decode perf
+  - **Batch:** `encodeMany(100 × chat_message)` vs. a loop in JS — batch API justification
+  - **Baseline required:** **both** JS packages — `tiktoken` (WASM) **and** `js-tiktoken` (pure JS). They have different target users and produce different speedup stories
+  - **Encoding load time:** a single `getEncoding("cl100k_base")` — verify that the BPE table load stays in the class constructor, not per `encode()`
 
 - **Acceptance thresholds (Green gate):**
-  - ≥2,0× vs. `js-tiktoken` bei Medium und Large (Hauptzielbaseline)
-  - ≥1,0× vs. `js-tiktoken` bei Small (Floor-Check)
-  - ≥1,2× vs. `tiktoken` (WASM) bei Medium und Large (Yellow akzeptabel hier)
-  - ≥0,9× vs. `tiktoken` (WASM) bei Small (darf leicht verlieren, aber kein Faktor-2-Einbruch)
-  - 100 % Parity: `encode` / `decode` Round-Trip über 1000 Random-Strings pro Encoding
-  - Cross-Verify: Outputs bit-identisch zu `tiktoken` npm auf Fixture-Korpus
+  - ≥2.0× vs. `js-tiktoken` at medium and large (main target baseline)
+  - ≥1.0× vs. `js-tiktoken` at small (floor check)
+  - ≥1.2× vs. `tiktoken` (WASM) at medium and large (Yellow acceptable here)
+  - ≥0.9× vs. `tiktoken` (WASM) at small (may lose marginally, but no 2× drop)
+  - 100% parity: `encode` / `decode` round-trip over 1000 random strings per encoding
+  - Cross-verify: outputs bit-identical to `tiktoken` npm on a fixture corpus
 
 - **Risks:**
-  1. **Small-Input-Regime unklar** — der kritische Punkt. Wenn Nutzer typischerweise 10-Byte-Strings tokenizen (Cost-Gate-Pattern), verlieren wir vermutlich gegen pure-JS (V8 JITs die BPE-Schleife für kurze Inputs gut). Muss vor Commit gemessen werden, sonst Yellow-Fallback
-  2. **WASM ist "good enough"** — User von `tiktoken` npm sehen <1,3× und wechseln evtl. nicht. Gewinn primär: prebuild-Binaries statt WASM-Bundle (~1 MB im Node-Modules-Tree weniger), keine WASM-Init-Latenz beim Startup. Positionierung wichtig
-  3. **BPE-Table-Bundle-Size** — `tiktoken-rs` bundelt die Merge-Tabellen statisch in die Binary. Pro Encoding ~2-5 MB → Gesamtbinary könnte ~20 MB werden bei allen 7 Encodings. Mitigation: Features pro Encoding gated, default `cl100k_base + o200k_base`, Rest opt-in via `features = ["p50k", "gpt2"]`
-  4. **`free()`-Semantik** — `tiktoken` npm zwingt User zu `.free()` wegen WASM-Memory. Bei NAPI ist das durch GC abgedeckt — kleine API-Asymmetrie, aber Parity-OK (no-op `free()` für Migration)
-  5. **Encoding-Download-Pattern** — Einige User nutzen `tiktoken`'s `load()`-API um Encodings from URL zu laden (Browser/Offline-Szenario). Bei native Rust ist das nicht relevant (Node-Context), aber API-Lücke markieren
-  6. **o200k_harmony** ist neu (Q1 2026, gpt-oss). Parity gegen `js-tiktoken` nur falls dort implementiert — evtl. nur gegen `tiktoken` WASM testbar
+  1. **Small-input regime unclear** — the critical point. If users typically tokenize 10-byte strings (cost-gate pattern), we probably lose against pure JS (V8 JITs the BPE loop well for short inputs). Has to be measured before commit, otherwise Yellow fallback
+  2. **WASM is "good enough"** — users of `tiktoken` npm see <1.3× and may not switch. Primary gain: prebuilt binaries instead of WASM bundle (~1 MB less in the node-modules tree), no WASM init latency at startup. Positioning matters
+  3. **BPE-table bundle size** — `tiktoken-rs` bundles the merge tables statically into the binary. Per encoding ~2–5 MB → total binary could be ~20 MB with all 7 encodings. Mitigation: features gated per encoding, default `cl100k_base + o200k_base`, rest opt-in via `features = ["p50k", "gpt2"]`
+  4. **`free()` semantics** — `tiktoken` npm forces users to call `.free()` because of WASM memory. With NAPI that's covered by GC — small API asymmetry, but parity OK (no-op `free()` for migration)
+  5. **Encoding download pattern** — some users use `tiktoken`'s `load()` API to load encodings from a URL (browser/offline scenario). Not relevant for native Rust (Node context), but flag the API gap
+  6. **o200k_harmony** is new (Q1 2026, gpt-oss). Parity against `js-tiktoken` only if it's implemented there — may only be testable against `tiktoken` WASM
 
 ## If NO-GO — BACKLOG entry
 
-N/A — GO empfohlen mit qualifizierter Klassifikation (Green vs. pure-JS, Yellow vs. WASM).
+N/A — GO recommended with a qualified classification (Green vs. pure JS, Yellow vs. WASM).
 
-## Phase-B Messung (2026-04-19, linux-x64, Node v22)
+## Phase B measurement (2026-04-19, linux-x64, Node v22)
 
-Implementiert in `crates/tiktoken/` gegen `tiktoken-rs 0.11`. Drei Baselines, drei Größen-Buckets (`cl100k_base`, ops/sec, höher = besser):
+Implemented in `crates/tiktoken/` against `tiktoken-rs 0.11`. Three baselines, three size buckets (`cl100k_base`, ops/sec, higher = better):
 
-| Szenario | @amigo-labs/tiktoken | tiktoken (WASM) | js-tiktoken | gpt-tokenizer |
+| Scenario | @amigo-labs/tiktoken | tiktoken (WASM) | js-tiktoken | gpt-tokenizer |
 |---|---:|---:|---:|---:|
-| encode 10 B (small) | **164 256 hz** | 7 006 hz | 73 907 hz | 586 445 hz |
-| encode ~2 KB (medium) | **5 999 hz** | 1 445 hz | 1 698 hz | 14 855 hz |
+| encode 10 B (small) | **164,256 hz** | 7,006 hz | 73,907 hz | 586,445 hz |
+| encode ~2 KB (medium) | **5,999 hz** | 1,445 hz | 1,698 hz | 14,855 hz |
 | encode ~90 KB (large) | **126 hz** | 38 hz | 28 hz | 269 hz |
-| 100 × 10 B (RAG batch) | **1 471 hz** | 67 hz | — | 4 364 hz |
+| 100 × 10 B (RAG batch) | **1,471 hz** | 67 hz | — | 4,364 hz |
 
-Speedup-Matrix (>1 = wir schneller):
+Speedup matrix (>1 = we're faster):
 
-| Szenario | vs. WASM | vs. js-tiktoken | vs. gpt-tokenizer |
+| Scenario | vs. WASM | vs. js-tiktoken | vs. gpt-tokenizer |
 |---|---:|---:|---:|
-| Small | **23,4×** ✅ | **2,22×** ✅ | **0,28×** ❌ |
-| Medium | **4,15×** ✅ | **3,53×** ✅ | **0,40×** ❌ |
-| Large | **3,32×** ✅ | **4,48×** ✅ | **0,47×** ❌ |
+| Small | **23.4×** ✅ | **2.22×** ✅ | **0.28×** ❌ |
+| Medium | **4.15×** ✅ | **3.53×** ✅ | **0.40×** ❌ |
+| Large | **3.32×** ✅ | **4.48×** ✅ | **0.47×** ❌ |
 
-**Vorhersage vs. Realität:**
-- Gegen `tiktoken` (WASM): vorhergesagt Yellow (~1,25×), gemessen **Green** (3–23×). Vorhersage war zu pessimistisch — der externe Benchmark ([maxim-saplin/tiktoken-bench](https://github.com/maxim-saplin/tiktoken-bench)) hat WASM gegen Python/Rust-Native gemessen, nicht gegen napi-rs. Der napi-rs-Pfad ist deutlich günstiger als WASM-Bridge + wasm-bindgen-Marshalling.
-- Gegen `js-tiktoken`: vorhergesagt 2,8× Green, gemessen **2-4,5× Green**. On-target.
-- Gegen `gpt-tokenizer`: **nicht antizipiert** — vorhergesagt in `gpt-tokenizer.md` als "pure-JS ~2,8× slower" analog zu js-tiktoken. Gemessen **gpt-tokenizer ist 2-3× schneller als wir**.
+**Prediction vs. reality:**
+- Against `tiktoken` (WASM): predicted Yellow (~1.25×), measured **Green** (3–23×). The prediction was too pessimistic — the external benchmark ([maxim-saplin/tiktoken-bench](https://github.com/maxim-saplin/tiktoken-bench)) measured WASM against Python/Rust native, not against napi-rs. The napi-rs path is significantly cheaper than WASM bridge + wasm-bindgen marshalling.
+- Against `js-tiktoken`: predicted 2.8× Green, measured **2–4.5× Green**. On target.
+- Against `gpt-tokenizer`: **not anticipated** — predicted in `gpt-tokenizer.md` as "pure JS ~2.8× slower" analogous to js-tiktoken. Measured **gpt-tokenizer is 2–3× faster than us**.
 
-**Warum `gpt-tokenizer` uns schlägt:**
-- LRU-Merge-Cache in der BPE-Schleife — wiederholte Bigram-Paare innerhalb eines Textes werden cached
-- V8-JIT optimiert den heißen Merge-Loop extrem aggressiv (inline caches für die `Map`-lookups)
-- Pure JS hat keine FFI-Fixkosten — selbst unsere 109 ns Floor schlagen durch
+**Why `gpt-tokenizer` beats us:**
+- LRU merge cache in the BPE loop — repeated bigram pairs within a text are cached
+- V8's JIT aggressively optimizes the hot merge loop (inline caches for the `Map` lookups)
+- Pure JS has no FFI fixed costs — even our 109 ns floor shows up
 
-**Warum `js-tiktoken` *nicht* so schnell ist (obwohl auch pure-JS):**
-- Kein LRU-Cache
-- Weniger monomorphe Hot-Path-Struktur
-- Auf dem 1-MB-externen-Bench 3× langsamer als Rust — das deckt sich mit unseren Messungen
+**Why `js-tiktoken` is *not* that fast (even though it's also pure JS):**
+- No LRU cache
+- Less monomorphic hot-path structure
+- On the 1-MB external bench 3× slower than Rust — that matches our measurements
 
-**Endklassifikation: 🟡 Yellow (mixed).** Grüner Win gegen `tiktoken` + `js-tiktoken` (18 M weekly DL kombiniert); Red gegen `gpt-tokenizer` (1 M weekly). Positionierung im README: "drop-in für tiktoken und js-tiktoken; **kein** Ersatz für gpt-tokenizer". 88 Tests grün (12 Unit + 70 Parität + 6 Fuzz).
+**Final classification: 🟡 Yellow (mixed).** Green win vs. `tiktoken` + `js-tiktoken` (18M weekly DL combined); Red vs. `gpt-tokenizer` (1M weekly). Positioning in the README: "drop-in for tiktoken and js-tiktoken; **not** a replacement for gpt-tokenizer". 88 tests green (12 unit + 70 parity + 6 fuzz).
 
-**Optionen für Phase C:**
-- **C.6 Algorithm:** LRU-Merge-Cache in `tiktoken-rs` upstream einbringen oder als lokaler Wrapper — realistisches 1,5-2× Upside im Medium-Bucket
-- **C.2 Output-Type:** `encodeOrdinary` könnte als `Buffer` mit LE-u32 statt `Uint32Array` zurückgeben (BASELINE §3: ~180 ns flat vs. Uint32Array-Alloc). Vermutlich <10 % Gain
-- **Yellow halten:** positionieren als "tiktoken-WASM-Killer" (15 M weekly), gpt-tokenizer-User ignorieren (1 M weekly). Defensive Empfehlung
+**Options for Phase C:**
+- **C.6 algorithm:** submit the LRU merge cache upstream to `tiktoken-rs` or ship as a local wrapper — realistic 1.5–2× upside in the medium bucket
+- **C.2 output type:** `encodeOrdinary` could return a `Buffer` with LE u32 instead of `Uint32Array` (BASELINE §3: ~180 ns flat vs. Uint32Array alloc). Probably <10% gain
+- **Hold Yellow:** position as a "tiktoken-WASM killer" (15M weekly), ignore gpt-tokenizer users (1M weekly). Defensive recommendation
 
-**Empfehlung:** Yellow shippen, Phase-C nur wenn upstream tiktoken-rs den LRU-Cache akzeptiert. Die WASM-User-Migration ist der primäre ROI.
+**Recommendation:** ship Yellow, only do Phase C if upstream tiktoken-rs accepts the LRU cache. The WASM user migration is the primary ROI.

--- a/docs/perf-review/tough-cookie.md
+++ b/docs/perf-review/tough-cookie.md
@@ -1,44 +1,44 @@
 # Candidate review: `tough-cookie`
 
-> **Status:** NO-GO · **Predicted:** 🟡 Yellow (Perf) / 🔴 Red (Scope) · **Reviewed:** 2026-04-19
+> **Status:** NO-GO · **Predicted:** 🟡 Yellow (perf) / 🔴 Red (scope) · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-Cookie-Parsing ist string-lastig und kurz — FFI-Trap-Shape für den Parse-Pfad. Der eigentliche Aufwand ist Cookie-Jar-State + Public Suffix List + IDN + RFC-6265-bis-Kompat; das ist ein Monatsprojekt für einen Yellow-Win.
+Cookie parsing is string-heavy and short — FFI-trap shape for the parse path. The actual work is cookie-jar state + Public Suffix List + IDN + RFC 6265-bis compatibility; that's a months-long project for a Yellow win.
 
 ## JS package
 
 - **npm:** `tough-cookie`
-- **Downloads:** ~157M/Woche
+- **Downloads:** ~157M/week
 - **Exports / API surface:** `Cookie`, `CookieJar`, `Store`, `MemoryCookieStore`, `parseDate`, `canonicalDomain`, `permuteDomain`, `getPublicSuffix`
-- **Typical input:** `Set-Cookie`-Header (~100–300 B) + Request-URL
-- **Typical output:** `Cookie`-Instanz oder Cookie-Liste bei Jar-Retrieval
-- **Realistic median use-case:** HTTP-Client speichert Cookie pro Response (eine Handvoll pro Request), liest sie pro Request; State-heavy, nicht Hot-Loop
+- **Typical input:** `Set-Cookie` header (~100–300 B) + request URL
+- **Typical output:** `Cookie` instance or cookie list on jar retrieval
+- **Realistic median use-case:** HTTP client stores cookie per response (a handful per request), reads them per request; state-heavy, not a hot loop
 
 ## Rust replacement
 
-- **Candidate crate(s):** `cookie` (parse/format), `publicsuffix` (PSL), `idna` (IDN). Kein direkter `tough-cookie`-Äquivalent als ein Crate
-- **Maintenance / license:** alle aktiv, MIT
-- **Known gotchas / divergences:** `tough-cookie` implementiert RFC 6265 + 6265-bis + WHATWG-Quirks (z.B. `same-site` eval, prefix-rules `__Host-`/`__Secure-`, `expires` Datumsformat-Heuristiken); Browser-Kompat-Tests sind umfangreich
+- **Candidate crate(s):** `cookie` (parse/format), `publicsuffix` (PSL), `idna` (IDN). No direct `tough-cookie` equivalent as a single crate
+- **Maintenance / license:** all active, MIT
+- **Known gotchas / divergences:** `tough-cookie` implements RFC 6265 + 6265-bis + WHATWG quirks (e.g. `same-site` eval, prefix rules `__Host-`/`__Secure-`, `expires` date format heuristics); browser-compat tests are extensive
 
 ## BACKLOG check
 
-BACKLOG: *Parity too expensive* — bestätigt. Seit der letzten Sichtung keine Änderung am Parity-Horizont.
+BACKLOG: *Parity too expensive* — confirmed. No change to the parity horizon since the last look.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Parse eines Cookie-Headers: ~500 ns – 2 µs in JS. FFI-Floor 109 ns = 5–20% Grundlast |
-| Input size distribution | 50–500 B Strings, direkt im FFI-Trap-Bereich |
-| Output size distribution | Einzelnes Cookie-Objekt mit ~10 Feldern — Object-Materialisierung über NAPI ist teuer |
-| Reusable setup (stateful potential) | PSL + Jar als NAPI-Class sinnvoll — aber JS `Jar` ist schon ein Objekt, der Win ist marginal |
-| Batch-usage realism | Niedrig (3–5 Cookies pro Request) |
-| FFI-share estimate vs. Rust work | Hoch — pro-Cookie FFI + Object-Output-Kosten essen Rust-Gain |
+| Per-call algorithmic work | Parse a cookie header: ~500 ns – 2 µs in JS. FFI floor 109 ns = 5–20% baseline cost |
+| Input size distribution | 50–500 B strings, directly in the FFI-trap zone |
+| Output size distribution | A single cookie object with ~10 fields — object materialization over NAPI is expensive |
+| Reusable setup (stateful potential) | PSL + jar as a NAPI class makes sense — but the JS `Jar` is already an object, the win is marginal |
+| Batch-usage realism | Low (3–5 cookies per request) |
+| FFI-share estimate vs. Rust work | High — per-cookie FFI + object output cost eat the Rust gain |
 
 ## Classification reasoning
 
-Selbst wenn der Rust-Parser 3× schneller wäre als `tough-cookie`, landet der Realworld-Call bei ~700 ns (FFI + Object-Materialisierung) vs. `tough-cookie` ~1.5 µs → 2× Win. Aber: PSL-Integration, IDN-Handling, `canonicalDomain`-Edge-Cases, Browser-Kompat-Suite = Wochen an Engineering. Und der Win verpufft, weil HTTP-Clients keine 100k Cookies/s parsen — sie parsen ~3 pro Request und warten dann auf Netzwerk. Die Perf-Rendite ist strukturell niedrig.
+Even if the Rust parser were 3× faster than `tough-cookie`, the real-world call lands at ~700 ns (FFI + object materialization) vs. `tough-cookie`'s ~1.5 µs → 2× win. But: PSL integration, IDN handling, `canonicalDomain` edge cases, browser-compat suite = weeks of engineering. And the win evaporates, because HTTP clients don't parse 100k cookies/s — they parse ~3 per request and then wait on the network. The perf return is structurally low.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/typst.md
+++ b/docs/perf-review/typst.md
@@ -1,75 +1,75 @@
 # Candidate review: `typst`
 
-> **Status:** GO (als neues Paket, kein Drop-in) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-20
+> **Status:** GO (as a new package, not a drop-in) · **Predicted:** 🟢 Green · **Reviewed:** 2026-04-20
 
 ## Verdict
 
-`typst` als Library ist ein Lehrbuch-Green-Shape, strukturell analog zu `commonmark` und `inflate`: **Markup-String + optionale JSON-Daten in → PDF-Bytes out, ein FFI-Crossing pro Dokument**. Die teure Arbeit (Parsing, Layout, Font-Resolution, PDF-Emission via `krilla`) läuft komplett Rust-seitig. Kein Callback-Boundary, kein Object-Traversal über die Grenze, kein Chain-API-Trap wie bei `pdfkit`.
+`typst` as a library is a textbook Green shape, structurally analogous to `commonmark` and `inflate`: **markup string + optional JSON data in → PDF bytes out, one FFI crossing per document**. The expensive work (parsing, layout, font resolution, PDF emission via `krilla`) runs entirely Rust-side. No callback boundary, no object traversal across the boundary, no chain-API trap like with `pdfkit`.
 
-Dies ist ein **neues Paket**, kein Drop-in. Die JS-Alternativen für mehrseitige Business-Reports mit Tabellen (Rechnungen, Statements, Dashboards) sind Puppeteer (Chromium-Prozess) oder `pdfmake` / `html-pdf-node` — ersteres hat hunderte MB Overhead und startet einen Browser pro Request, letzteres ist pures JS ohne ernsthafte Typesetting-Engine. Gegen beide ist ≥2× trivial erreichbar, gegen Puppeteer eher 10–50×.
+This is a **new package**, not a drop-in. The JS alternatives for multi-page business reports with tables (invoices, statements, dashboards) are Puppeteer (a Chromium process) or `pdfmake` / `html-pdf-node` — the former has hundreds of MB of overhead and starts a browser per request, the latter is pure JS without a serious typesetting engine. Against both, ≥2× is trivially reachable; against Puppeteer more like 10–50×.
 
-Parity ist kein Ziel: Typst ist ein eigenes Markup-Sprachen-Ökosystem — das ist das Produkt, nicht der Kompromiss.
+Parity is not a goal: Typst is its own markup-language ecosystem — that's the product, not the compromise.
 
 ## JS package
 
-- **npm:** kein direkter Drop-in-Kandidat — dieses Paket ist ein **neues Produkt**. Vergleichs-Alternativen in JS für Business-Report-Generation:
-  - `puppeteer` (~5M/Woche) — HTML→PDF via Chromium, höchste Fidelity aber massiver Prozess-Overhead
-  - `pdfmake` (~400k/Woche) — pure-JS document-as-data-API, mit Tabellen + Page-Breaks
-  - `html-pdf-node` / `html-pdf-chrome` (~150k/Woche) — Wrapper um Chromium/Puppeteer
-  - `jsreport` / `carbone` — höhere Abstraktion, verwenden intern oft LibreOffice oder Puppeteer
-- **Downloads:** n/a (Neuling; `typst-js` npm-Paket mit ~5k/Woche ist ein WASM-Build von Typst-CLI, nicht als Lib konsumierbar)
-- **Exports / API surface:** klein gehalten — `compile(source, data?) → Buffer`, stateful `TypstCompiler`-Class für wiederholte Calls mit geteiltem Font- und Package-Cache
-- **Typical input:** Typst-Source 2–50 KB + optionales JSON-Data-Objekt 100 B – 500 KB (Rechnungs-Positionen, Report-Kennzahlen)
-- **Typical output:** PDF-Bytes 20 KB – 5 MB, je nach Seitenzahl und eingebetteten Assets
-- **Realistic median use-case:** Server-seitige Rechnungs-/Statement-Generation, 10–500 Dokumente pro Request, jedes 2–20 Seiten, Templates werden einmal geschrieben und viele Male mit variablen Daten gerendert
+- **npm:** no direct drop-in candidate — this package is a **new product**. Comparison alternatives in JS for business-report generation:
+  - `puppeteer` (~5M/week) — HTML→PDF via Chromium, highest fidelity but massive process overhead
+  - `pdfmake` (~400k/week) — pure-JS document-as-data API, with tables + page breaks
+  - `html-pdf-node` / `html-pdf-chrome` (~150k/week) — wrappers around Chromium/Puppeteer
+  - `jsreport` / `carbone` — higher-level abstraction, often use LibreOffice or Puppeteer internally
+- **Downloads:** n/a (newcomer; the `typst-js` npm package at ~5k/week is a WASM build of the Typst CLI, not consumable as a library)
+- **Exports / API surface:** kept small — `compile(source, data?) → Buffer`, stateful `TypstCompiler` class for repeated calls with shared font and package cache
+- **Typical input:** Typst source 2–50 KB + optional JSON data object 100 B – 500 KB (invoice line items, report KPIs)
+- **Typical output:** PDF bytes 20 KB – 5 MB, depending on page count and embedded assets
+- **Realistic median use-case:** server-side invoice/statement generation, 10–500 documents per request, each 2–20 pages, templates written once and rendered many times with variable data
 
 ## Rust replacement
 
-- **Candidate crate(s):** `typst` (primär — die Core-Library des Typst-Ökosystems, enthält Parser, Compiler, Layout-Engine) zusammen mit `typst-pdf` (PDF-Export über `krilla`) und `typst-kit` (Font- und Package-Resolution-Helpers für Library-Einbettung).
-- **Maintenance / license:** Sehr aktiv (typst GmbH, breites OSS-Umfeld), Apache-2.0, saubere Library-Trennung ab 0.11+. Keine bekannten ABI-Bruch-Probleme pro Release in der `typst`-Crate selbst, API zwischen Major-Versionen stabiler als bei `krilla` oder `pdf-writer` solo.
+- **Candidate crate(s):** `typst` (primary — the core library of the Typst ecosystem, contains parser, compiler, layout engine) together with `typst-pdf` (PDF export via `krilla`) and `typst-kit` (font and package-resolution helpers for library embedding).
+- **Maintenance / license:** very active (typst GmbH, broad OSS surroundings), Apache-2.0, clean library separation from 0.11+. No known ABI-break issues per release in the `typst` crate itself; the API between major versions is more stable than `krilla` or `pdf-writer` alone.
 - **Known gotchas / divergences:**
-  - **Font-Strategie muss explizit entschieden sein** — typst löst Fonts nicht out-of-the-box: Entweder bundlen wir einen Default-Set (Libertinus + Fira + New Computer Modern, ~15–20 MB), oder wir akzeptieren Caller-provided TTF-Buffers, oder wir resolven von Disk. Die Wahl prägt Binary-Size und Portabilität.
-  - **Package-Resolution** (`#import "@preview/…"`) geht online gegen den Typst-Package-Index. Default muss **offline-only** sein (Supply-Chain-Risiko, Sandboxing) — opt-in später, falls überhaupt.
-  - **Cold-Start:** erster `compile()`-Call lädt Fonts, parst Core-Library, kostet 50–200 ms. Nur via `TypstCompiler`-Class amortisierbar.
-  - **Binary-Size:** Typst bringt substantielle Deps mit (Rust-Regex-Engine, ICU-Teile, `krilla`, Font-Parser). Release-Build mit `lto` + `strip` geschätzt ~15–25 MB pro Plattform-Target — das verdoppelt ungefähr das aktuelle größte Paket im Repo. Muss explizit gegen die Policy gehalten werden.
-  - **Kein Pixel-Parity-Ziel** gegen Puppeteer/LibreOffice — wie bei `commonmark` gegen `marked`: eigene Positionierung als spec-konformer Typst-Renderer.
+  - **Font strategy must be explicitly decided** — typst doesn't resolve fonts out of the box: either we bundle a default set (Libertinus + Fira + New Computer Modern, ~15–20 MB), or we accept caller-provided TTF buffers, or we resolve from disk. The choice shapes binary size and portability.
+  - **Package resolution** (`#import "@preview/…"`) goes online against the Typst package index. Default must be **offline-only** (supply-chain risk, sandboxing) — opt-in later, if at all.
+  - **Cold start:** first `compile()` call loads fonts, parses the core library, costs 50–200 ms. Only amortizable via a `TypstCompiler` class.
+  - **Binary size:** Typst brings substantial deps (Rust regex engine, ICU parts, `krilla`, font parser). Release build with `lto` + `strip` estimated at ~15–25 MB per platform target — roughly doubles the largest current package in the repo. Must be weighed explicitly against the policy.
+  - **No pixel-parity goal** vs. Puppeteer/LibreOffice — same as `commonmark` vs. `marked`: own positioning as a spec-conformant Typst renderer.
 
 ## BACKLOG check
 
-Kein bestehender `typst`-Eintrag in `BACKLOG.md`. Der einzige PDF-Bezug in `BACKLOG.md:12` ist `pdf-parse` (Text-Extraction via `pdf-extract` / `lopdf`) — das ist der Read-Pfad, nicht der Write-Pfad. Kein Overlap.
+No existing `typst` entry in `BACKLOG.md`. The only PDF-related reference in `BACKLOG.md:12` is `pdf-parse` (text extraction via `pdf-extract` / `lopdf`) — that's the read path, not the write path. No overlap.
 
-Abgrenzung zu bestehenden Reviews:
-- `docs/perf-review/pdfkit.md` (2026-04-20) empfiehlt `printpdf` für den **Label-/Ticket-Use-Case** (~2–20 KB, High-Volume-Batch, triviales Layout). Die dortige Analyse schließt explizit Text-Wrapping und Tabellen vom v1-Scope aus. Der vorliegende typst-Review adressiert den komplementären Use-Case — mehrseitige Dokumente mit Tabellen, berechneten Summen, richtiger Typografie. Die beiden Pakete kollidieren nicht; sie decken unterschiedliche Shapes.
-- `docs/post-mortems/xml.md` ist die Warnung gegen Object-Traversal über die FFI-Grenze — typst vermeidet das per Design (Bytes-in, Bytes-out).
+Delineation to existing reviews:
+- `docs/perf-review/pdfkit.md` (2026-04-20) recommends `printpdf` for the **label/ticket use-case** (~2–20 KB, high-volume batch, trivial layout). That analysis explicitly excludes text wrapping and tables from v1 scope. This typst review addresses the complementary use-case — multi-page documents with tables, computed totals, proper typography. The two packages don't collide; they cover different shapes.
+- `docs/post-mortems/xml.md` is the warning against object traversal across the FFI boundary — typst avoids that by design (bytes-in, bytes-out).
 
-Kein Eintrag in `docs/packages.json`.
+No entry in `docs/packages.json`.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Substantiell.** 10-seitige Rechnung mit Tabelle ~8–25 ms Rust-Compute (Parse + Layout + PDF-Emit). 50-seitiger Report mit Math/Charts ~80–300 ms. Relative zur FFI-Fixkostenbasis (~110 ns) ist das um Größenordnungen Headroom. |
-| Input size distribution | Typst-Source 2–50 KB + JSON-Daten 0.1–500 KB. Via `Buffer` Input (wie `renderBytes` in `commonmark`) ist FFI-Input-Kost ~flat 180 ns unabhängig von der Größe (siehe `docs/BASELINE.md:28–30`). Für String-Input bis 50 KB wäre es ~20 µs UTF-16→UTF-8 — vernachlässigbar gegenüber Compute. |
-| Output size distribution | PDF-Bytes 20 KB – 5 MB. `Buffer`-Return ist flat ~180 ns bis 10 MB (BASELINE.md:30) — Output-FFI-Kost ist ein Rauschen im Budget. |
-| Reusable setup (stateful potential) | **Hoch.** Font-Parsing + Package-Cache kostet 50–200 ms cold pro Font-Set. Ein `TypstCompiler`-NAPI-Class cached Fonts, geparste Core-Library-Module, und (wenn aktiviert) geladene Packages. Bei 500 Rechnungen mit gleichem Template + gleichem Font-Set ist das der Unterschied zwischen 25 s und 4 s Gesamt-Wall-Clock. |
-| Batch-usage realism | **Hoch.** Rechnungslauf, Monats-Statement-Batch, Report-Generation für Dashboard — der Default ist Batch, nicht Einzel-Request. `compileMany(jobs)` über `rayon::par_iter` kollabiert die FFI-Crossings und nutzt mehrere Cores — siehe `crates/commonmark/src/lib.rs:183–194` als Referenz-Pattern. |
-| FFI-share estimate vs. Rust work | <1% bei 10+-seitigen Reports (einmal FFI-in, 10+ ms Rust-Compute, einmal FFI-out). Selbst bei 2-seitigen Rechnungen <5%. Die Compute-Seite dominiert strukturell. |
+| Per-call algorithmic work | **Substantial.** 10-page invoice with a table ~8–25 ms Rust compute (parse + layout + PDF emit). 50-page report with math/charts ~80–300 ms. Relative to the FFI fixed-cost baseline (~110 ns), that's orders of magnitude of headroom. |
+| Input size distribution | Typst source 2–50 KB + JSON data 0.1–500 KB. Via `Buffer` input (like `renderBytes` in `commonmark`), FFI input cost is ~flat 180 ns regardless of size (see `docs/BASELINE.md:28–30`). For string input up to 50 KB it would be ~20 µs UTF-16→UTF-8 — negligible next to compute. |
+| Output size distribution | PDF bytes 20 KB – 5 MB. `Buffer` return is flat ~180 ns up to 10 MB (BASELINE.md:30) — output FFI cost is noise in the budget. |
+| Reusable setup (stateful potential) | **High.** Font parsing + package cache costs 50–200 ms cold per font set. A `TypstCompiler` NAPI class caches fonts, parsed core-library modules, and (if enabled) loaded packages. On 500 invoices with the same template + same font set, that's the difference between 25 s and 4 s total wall-clock. |
+| Batch-usage realism | **High.** Invoice runs, monthly statement batches, report generation for dashboards — the default is batch, not single request. `compileMany(jobs)` via `rayon::par_iter` collapses the FFI crossings and uses multiple cores — see `crates/commonmark/src/lib.rs:183–194` as a reference pattern. |
+| FFI-share estimate vs. Rust work | <1% for 10+-page reports (one FFI-in, 10+ ms Rust compute, one FFI-out). Even for 2-page invoices <5%. The compute side dominates structurally. |
 
 ## Classification reasoning
 
-Der Shape matcht exakt die bestehenden Green-Packages `commonmark`, `inflate`, `zip`, `sanitize-html`: **Bytes-in, substantielle Compute, Bytes-out, kein Callback-Boundary, kein Object-Traversal**. Die Rust-Seite macht genug echte Arbeit pro Byte, dass die FFI-Fixkosten unsichtbar werden. Per `docs/BASELINE.md:25–33` ist der relevante Floor (109 ns noop, 180 ns Buffer-Return, ~35 µs pro 100 KB String-Input) um drei Größenordnungen kleiner als die erwartete Compute-Zeit (mehrere ms pro Dokument) — struktureller Headroom ist also vorhanden.
+The shape matches the existing Green packages `commonmark`, `inflate`, `zip`, `sanitize-html` exactly: **bytes-in, substantial compute, bytes-out, no callback boundary, no object traversal**. The Rust side does enough real work per byte that the FFI fixed costs go invisible. Per `docs/BASELINE.md:25–33`, the relevant floor (109 ns noop, 180 ns buffer return, ~35 µs per 100 KB string input) is three orders of magnitude smaller than the expected compute time (several ms per document) — so structural headroom is there.
 
-Die eigentliche Green-Bedingung ist der kleinste realistische Input: **eine 1-seitige Rechnung, kein Batch, Cold-Start inklusive**. Cold wird das ~100–200 ms (Font-Load dominiert) — hier verliert typst gegen `pdfmake` (~30–50 ms für ein einfaches Dokument in pure-JS). Hot, mit `TypstCompiler`-Class, läuft dieselbe Rechnung in ~5–10 ms — dann 3–6× schneller als `pdfmake` bei besserer Typografie. Der 2×-Kleinster-Input-Gate hält **nur** im Hot-Path. Das muss in der Dokumentation transparent sein — es ist dieselbe Nuance wie bei `commonmark`'s `Renderer`-Class.
+The actual Green condition is the smallest realistic input: **a 1-page invoice, no batch, cold start included**. Cold that's ~100–200 ms (font load dominates) — typst loses against `pdfmake` there (~30–50 ms for a simple document in pure JS). Hot, with the `TypstCompiler` class, the same invoice runs in ~5–10 ms — then 3–6× faster than `pdfmake` with better typography. The 2×-at-smallest-input gate holds **only** on the hot path. That has to be transparent in the docs — it's the same nuance as with `commonmark`'s `Renderer` class.
 
-Gegen Puppeteer/`html-pdf-node` gewinnt typst bei jedem Input strukturell, weil diese einen Browser-Prozess starten oder einen persistenten behalten (Memory-Overhead ~100–300 MB pro Worker). Für serverseitige Rechnungs-Generation ist das ein harter Kostenvorteil, nicht nur Wall-Clock.
+Against Puppeteer/`html-pdf-node`, typst wins structurally on every input, because those start a browser process or hold one persistent (memory overhead ~100–300 MB per worker). For server-side invoice generation, that's a hard cost advantage, not just wall-clock.
 
-Ein `Parser-`/`handlebars-Shape-Trap` existiert nicht: typst hat keine Callback-Erweiterungspunkte über die FFI. Daten kommen als JSON (ein Blob, ein Marshal), Template-Module kommen als Strings (ein Blob, ein Marshal). Keine `--include-helper=function`-Escape-Hatches.
+A `parser-`/`handlebars`-shape trap does not exist: typst has no callback extension points across the FFI. Data comes in as JSON (one blob, one marshal), template modules come in as strings (one blob, one marshal). No `--include-helper=function` escape hatches.
 
-**Benchmark-Gap-Flag:** Prediction ist qualitativ. Vor Green-Gate müssen die vier Szenarien unten gemessen werden — ohne Zahlen bleibt das Paket auf 🟡 Yellow, wie bei `pdfkit.md`.
+**Benchmark gap flag:** the prediction is qualitative. Before the Green gate, the four scenarios below must be measured — without numbers the package stays at 🟡 Yellow, as with `pdfkit.md`.
 
 ## If GO — proposed port
 
-- **Recommended crate-name:** `@amigo-labs/typst`
+- **Recommended crate name:** `@amigo-labs/typst`
 - **Primary API sketch:**
   ```ts
   type FontSpec = { name?: string; data: Buffer };
@@ -99,35 +99,35 @@ Ein `Parser-`/`handlebars-Shape-Trap` existiert nicht: typst hat keine Callback-
     compileMany(jobs: CompileOptions[]): Buffer[];
   }
   ```
-  Explizit **nicht** Puppeteer- oder `pdfmake`-kompatibel. Die Eingabesprache *ist* Typst-Markup — das ist bewusstes Produktangebot.
+  Explicitly **not** compatible with Puppeteer or `pdfmake`. The input language *is* Typst markup — that's a deliberate product offering.
 
 - **Must-have benchmark scenarios:**
-  - **small-cold:** 1-seitige Rechnung, einmaliger `compile()`-Call, gegen `pdfmake` + `puppeteer`. Cold-Start-Kosten transparent ausweisen.
-  - **small-hot:** 1-seitige Rechnung via `TypstCompiler.compile()` nach Warm-up, gegen dieselbe Baseline. Das ist der eigentliche Green-Gate.
-  - **batch-500:** `compileMany` mit 500 Rechnungen, identisches Template, variable Daten. Gegen Puppeteer (Worker-Pool mit 4 Workers) und `pdfmake` (Single-Thread). Der Hauptgewinn-Case.
-  - **long-report:** 50-seitiger Geschäftsbericht mit Tabellen, Charts (als SVG/PNG), Titelseite, Inhaltsverzeichnis. Gegen Puppeteer-mit-ChartJS-HTML. Prüft Layout-Skalierung.
-  - **realistic median:** 5-seitiges Monats-Statement mit 50-Zeilen-Tabelle, einem eingebetteten Chart und berechneten Summen.
+  - **small-cold:** 1-page invoice, single `compile()` call, against `pdfmake` + `puppeteer`. Report cold-start cost transparently.
+  - **small-hot:** 1-page invoice via `TypstCompiler.compile()` after warm-up, against the same baseline. This is the actual Green gate.
+  - **batch-500:** `compileMany` with 500 invoices, identical template, variable data. Against Puppeteer (worker pool with 4 workers) and `pdfmake` (single-thread). The main win case.
+  - **long-report:** 50-page business report with tables, charts (as SVG/PNG), title page, table of contents. Against Puppeteer + ChartJS HTML. Tests layout scaling.
+  - **realistic median:** 5-page monthly statement with 50-row table, an embedded chart, and computed totals.
 
 - **Acceptance thresholds (Green gate):**
   - small-hot ≥ **2×** `pdfmake`
-  - batch-500 ≥ **5×** `pdfmake` und ≥ **10×** `puppeteer` (wall-clock inkl. Prozess-Startup bei Puppeteer)
-  - long-report ≥ **2×** `puppeteer` (hier ist Puppeteer mit HTML+Chart-Libs durchaus schnell — das Ziel ist konservativ)
-  - small-cold darf schlechter sein als `pdfmake` — muss aber dokumentiert werden, und der `compile()`-Standalone-Path sollte im README explizit als "für One-Shot-Usage, Warm-Path nutzt `TypstCompiler`" positioniert sein
-  - Cold-Start-Kosten (erster `TypstCompiler.compile()` inkl. Font-Load) müssen ausgewiesen werden — Transparenz-Anforderung analog `pdfkit.md`.
+  - batch-500 ≥ **5×** `pdfmake` and ≥ **10×** `puppeteer` (wall-clock incl. process startup for Puppeteer)
+  - long-report ≥ **2×** `puppeteer` (Puppeteer + HTML chart libs is actually fast here — the target is conservative)
+  - small-cold is allowed to be worse than `pdfmake` — but must be documented, and the `compile()` standalone path should be explicitly positioned in the README as "for one-shot usage, warm path uses `TypstCompiler`"
+  - Cold-start cost (first `TypstCompiler.compile()` incl. font load) has to be reported — transparency requirement analogous to `pdfkit.md`.
 
 - **Risks:**
-  - **Binary-Size-Explosion.** Typst + fonts + krilla + pdf-writer ergeben geschätzt 15–25 MB pro NAPI-Target. Sechs Targets = 90–150 MB npm-Artefakt-Gesamtgröße. Muss gegen Repo-Policy gehalten werden. Mitigation: optional ein `@amigo-labs/typst-fonts`-Peer-Paket für die Default-Fonts, `@amigo-labs/typst` selbst bleibt fontfrei.
-  - **Font-Resolution-Komplexität.** Drei plausible Strategien (bundled / user-TTFs / disk-resolve) und alle drei werden von verschiedenen User-Klassen gewollt. v1 muss eine wählen und die anderen dokumentiert zurückstellen, sonst läuft das API-Design in drei Richtungen gleichzeitig auseinander.
-  - **Typst-API-Churn.** Die Library-API von `typst` + `typst-pdf` + `typst-kit` ist ab 0.11 vergleichsweise stabil, aber nicht 1.0. Major-Upgrades alle ~6 Monate, manche mit API-Shifts. Wir committen uns auf ein Version-Pin und aktive Wartung des Upgrades.
-  - **User-Erwartungshaltung "LaTeX-in-JS".** Typst ist nicht LaTeX, kennt nicht jede LaTeX-Konvention. Wird Support-Issues erzeugen, die nur mit "Das ist Typst, nicht LaTeX — siehe typst.app" beantwortbar sind. README muss das Upfront machen.
-  - **Baseline-Nuancierung:** `docs/BASELINE.md` misst kein Typst-Compute. FFI-Share-Schätzung oben ist aus Crate-eigenen Benchmarks der Typst-Community abgeleitet, nicht in unserem Harness gemessen. Nach Port sollte der `_ffi-bench`-Harness um einen `compilePdfJob`-Case erweitert werden.
+  - **Binary-size explosion.** Typst + fonts + krilla + pdf-writer estimate to 15–25 MB per NAPI target. Six targets = 90–150 MB total npm artifact size. Has to be weighed against the repo policy. Mitigation: optionally a `@amigo-labs/typst-fonts` peer package for the default fonts, `@amigo-labs/typst` itself stays font-free.
+  - **Font-resolution complexity.** Three plausible strategies (bundled / user TTFs / disk-resolve) and all three are wanted by different user classes. v1 has to pick one and push the others into documented follow-ups, otherwise the API design diverges in three directions at once.
+  - **Typst API churn.** The library API of `typst` + `typst-pdf` + `typst-kit` is comparatively stable from 0.11, but not 1.0. Major upgrades every ~6 months, some with API shifts. We're committing to a version pin and active maintenance of upgrades.
+  - **User expectation "LaTeX-in-JS".** Typst is not LaTeX, doesn't know every LaTeX convention. Will produce support issues that can only be answered with "That's Typst, not LaTeX — see typst.app". The README has to make this upfront.
+  - **Baseline nuance:** `docs/BASELINE.md` doesn't measure Typst compute. The FFI-share estimate above is derived from Typst community's own benchmarks, not measured in our harness. After the port, extend the `_ffi-bench` harness with a `compilePdfJob` case.
 
 ## If NO-GO — BACKLOG entry
 
-Falls das Binary-Size-Budget (90–150 MB Gesamt für sechs Targets) als Showstopper bewertet wird, oder falls der Use-Case als zu schmal für ein eigenes Paket eingestuft wird:
+If the binary-size budget (90–150 MB total for six targets) is judged a showstopper, or if the use-case is deemed too narrow for its own package:
 
 ```markdown
-- **typst (als Library)** (nicht auf npm, ~5k/Woche als WASM-Build). Evaluiert in `docs/perf-review/typst.md`. FFI-Shape ist Lehrbuch-Green (bytes-in, bytes-out, keine Callbacks), Compute-Gewinn gegen Puppeteer/pdfmake substantiell (prognostiziert 5–50× je Use-Case). Zurückgestellt wegen Binary-Size (~15–25 MB pro Plattform × 6 Targets = 90–150 MB npm-Artefakt) und Scope-Frage: Business-Report-Generation ist ein enges Vertical, das einen signifikanten Teil der Repo-Download-Größe beansprucht. Re-Evaluation, sobald Typst ein schlankeres Embedding-Profil bietet oder das Binary-Size-Budget des Repos erweitert wird.
+- **typst (as library)** (not on npm, ~5k/week as WASM build). Evaluated in `docs/perf-review/typst.md`. FFI shape is textbook Green (bytes-in, bytes-out, no callbacks), compute win against Puppeteer/pdfmake substantial (predicted 5–50× depending on use-case). Deferred due to binary size (~15–25 MB per platform × 6 targets = 90–150 MB npm artifact) and scope question: business-report generation is a narrow vertical that claims a significant share of the repo's download size. Re-evaluate once Typst offers a slimmer embedding profile or the repo's binary-size budget expands.
 ```
 
-Section in `BACKLOG.md`: **Parity too expensive** (passt nicht — ist kein Parity-Problem) → eher neue Sektion oder **Scope too large**.
+Section in `BACKLOG.md`: **Parity too expensive** (doesn't fit — it's not a parity problem) → rather a new section or **Scope too large**.

--- a/docs/perf-review/ws.md
+++ b/docs/perf-review/ws.md
@@ -1,48 +1,48 @@
 # Candidate review: `ws`
 
-> **Status:** NO-GO · **Predicted:** 🔴 Red (Integration) / ⚫ Black (Shape) · **Reviewed:** 2026-04-19
+> **Status:** NO-GO · **Predicted:** 🔴 Red (integration) / ⚫ Black (shape) · **Reviewed:** 2026-04-19
 
 ## Verdict
 
-`ws` ist Socket + Protocol + Event-Emitter, tief verzahnt mit Node's `net`/`tls`. Rust-WebSocket-Crates (`tungstenite`, `fastwebsockets`) sind schnell — aber sie in Nodes libuv-Event-Loop zu fädeln ohne Performance-Regression ist eine Eigen-Framework-Aufgabe, nicht ein NAPI-Binding.
+`ws` is socket + protocol + event emitter, deeply intertwined with Node's `net`/`tls`. Rust WebSocket crates (`tungstenite`, `fastwebsockets`) are fast — but threading them into Node's libuv event loop without a performance regression is a bespoke-framework task, not a NAPI binding.
 
 ## JS package
 
 - **npm:** `ws`
-- **Downloads:** ~204M/Woche
-- **Exports / API surface:** `WebSocket` (Client), `WebSocketServer`, Event-Emitter (`open`, `message`, `close`, `error`, `ping`, `pong`), Per-Message-Deflate, Fragmentation, Binary+Text-Modi
-- **Typical input:** TCP-Stream → Frames → Messages; pro-Message 10 B – 1 MB
-- **Typical output:** Events pro Frame/Message
-- **Realistic median use-case:** WebSocket-Server mit Event-Handlern auf allen Nachrichten
+- **Downloads:** ~204M/week
+- **Exports / API surface:** `WebSocket` (client), `WebSocketServer`, event emitter (`open`, `message`, `close`, `error`, `ping`, `pong`), per-message deflate, fragmentation, binary+text modes
+- **Typical input:** TCP stream → frames → messages; per message 10 B – 1 MB
+- **Typical output:** events per frame/message
+- **Realistic median use-case:** WebSocket server with event handlers on all messages
 
 ## Rust replacement
 
-- **Candidate crate(s):** `tungstenite` (sync), `tokio-tungstenite`, `fastwebsockets` (Deno-Team)
-- **Maintenance / license:** aktiv, MIT/Apache
-- **Known gotchas / divergences:** `ws` nutzt Nodes `net.Socket` direkt. Rust müsste entweder ein separates `tokio`-Runtime neben libuv fahren (Ressourcen-Duplication, Event-Loop-Integration) oder über NAPI auf den JS-Socket zugreifen — was jeden Frame einzeln über FFI schickt
+- **Candidate crate(s):** `tungstenite` (sync), `tokio-tungstenite`, `fastwebsockets` (Deno team)
+- **Maintenance / license:** active, MIT/Apache
+- **Known gotchas / divergences:** `ws` uses Node's `net.Socket` directly. Rust would have to either run a separate `tokio` runtime alongside libuv (resource duplication, event-loop integration) or access the JS socket via NAPI — which sends every frame individually across the FFI
 
 ## BACKLOG check
 
-BACKLOG: *Scope too large* — bestätigt.
+BACKLOG: *Scope too large* — confirmed.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | Frame-Decode + Mask-XOR + optional Deflate; pro 1 KB Frame ~1–10 µs |
-| Input size distribution | Streaming, Frames beliebig |
-| Output size distribution | Event mit Payload-Buffer |
-| Reusable setup (stateful potential) | Connection-State = NAPI-Class — unumgänglich |
-| Batch-usage realism | Hoch im Protokoll, aber jede Message muss an JS-Handler = FFI-Callback |
-| FFI-share estimate vs. Rust work | **Callback pro Message**: genau der `htmlparser2`-Shape |
+| Per-call algorithmic work | Frame decode + mask XOR + optional deflate; per 1 KB frame ~1–10 µs |
+| Input size distribution | Streaming, frames arbitrary |
+| Output size distribution | Event with payload buffer |
+| Reusable setup (stateful potential) | Connection state = NAPI class — unavoidable |
+| Batch-usage realism | High in the protocol, but every message has to go to the JS handler = FFI callback |
+| FFI-share estimate vs. Rust work | **Callback per message**: exactly the `htmlparser2` shape |
 
 ## Classification reasoning
 
-Zwei unabhängige Killer:
-1. **Event-Loop-Integration**: `ws` leiht sich Nodes `net.Socket`. Rust kann nicht ohne Weiteres in diese Loop hineinlesen/-schreiben. Alternative ist eigene `tokio`-Runtime = zweiter Thread-Pool, Sync-Kosten zwischen Loops, doppelte Socket-Buffer.
-2. **Message-Callback-Shape**: Das Nutzerinterface ist `ws.on('message', (data) => …)`. Jede Message = FFI-Callback. Bei einem Chat-Server mit 10K msg/s × 2 µs FFI = 20 ms/s nur für Overhead.
+Two independent killers:
+1. **Event-loop integration**: `ws` borrows Node's `net.Socket`. Rust can't easily read from/write to this loop. The alternative is its own `tokio` runtime = a second thread pool, sync cost between loops, doubled socket buffers.
+2. **Message-callback shape**: the user interface is `ws.on('message', (data) => …)`. Every message = FFI callback. On a chat server with 10K msg/s × 2 µs FFI = 20 ms/s of pure overhead.
 
-`fastwebsockets` gewinnt gegenüber `ws` ~3–5× im Benchmark **bei direktem Rust-Client**, weil kein FFI. Im Rust-über-NAPI-Mix würde dieser Win an der Message-Grenze verloren. Post-Mortem-Muster: C.1-Input-Type hilft nicht (Buffer ist schon Zero-Copy bei `ws`), C.4-Stateful ist schon so, C.3-Batch ist nicht drop-in-machbar.
+`fastwebsockets` wins ~3–5× over `ws` in benchmarks **as a direct Rust client**, because no FFI. In a Rust-over-NAPI mix, that win would be lost at the message boundary. Post-mortem pattern: C.1 input-type doesn't help (Buffer is already zero-copy with `ws`), C.4 stateful is already how it works, C.3 batch is not feasible as a drop-in.
 
 ## If NO-GO — BACKLOG entry
 

--- a/docs/perf-review/xml.md
+++ b/docs/perf-review/xml.md
@@ -1,38 +1,38 @@
-# Perf-Review: `@amigo-labs/xml`
+# Perf review: `@amigo-labs/xml`
 
 > **Status:** 🗄️ Archived (never published) · **Reviewed:** 2026-04-19 · **Version:** 0.2.0 (final)
 
 ## Verdict
 
-Archiviert ohne Deprecation-Window — das Paket war nie auf npm und
-brauchte deswegen keine 3-Monats-Warn-Phase. Crate liegt jetzt unter
-`archived/xml/`, aus Cargo/pnpm-Workspace raus, aus
-`docs/packages.json` / `docs/data.json` / `scripts/measure-size.mjs`
-entfernt. Der Grund bleibt derselbe: `parseXmlToJson` ist ein realer
-Hebel (1,9–3,1× schneller als das alte `parseXml`, gewinnt den 1 KB
-Bucket 1,55× gegen `sax`), aber am median 100 KB-RSS 0,78× und am
-10 MB-SOAP 0,72× `sax`. Post-Mortem-Text („not tried") war falsch und
-wurde mit den echten Zahlen aus dieser Messung ersetzt.
+Archived without a deprecation window — the package was never on npm and
+therefore didn't need a 3-month warning phase. The crate now lives under
+`archived/xml/`, out of the Cargo/pnpm workspace, and removed from
+`docs/packages.json` / `docs/data.json` / `scripts/measure-size.mjs`.
+The reason stays the same: `parseXmlToJson` is a real lever (1.9–3.1× faster
+than the old `parseXml`, wins the 1 KB bucket 1.55× against `sax`), but on
+the median 100 KB RSS 0.78× and on the 10 MB SOAP 0.72× of `sax`. The
+post-mortem text ("not tried") was wrong and has been replaced with the
+real numbers from this measurement.
 
 ## Classification rationale
 
-**Pass A-Gate (aus dem 2026-04-19-Plan) verfehlt.** Schwelle war:
-10 MB ≥ 2× sax UND 100 KB ≥ 1× sax. Reale Messung nach Export +
-Bench-Ergänzung:
+**Pass-A gate (from the 2026-04-19 plan) missed.** The threshold was:
+10 MB ≥ 2× sax AND 100 KB ≥ 1× sax. Real measurement after export +
+bench addition:
 
-- 10 MB: 1,42 Hz amigo vs. 1,98 Hz sax → **0,72×** (verfehlt, Faktor 2
-  fehlt)
-- 100 KB: 354 Hz amigo vs. 455 Hz sax → **0,78×** (verfehlt, 28 %
-  fehlen)
-- 1 KB: 279 k Hz amigo vs. 180 k Hz sax → **1,55×** (bestanden, aber
-  einzeln nicht entscheidend)
+- 10 MB: 1.42 Hz amigo vs. 1.98 Hz sax → **0.72×** (missed, factor of 2
+  missing)
+- 100 KB: 354 Hz amigo vs. 455 Hz sax → **0.78×** (missed, 28%
+  missing)
+- 1 KB: 279k Hz amigo vs. 180k Hz sax → **1.55×** (passed, but not
+  decisive on its own)
 
-**Pass B (partial):** Das 100-KB-Gap ist eng genug dass C.1/C.2 Buffer-
-I/O es potentiell kippen könnten (prognostisch ~1,1× sax). Das 10-MB-
-Gap ist zu groß — die Analyse ergibt dass dort **JSON.parse auf der JS-
-Seite** (~15 MB JSON zurück) der Hauptkostentreiber ist, nicht mehr FFI.
-Das ist strukturell: jeder Rust-Port der Events als JSON zurück gibt
-wird an V8's JSON-Decoder für den ganzen Output limitiert.
+**Pass B (partial):** the 100 KB gap is tight enough that C.1/C.2 buffer
+I/O could potentially flip it (forecast ~1.1× sax). The 10 MB gap is
+too big — the analysis shows that **JSON.parse on the JS side** (~15 MB
+JSON back) is the main cost driver there, no longer FFI. That's
+structural: any Rust port that returns events as JSON will be limited by
+V8's JSON decoder for the full output.
 
 ## Evidence
 
@@ -40,136 +40,136 @@ wird an V8's JSON-Decoder für den ganzen Output limitiert.
 
 Node v22.x, Linux x64 glibc, vitest 3.2.4, release build (workspace LTO).
 
-| Szenario | parseXml | **parseXmlToJson** | SAX-API | sax | vs. sax (best amigo) |
+| Scenario | parseXml | **parseXmlToJson** | SAX API | sax | vs. sax (best amigo) |
 |---|---:|---:|---:|---:|---:|
-| small SVG 1 KB | 143 885 Hz | **279 093 Hz** | 142 554 Hz | 179 724 Hz | **1,55×** ✓ |
-| RSS 100 KB | 146 Hz | **354 Hz** | — | 455 Hz | 0,78× ✗ |
-| SOAP 10 MB | 0,462 Hz | **1,42 Hz** | — | 1,98 Hz | 0,72× ✗ |
+| small SVG 1 KB | 143,885 Hz | **279,093 Hz** | 142,554 Hz | 179,724 Hz | **1.55×** ✓ |
+| RSS 100 KB | 146 Hz | **354 Hz** | — | 455 Hz | 0.78× ✗ |
+| SOAP 10 MB | 0.462 Hz | **1.42 Hz** | — | 1.98 Hz | 0.72× ✗ |
 
-Vergleich zur alten `docs/data.json`-Zahl: `parseXml` 100 KB war
-110 Hz, jetzt 146 Hz — Varianz innerhalb der Runs (±2,66 % rme), aber
-Größenordnung konsistent.
+Compared to the old `docs/data.json` number: `parseXml` 100 KB was
+110 Hz, now 146 Hz — variance within the runs (±2.66% rme), but
+order of magnitude consistent.
 
-Innerhalb unserer eigenen Varianten ist `parseXmlToJson` der klare
-Sieger:
+Within our own variants, `parseXmlToJson` is the clear
+winner:
 
-- vs. `parseXml`: 1,94× (1 KB), 2,43× (100 KB), **3,07× (10 MB)**
-- vs. SAX-API: 1,96× (1 KB, andere Größen nicht ausgeführt)
+- vs. `parseXml`: 1.94× (1 KB), 2.43× (100 KB), **3.07× (10 MB)**
+- vs. SAX API: 1.96× (1 KB, other sizes not run)
 
-Das ist das signifikanteste Single-Lever-Ergebnis den dieser Crate je
-hatte — aber eben nur relativ zur eigenen Baseline.
+That's the most significant single-lever result this crate ever
+had — but only relative to its own baseline.
 
 ### Realistic use-case
 
-100 KB RSS ist der Median-Anwendungsfall (Feed-Reader, Config-Parser,
-einfache SOAP-Responses). Das ist der Bucket den wir verlieren. 1 KB
-SVG-Parsing kommt im Web-Dev-Kontext vor (Inline-Icons, einfache
-Grafiken), aber dort rechtfertigt der Gewinn kaum einen nativen
-Binary-Dependency-Aufschlag. 10 MB ist der Tail (Dumps, Batch-APIs) —
-dort haben wir strukturell JSON-Parse-Overhead.
+100 KB RSS is the median use-case (feed reader, config parser,
+simple SOAP responses). That's the bucket we lose. 1 KB SVG parsing
+comes up in the web-dev context (inline icons, simple graphics), but
+there the win barely justifies a native binary-dependency overhead.
+10 MB is the tail (dumps, batch APIs) — where we have a structural
+JSON-parse overhead.
 
 ### Benchmark gaps
 
-Alle vorherigen Gaps sind jetzt gefüllt:
+All previous gaps are now filled:
 
-- ✅ `parseXmlToJson` in allen drei Größenklassen gemessen
-- ✅ 10 MB SOAP amigo-Seite gemessen (`parseXml` UND `parseXmlToJson`)
+- ✅ `parseXmlToJson` measured in all three size classes
+- ✅ 10 MB SOAP amigo side measured (`parseXml` AND `parseXmlToJson`)
 
-Verbleibender potentieller Gap: **Buffer-Input/Output-Variante fehlt
-immer noch** (nicht nur Bench, sondern API). Prognose: würde 100 KB
-plausibel auf ~1,1× `sax` heben, 10 MB bliebe verloren wegen
+Remaining potential gap: **a buffer input/output variant is still
+missing** (not just the bench, but the API). Forecast: would plausibly
+raise 100 KB to ~1.1× `sax`, 10 MB would stay lost because of
 JSON.parse.
 
 ### API surface
 
-Jetzt drei exportierte Pfade:
+Three exported paths now:
 
-- `parseXml(input, strict?) → XmlEvent[]` — Tree-of-Events, teuer wegen
-  `Vec<Object>`-Marshalling. Mittel- bis Langfristig Kandidat für Dead-
-  Code.
-- `parseXmlToJson(input, strict?) → string` — einzige realistische
-  Performance-API. 1 FFI-Crossing, JSON.parse JS-seitig. Frisch in
-  `wrapper.js` exportiert (vorher nur in `index.js`).
-- `parser()` (wrapper.js) — `sax`-kompatibles Callback-API. Ruft intern
-  `parseXml` einmal + dispatcht in JS. Strukturell unrettbar da wir
-  aber auch nicht direkt auf Rust-Callbacks gehen wollen.
+- `parseXml(input, strict?) → XmlEvent[]` — tree-of-events, expensive because of
+  `Vec<Object>` marshalling. Mid- to long-term candidate for dead
+  code.
+- `parseXmlToJson(input, strict?) → string` — the only realistic
+  performance API. 1 FFI crossing, JSON.parse on the JS side. Freshly
+  exported in `wrapper.js` (previously only in `index.js`).
+- `parser()` (wrapper.js) — `sax`-compatible callback API. Internally calls
+  `parseXml` once + dispatches in JS. Structurally unsalvageable since we
+  also don't want to go directly to Rust callbacks.
 
 ### Bundle / binary size
 
-Aus `docs/data.json`: `@amigo-labs/xml` Install-Size 434 KB vs.
-`sax` 56 KB. **7,7× größer** — für einen Bucket der wir median verlieren
-ist das zusätzlicher Argumenten für die Deprecation.
+From `docs/data.json`: `@amigo-labs/xml` install size 434 KB vs.
+`sax`'s 56 KB. **7.7× larger** — for a bucket we lose at the median,
+that's extra ammunition for the deprecation.
 
 ### FFI-overhead baseline
 
-Prediction aus `docs/BASELINE.md` war: parseXmlToJson sollte bei 100 KB
-~250-300 Hz liefern (parity mit sax). Reale Messung: **354 Hz.**
-Prediction hat die JS-seitige JSON.parse-Kosten unterschätzt bei 10 MB,
-aber bei 100 KB war die Schätzung sogar pessimistisch. Baseline-Modell
-ist für kleine/mittlere Eingaben brauchbar, unterschätzt bei 10 MB+ den
-JS-side JSON.parse-Anteil.
+Prediction from `docs/BASELINE.md` was: parseXmlToJson should deliver
+~250–300 Hz at 100 KB (parity with sax). Real measurement: **354 Hz.**
+The prediction underestimated the JS-side JSON.parse cost at 10 MB,
+but at 100 KB the estimate was even pessimistic. The baseline model
+is usable for small/medium inputs, underestimates the JS-side
+JSON.parse share at 10 MB+.
 
-## Phase-C optimization checklist (updated mit Messdaten)
+## Phase-C optimization checklist (updated with measurement data)
 
 | # | Lever | Applicable | Notes |
 |---|---|---|---|
-| C.1 | Input-type minimization (Buffer-overload) | **gated (marginal)** | 100 KB: ~0,35 ms/call sparbar (~12 %). 10 MB: ~35 ms (~5 %). Nur in Kombination mit C.2 sinnvoll, und selbst dann nicht deprecation-umkehrend. |
-| C.2 | Output-type (parseXmlToJson → Buffer) | **gated (marginal)** | 100 KB: ~0,5 ms sparbar (~18 %). Zusammen mit C.1 plausibel 1,05–1,15× sax @ 100 KB — Grenzfall. 10 MB: JSON.parse JS-side dominiert → Buffer-out ändert nichts. |
-| C.3 | Batch API | n/a | parse_xml* ist bereits 1-call-per-doc. |
-| C.4 | Stateful API | n/a | quick-xml hat keinen nennenswerten Setup-Cost. |
-| C.5 | Parallelization | n/a | XML-Parse ist sequentiell. |
-| C.6 | Algorithm swap | already done | quick-xml ist State-of-the-Art. |
-| C.7 | Allocator tuning (SmallVec in decode_attrs) | **gated (small)** | Micro-Optimierung. ~2–5 % plausibel, verändert Klassifikation nicht. |
-| C.8 | Bundle-size | already done | Workspace-Profile. Binary-Install-Size (434 KB) lässt sich nicht unter `sax`'s 56 KB drücken. |
+| C.1 | Input-type minimization (Buffer overload) | **gated (marginal)** | 100 KB: ~0.35 ms/call savable (~12%). 10 MB: ~35 ms (~5%). Only makes sense combined with C.2, and even then doesn't reverse the deprecation. |
+| C.2 | Output type (parseXmlToJson → Buffer) | **gated (marginal)** | 100 KB: ~0.5 ms savable (~18%). Together with C.1 plausibly 1.05–1.15× sax @ 100 KB — borderline. 10 MB: JSON.parse JS-side dominates → Buffer-out changes nothing. |
+| C.3 | Batch API | n/a | parse_xml* is already 1-call-per-doc. |
+| C.4 | Stateful API | n/a | quick-xml has no notable setup cost. |
+| C.5 | Parallelization | n/a | XML parse is sequential. |
+| C.6 | Algorithm swap | already done | quick-xml is state-of-the-art. |
+| C.7 | Allocator tuning (SmallVec in decode_attrs) | **gated (small)** | Micro-optimization. ~2–5% plausible, doesn't change classification. |
+| C.8 | Bundle size | already done | Workspace profile. Binary install size (434 KB) can't be pressed below `sax`'s 56 KB. |
 
-**Zusätzlicher Hebel, nicht in der Standard-Liste:**
-- **Filter-/Query-API** (z. B. `extractTextByPath(xml, "//title") → Buffer`)
-  würde JSON.parse ganz umgehen und wäre bei 10 MB plausibel 5–10×
-  sax. Aber das ist ein anderes Produkt. Nicht im Scope von XML-Parse-
-  Deprecation.
+**Additional lever, not in the standard list:**
+- A **filter/query API** (e.g. `extractTextByPath(xml, "//title") → Buffer`)
+  would skip JSON.parse entirely and would plausibly be 5–10× sax at
+  10 MB. But that's a different product. Not in the scope of XML-parse
+  deprecation.
 
 ## Action taken (2026-04-19)
 
-Durchgezogen, da das Paket nie publiziert wurde und keine Migrations-
-Phase nötig ist:
+Pulled through, since the package was never published and no migration
+phase is needed:
 
-1. `crates/xml/` → `archived/xml/` (Git-Rename erhalten).
-2. `archived/xml/package.json` bekommt `"private": true`, `deprecated`-
-   Feld entfernt, description auf archive-hint geändert.
-3. `archived/xml/README.md` komplett umgeschrieben zu Archive-Header +
-   historical-Usage-Beispiel.
-4. Cargo-Workspace (`Cargo.toml`) und pnpm-Workspace (`pnpm-workspace.yaml`)
-   zeigen auf `crates/*` — Move aus `crates/` entfernt xml automatisch,
-   keine Edits nötig. Verifiziert mit `cargo metadata`: amigo-xml nicht
-   mehr Member.
-5. `docs/packages.json` — xml-Eintrag entfernt.
-6. `docs/data.json` — beide xml-Blöcke (benchmarks + install-size)
-   entfernt.
-7. `scripts/measure-size.mjs` — xml-Eintrag entfernt.
-8. `docs/post-mortems/xml.md` — „not tried" durch die realen Zahlen
-   aus dieser Review ersetzt, Status auf „archived 2026-04-19 (never
-   published to npm)" gesetzt, Deprecation-Plan durch Archival-Sektion
-   ersetzt.
-9. `docs/perf-review.md` Ergebnis-Tabelle — xml-Zeile auf
-   🗄️ **ARCHIVED** mit parseXml/parseXmlToJson-Range aktualisiert.
+1. `crates/xml/` → `archived/xml/` (git rename preserved).
+2. `archived/xml/package.json` gets `"private": true`, `deprecated`
+   field removed, description changed to archive hint.
+3. `archived/xml/README.md` completely rewritten to archive header +
+   historical-usage example.
+4. Cargo workspace (`Cargo.toml`) and pnpm workspace (`pnpm-workspace.yaml`)
+   point to `crates/*` — the move out of `crates/` removed xml
+   automatically, no edits needed. Verified with `cargo metadata`: amigo-xml
+   is no longer a member.
+5. `docs/packages.json` — xml entry removed.
+6. `docs/data.json` — both xml blocks (benchmarks + install size)
+   removed.
+7. `scripts/measure-size.mjs` — xml entry removed.
+8. `docs/post-mortems/xml.md` — "not tried" replaced by the real numbers
+   from this review, status set to "archived 2026-04-19 (never
+   published to npm)", deprecation plan replaced by an archival
+   section.
+9. `docs/perf-review.md` result table — xml row updated to
+   🗄️ **ARCHIVED** with parseXml/parseXmlToJson range.
 
-## Nicht durchgeführt — begründet verworfen
+## Not done — justifiably dropped
 
-- **Buffer-I/O-Sprint (C.1/C.2):** Hätte 100 KB plausibel auf 1,05–1,15×
-  `sax` gehoben, aber 10 MB bleibt JSON.parse-dominiert und der
-  Bundle-Size-Gap (7,7×) bleibt. Aufwand für einen Grenzfall-Win am
-  Median nicht gerechtfertigt.
-- **Filter-/Query-API:** Wäre ein anderes Produkt. Falls in Zukunft ein
-  konkreter Use-Case das rechtfertigt: BACKLOG-Eintrag unter einem
-  neuen „XML-Extraction"-Scope, nicht eine Wiederbelebung des
-  General-Purpose-Parsers.
+- **Buffer I/O sprint (C.1/C.2):** would plausibly lift 100 KB to 1.05–1.15×
+  `sax`, but 10 MB stays JSON.parse-dominated and the
+  bundle-size gap (7.7×) stays. Effort not justified for a borderline win
+  at the median.
+- **Filter/query API:** would be a different product. If a concrete
+  use-case justifies it in the future: BACKLOG entry under a new
+  "XML extraction" scope, not a revival of the general-purpose
+  parser.
 
 ## References
 
 - Archived crate: `archived/xml/` (was `crates/xml/`)
 - Bench (historical): removed with the deprecated-bench cleanup; see git history for `archived/xml/__bench__/index.bench.ts`
 - Lib (historical): `archived/xml/src/lib.rs`
-- Post-Mortem (updated with measured numbers): `docs/post-mortems/xml.md`
-- FFI-Baseline: `docs/BASELINE.md`
+- Post-mortem (updated with measured numbers): `docs/post-mortems/xml.md`
+- FFI baseline: `docs/BASELINE.md`
 - Implementation commit `parseXmlToJson`: `d1e2e46`
 - Re-bench + archive commits: this PR


### PR DESCRIPTION
The BASELINE.md doc was mixed German/English. Translate the German
prose and headings to English so all documentation in the repo is
consistent.