### PR TITLE
fix: address every P0/P1/P2 finding in the 2026-04-25 code review

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,23 @@
+# cargo-audit configuration for the audit-rust CI job.
+#
+# The CI step runs `cargo audit --deny warnings` so any new advisory —
+# vulnerability OR unmaintained-package — fails the build. The list
+# below carves out only the specific transitive advisories we already
+# know about, with a one-line reason and the upstream that pulls them
+# in. Each entry should get re-evaluated on every typst version bump.
+
+[advisories]
+ignore = [
+    # `yaml-rust` is unmaintained per RUSTSEC-2024-0320. Pulled by
+    # `syntect` → `typst-library` → `typst`. Typst's syntax-highlighting
+    # path is the only consumer; we don't drive yaml-rust ourselves.
+    "RUSTSEC-2024-0320",
+    # `paste` is no longer maintained per RUSTSEC-2024-0436. Pulled by
+    # `hayagriva` (typst's citation processor) and `biblatex`. No direct
+    # use from our crates.
+    "RUSTSEC-2024-0436",
+    # `bincode 1.3.3` is unmaintained per RUSTSEC-2025-0141. Pulled by
+    # `syntect` → `typst-library`. The 2.x line is maintained but
+    # syntect hasn't migrated yet.
+    "RUSTSEC-2025-0141",
+]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Dependabot keeps three ecosystems aligned for amigo-native:
+#
+# - cargo: workspace-wide updates for every `Cargo.toml` under `crates/`
+#   plus the root manifest
+# - npm: per-crate `package.json` updates for both runtime and devDeps
+# - github-actions: pinned action references in `.github/workflows/`
+#
+# Updates land as a single weekly batch on Monday morning UTC. The
+# manifest layout is `crates/<name>/{Cargo.toml,package.json}` so we use
+# `directories` (plural) where Dependabot supports it. Fall back to
+# explicit per-directory entries where it doesn't.
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor:
+        update-types: ['minor', 'patch']
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor:
+        update-types: ['minor', 'patch']
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install cargo-audit
-        run: cargo install --locked cargo-audit
+      # taiki-e/install-action downloads a prebuilt cargo-audit binary
+      # from the upstream release page (~3s) and caches it across runs;
+      # `cargo install --locked cargo-audit` rebuilt it from source on
+      # every push (~2 minutes plus crates.io flake risk).
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
       - name: Run cargo audit
         run: cargo audit --deny warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  NODE_VERSION: '24'
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -23,12 +26,22 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Check crate registry is in sync
         run: node scripts/sync-registry.mjs --check
       - run: pnpm run lint
+
+  audit-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+      - name: Run cargo audit
+        run: cargo audit --deny warnings
 
   test-rust:
     runs-on: ubuntu-latest
@@ -51,7 +64,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build all crates
@@ -75,7 +88,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Download NAPI binaries
@@ -101,7 +114,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Download NAPI binaries
@@ -172,7 +185,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Download NAPI binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  NODE_VERSION: '24'
+
 jobs:
   resolve:
     runs-on: ubuntu-latest
@@ -98,7 +101,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
@@ -127,7 +130,7 @@ jobs:
         shell: bash
         run: pnpm --filter @amigo-labs/${{ needs.resolve.outputs.crate }} run build --target ${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.target }}
           path: crates/${{ needs.resolve.outputs.crate }}/*.node
@@ -143,7 +146,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
           cache: pnpm
       - run: pnpm install --frozen-lockfile
@@ -158,7 +161,7 @@ jobs:
             fi
           done
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ pnpm bench          # full benchmark suite
 Prerequisites:
 
 - Rust (edition 2024)
-- Node.js ≥ 20
+- Node.js ≥ 22
 - pnpm
 
 ## Proposing a new package

--- a/crates/bm25/src/lib.rs
+++ b/crates/bm25/src/lib.rs
@@ -90,7 +90,7 @@ impl Bm25Index {
     /// whole corpus. Preferred over repeated `addDoc`.
     #[napi(js_name = "addAll")]
     pub fn add_all(&self, docs: Vec<BmDocument>) -> Result<()> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         for doc in docs {
             let toks = inner.tokenize(&doc.text);
             inner.index.add(doc.id, toks);
@@ -101,7 +101,7 @@ impl Bm25Index {
     /// Add a single document. Prefer `addAll` for bulk ingest.
     #[napi(js_name = "addDoc")]
     pub fn add_doc(&self, id: String, text: String) -> Result<()> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let toks = inner.tokenize(&text);
         inner.index.add(id, toks);
         Ok(())
@@ -109,7 +109,7 @@ impl Bm25Index {
 
     #[napi(js_name = "search")]
     pub fn search(&self, query: String, options: Option<SearchOptions>) -> Vec<SearchHit> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let query_tokens = inner.tokenize(&query);
         let scores = bm25_scores(&inner.index, &query_tokens, inner.params);
         let limit = options.and_then(|o| o.limit).unwrap_or(10) as usize;
@@ -125,6 +125,10 @@ impl Bm25Index {
 
     #[napi(js_name = "size")]
     pub fn size(&self) -> u32 {
-        self.inner.lock().unwrap().index.len() as u32
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .index
+            .len() as u32
     }
 }

--- a/crates/deepmerge/__conformance__/parity.spec.ts
+++ b/crates/deepmerge/__conformance__/parity.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Core parity smoke against deepmerge@4. The exhaustive case matrix
+ * lives in `upstream.spec.ts`; this file is the contract gate that
+ * every release must pass.
+ */
+import { describe, it, expect } from 'vitest'
+import amigoMerge from '../wrapper.js'
+import upstream from 'deepmerge'
+
+describe('deepmerge — parity gate', () => {
+  it('flat object merge matches upstream', () => {
+    const a = { x: 1, y: 2 }
+    const b = { y: 99, z: 3 }
+    expect(amigoMerge(a, b)).toEqual(upstream(a, b))
+  })
+
+  it('deep nested merge matches upstream', () => {
+    const a = { x: { a: 1, y: { z: 1 } } }
+    const b = { x: { b: 2, y: { w: 2 } } }
+    expect(amigoMerge(a, b)).toEqual(upstream(a, b))
+  })
+
+  it('default array concat matches upstream', () => {
+    const a = { l: [1, 2] }
+    const b = { l: [3, 4] }
+    expect(amigoMerge(a, b)).toEqual(upstream(a, b))
+  })
+
+  it('__proto__ pollution is filtered (matches upstream)', () => {
+    const poison = JSON.parse('{"__proto__": {"polluted": true}}')
+    const amigo = amigoMerge({}, poison) as Record<string, unknown>
+    const ups = upstream({}, poison) as Record<string, unknown>
+    expect(amigo.polluted).toBeUndefined()
+    expect(ups.polluted).toBeUndefined()
+  })
+})

--- a/crates/deepmerge/package.json
+++ b/crates/deepmerge/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "napi pre-publish --skip-optional-publish --no-gh-release",
     "test": "vitest run __test__",
     "bench": "vitest bench",
-    "test:conformance": "vitest run __conformance__/fuzz.spec.ts",
+    "test:conformance": "vitest run __conformance__",
     "test:all": "vitest run",
     "test:upstream": "vitest run __conformance__/upstream.spec.ts"
   },

--- a/crates/diff/src/lib.rs
+++ b/crates/diff/src/lib.rs
@@ -112,7 +112,7 @@ pub fn diff_trimmed_lines(old_str: String, new_str: String) -> Vec<Hunk> {
 /// This is the Green hot-path for large or char-level diffs where the
 /// hunk-array shape drowns in Vec<String> allocation.
 #[napi(js_name = "diffLinesToOffsets")]
-pub fn diff_lines_to_offsets(old_str: String, new_str: String) -> Buffer {
+pub fn diff_lines_to_offsets(old_str: String, new_str: String) -> Result<Buffer> {
     build_offsets(
         TextDiff::from_lines(&old_str, &new_str)
             .iter_all_changes()
@@ -122,7 +122,7 @@ pub fn diff_lines_to_offsets(old_str: String, new_str: String) -> Buffer {
 
 /// Offset-packed char diff. Same layout as `diffLinesToOffsets`.
 #[napi(js_name = "diffCharsToOffsets")]
-pub fn diff_chars_to_offsets(old_str: String, new_str: String) -> Buffer {
+pub fn diff_chars_to_offsets(old_str: String, new_str: String) -> Result<Buffer> {
     build_offsets(
         TextDiff::from_chars(&old_str, &new_str)
             .iter_all_changes()
@@ -131,7 +131,14 @@ pub fn diff_chars_to_offsets(old_str: String, new_str: String) -> Buffer {
 }
 
 /// Shared builder for the offset-packed layout. Each entry is 5 × u32.
-fn build_offsets<I: Iterator<Item = (ChangeTag, usize)>>(iter: I) -> Buffer {
+///
+/// Offsets are u32 because the JS surface unpacks them with
+/// `Uint32Array`. A single hunk longer than `u32::MAX` (~4 GiB) would
+/// overflow `old_pos`/`new_pos` silently and emit nonsense entries; bail
+/// instead with a napi error. Real diff inputs that exceed 4 GiB are
+/// vanishingly rare but the failure mode (silent corruption) is bad
+/// enough to warrant the check.
+fn build_offsets<I: Iterator<Item = (ChangeTag, usize)>>(iter: I) -> Result<Buffer> {
     let mut out: Vec<u8> = Vec::new();
     let mut old_pos: u32 = 0;
     let mut new_pos: u32 = 0;
@@ -173,11 +180,20 @@ fn build_offsets<I: Iterator<Item = (ChangeTag, usize)>>(iter: I) -> Buffer {
             run_new_start = new_pos;
         }
 
+        let len_u32: u32 = len.try_into().map_err(|_| {
+            Error::from_reason(format!(
+                "diff hunk of {len} elements exceeds u32::MAX; offset buffer can't represent it"
+            ))
+        })?;
         if adv_old {
-            old_pos += len as u32;
+            old_pos = old_pos.checked_add(len_u32).ok_or_else(|| {
+                Error::from_reason("offset overflow on old side; total length > u32::MAX")
+            })?;
         }
         if adv_new {
-            new_pos += len as u32;
+            new_pos = new_pos.checked_add(len_u32).ok_or_else(|| {
+                Error::from_reason("offset overflow on new side; total length > u32::MAX")
+            })?;
         }
     }
 
@@ -192,7 +208,7 @@ fn build_offsets<I: Iterator<Item = (ChangeTag, usize)>>(iter: I) -> Buffer {
         );
     }
 
-    out.into()
+    Ok(out.into())
 }
 
 /// Unified-diff-format patch string.

--- a/crates/encoding/__conformance__/parity.spec.ts
+++ b/crates/encoding/__conformance__/parity.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Core parity smoke against iconv-lite@0.6. The exhaustive encoding
+ * matrix lives in `upstream.spec.ts`; this file is the contract gate
+ * that every release must pass.
+ */
+import { describe, it, expect } from 'vitest'
+import { encode as amigoEncode, decode as amigoDecode, encodingExists as amigoExists } from '../index.js'
+import * as iconv from 'iconv-lite'
+
+const STRINGS: Array<[string, string]> = [
+  ['ascii', 'Hello, World!'],
+  ['latin1-range', 'café résumé'],
+  ['cyrillic', 'Привет мир'],
+  ['japanese', 'こんにちは世界'],
+  ['emoji', 'Hello 🌍'],
+]
+
+describe('encoding — parity gate: utf-8 roundtrip', () => {
+  for (const [name, s] of STRINGS) {
+    it(`utf-8 encode(${name})`, () => {
+      const a = Buffer.from(amigoEncode(s, 'utf-8'))
+      const b = iconv.encode(s, 'utf-8')
+      expect(a.equals(b)).toBe(true)
+    })
+
+    it(`utf-8 decode(${name})`, () => {
+      const bytes = iconv.encode(s, 'utf-8')
+      expect(amigoDecode(bytes, 'utf-8')).toBe(iconv.decode(bytes, 'utf-8'))
+    })
+  }
+})
+
+describe('encoding — parity gate: encodingExists', () => {
+  for (const label of ['utf-8', 'utf8', 'latin1', 'windows-1252', 'shift_jis', 'gbk']) {
+    it(`recognises "${label}"`, () => {
+      expect(amigoExists(label)).toBe(iconv.encodingExists(label))
+    })
+  }
+})

--- a/crates/encoding/package.json
+++ b/crates/encoding/package.json
@@ -38,7 +38,7 @@
     "prepublishOnly": "napi pre-publish --skip-optional-publish --no-gh-release",
     "test": "vitest run __test__",
     "bench": "vitest bench",
-    "test:conformance": "vitest run __conformance__/fuzz.spec.ts",
+    "test:conformance": "vitest run __conformance__",
     "test:all": "vitest run",
     "test:upstream": "vitest run __conformance__/upstream.spec.ts"
   },

--- a/crates/file-type/__conformance__/parity.spec.ts
+++ b/crates/file-type/__conformance__/parity.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Core parity smoke against file-type@19. The exhaustive magic-byte
+ * matrix lives in `upstream.spec.ts`; this file is the contract gate
+ * that every release must pass.
+ */
+import { describe, it, expect } from 'vitest'
+import { fileTypeFromBufferSync as amigoSync } from '../index.js'
+import { fileTypeFromBuffer as upstreamAsync } from 'file-type'
+
+const FIXTURES: Array<{ name: string; bytes: number[] }> = [
+  {
+    name: 'PNG',
+    bytes: [
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+      0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
+      0x15, 0xc4, 0x89,
+    ],
+  },
+  { name: 'JPEG', bytes: [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46] },
+  { name: 'PDF', bytes: [0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e] },
+  { name: 'GZIP', bytes: [0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00] },
+]
+
+function mimeEquiv(a?: string | null, b?: string | null): boolean {
+  if (!a || !b) return !a && !b
+  if (a === b) return true
+  return a.replace('application/x-zip', 'application/zip') === b.replace('application/x-zip', 'application/zip')
+}
+
+describe('file-type — parity gate', () => {
+  for (const fx of FIXTURES) {
+    it(`agrees on ${fx.name}`, async () => {
+      const buf = Buffer.from(fx.bytes)
+      const ours = amigoSync(buf)
+      const theirs = await upstreamAsync(new Uint8Array(buf))
+      expect(!!ours).toBe(!!theirs)
+      if (ours && theirs) expect(mimeEquiv(ours.mime, theirs.mime)).toBe(true)
+    })
+  }
+
+  it('returns null on plain text (matches upstream)', async () => {
+    const buf = Buffer.from('just some plain text')
+    const ours = amigoSync(buf)
+    const theirs = await upstreamAsync(new Uint8Array(buf))
+    expect(!!ours).toBe(!!theirs)
+  })
+})

--- a/crates/file-type/package.json
+++ b/crates/file-type/package.json
@@ -35,7 +35,7 @@
     "prepublishOnly": "napi pre-publish --skip-optional-publish --no-gh-release",
     "test": "vitest run __test__",
     "bench": "vitest bench",
-    "test:conformance": "vitest run __conformance__/fuzz.spec.ts",
+    "test:conformance": "vitest run __conformance__",
     "test:all": "vitest run",
     "test:upstream": "vitest run __conformance__/upstream.spec.ts"
   },

--- a/crates/inflate/__conformance__/parity.spec.ts
+++ b/crates/inflate/__conformance__/parity.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Core parity smoke against pako@2 and node:zlib. The full input matrix
+ * (including 100 KB inputs and the raw-vs-zlib variants) lives in
+ * `upstream.spec.ts`; this file is the contract gate that every release
+ * must pass.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  deflate as amigoDeflate,
+  inflate as amigoInflate,
+  gzip as amigoGzip,
+  ungzip as amigoUngzip,
+} from '../index.js'
+import pako from 'pako'
+import * as zlib from 'node:zlib'
+
+const INPUTS: Array<[string, Buffer]> = [
+  ['empty', Buffer.alloc(0)],
+  ['small-ascii', Buffer.from('hello world', 'utf-8')],
+  ['repeated-1KB', Buffer.from('amigo '.repeat(200), 'utf-8')],
+]
+
+describe('inflate — parity gate vs pako@2', () => {
+  for (const [name, input] of INPUTS) {
+    it(`amigo.deflate → pako.inflate (${name})`, () => {
+      const enc = amigoDeflate(input)
+      const dec = Buffer.from(pako.inflate(enc))
+      expect(dec.equals(input)).toBe(true)
+    })
+
+    it(`pako.deflate → amigo.inflate (${name})`, () => {
+      const enc = Buffer.from(pako.deflate(input))
+      const dec = amigoInflate(enc)
+      expect(dec.equals(input)).toBe(true)
+    })
+
+    it(`amigo.gzip → pako.ungzip (${name})`, () => {
+      const enc = amigoGzip(input)
+      const dec = Buffer.from(pako.ungzip(enc))
+      expect(dec.equals(input)).toBe(true)
+    })
+  }
+})
+
+describe('inflate — parity gate vs node:zlib', () => {
+  it('amigo.deflate → zlib.inflateSync round-trips', () => {
+    const input = Buffer.from('the quick brown fox', 'utf-8')
+    const enc = amigoDeflate(input)
+    const dec = zlib.inflateSync(enc)
+    expect(Buffer.from(dec).equals(input)).toBe(true)
+  })
+
+  it('zlib.deflateSync → amigo.inflate round-trips', () => {
+    const input = Buffer.from('the quick brown fox', 'utf-8')
+    const enc = zlib.deflateSync(input)
+    const dec = amigoInflate(Buffer.from(enc))
+    expect(dec.equals(input)).toBe(true)
+  })
+
+  it('amigo.ungzip rejects oversize input above maxOutputSize', () => {
+    const input = Buffer.alloc(1024 * 1024)
+    const enc = amigoGzip(input)
+    expect(() => amigoUngzip(enc, { maxOutputSize: 256 * 1024 })).toThrow(/max_output_size/)
+  })
+})

--- a/crates/inflate/__test__/index.spec.ts
+++ b/crates/inflate/__test__/index.spec.ts
@@ -36,4 +36,20 @@ describe('inflate', () => {
   it('throws on malformed zlib input', () => {
     expect(() => inflate(Buffer.from([0, 1, 2, 3]))).toThrow()
   })
+
+  it('rejects decompression bomb above maxOutputSize', () => {
+    // 1 MiB of zeros compresses to ~1 KiB; with a 256 KiB cap the
+    // decompressor must error rather than produce the full output.
+    const bomb = gzip(Buffer.alloc(1024 * 1024))
+    expect(() => ungzip(bomb, { maxOutputSize: 256 * 1024 })).toThrow(/max_output_size/)
+
+    const zlibBomb = deflate(Buffer.alloc(1024 * 1024))
+    expect(() => inflate(zlibBomb, { maxOutputSize: 256 * 1024 })).toThrow(/max_output_size/)
+  })
+
+  it('passes when decompressed size is under maxOutputSize', () => {
+    const enc = gzip(Buffer.from('hello world'.repeat(100)))
+    const out = ungzip(enc, { maxOutputSize: 64 * 1024 })
+    expect(out.length).toBeGreaterThan(0)
+  })
 })

--- a/crates/inflate/index.d.ts
+++ b/crates/inflate/index.d.ts
@@ -6,13 +6,21 @@ export declare function deflateRaw(data: Buffer, options?: InflateOptions | unde
 
 export declare function gzip(data: Buffer, options?: InflateOptions | undefined | null): Buffer
 
-export declare function inflate(data: Buffer): Buffer
+export declare function inflate(data: Buffer, options?: InflateOptions | undefined | null): Buffer
 
 export interface InflateOptions {
   /** Compression level 0–9 (default 6, analogous to pako). */
   level?: number
+  /**
+   * Hard cap on decompressed output size in bytes. Defaults to
+   * `DEFAULT_MAX_OUTPUT_SIZE` (256 MiB). Decompression that would
+   * exceed this limit returns a napi error rather than allocating
+   * further. Pass `0` to disable the cap (not recommended for
+   * untrusted input — gzip bombs expand to terabytes).
+   */
+  maxOutputSize?: number
 }
 
-export declare function inflateRaw(data: Buffer): Buffer
+export declare function inflateRaw(data: Buffer, options?: InflateOptions | undefined | null): Buffer
 
-export declare function ungzip(data: Buffer): Buffer
+export declare function ungzip(data: Buffer, options?: InflateOptions | undefined | null): Buffer

--- a/crates/inflate/package.json
+++ b/crates/inflate/package.json
@@ -37,7 +37,7 @@
     "prepublishOnly": "napi pre-publish --skip-optional-publish --no-gh-release",
     "test": "vitest run __test__",
     "bench": "vitest bench",
-    "test:conformance": "vitest run __conformance__/fuzz.spec.ts",
+    "test:conformance": "vitest run __conformance__",
     "test:all": "vitest run",
     "test:upstream": "vitest run __conformance__/upstream.spec.ts"
   },

--- a/crates/inflate/src/lib.rs
+++ b/crates/inflate/src/lib.rs
@@ -11,15 +11,34 @@ use std::io::{Read, Write};
 pub struct InflateOptions {
     /// Compression level 0–9 (default 6, analogous to pako).
     pub level: Option<u32>,
+    /// Hard cap on decompressed output size in bytes. Defaults to
+    /// `DEFAULT_MAX_OUTPUT_SIZE` (256 MiB). Decompression that would
+    /// exceed this limit returns a napi error rather than allocating
+    /// further. Pass `0` to disable the cap (not recommended for
+    /// untrusted input — gzip bombs expand to terabytes).
+    pub max_output_size: Option<u32>,
 }
+
+/// Default decompression-bomb guard (256 MiB). A 10 MB gzip bomb that
+/// expands to 100 GB hits this limit at 256 MB and is rejected, leaving
+/// the host process responsive.
+const DEFAULT_MAX_OUTPUT_SIZE: u64 = 256 * 1024 * 1024;
 
 fn to_napi_err<E: std::fmt::Display>(e: E) -> Error {
     Error::from_reason(e.to_string())
 }
 
-fn compression_from(opts: Option<InflateOptions>) -> Compression {
+fn compression_from(opts: Option<&InflateOptions>) -> Compression {
     let level = opts.and_then(|o| o.level).unwrap_or(6).min(9);
     Compression::new(level)
+}
+
+fn max_output_size_from(opts: Option<&InflateOptions>) -> u64 {
+    match opts.and_then(|o| o.max_output_size) {
+        Some(0) => u64::MAX,
+        Some(n) => n as u64,
+        None => DEFAULT_MAX_OUTPUT_SIZE,
+    }
 }
 
 /// Heuristic for the decompressed-size pre-allocation. Real-world
@@ -52,9 +71,10 @@ fn estimated_inflate_size(compressed_len: usize) -> usize {
 /// `clippy::uninit_vec` is a conservative default; for `u8` every bit
 /// pattern is valid and `decompress` writes every byte we expose.
 #[allow(clippy::uninit_vec)]
-fn decompress_bulk(input: &[u8], zlib_header: bool) -> Result<Vec<u8>> {
+fn decompress_bulk(input: &[u8], zlib_header: bool, max_output: u64) -> Result<Vec<u8>> {
     let mut dec = Decompress::new(zlib_header);
-    let initial = estimated_inflate_size(input.len()).max(64);
+    let cap = (max_output.min(usize::MAX as u64)) as usize;
+    let initial = estimated_inflate_size(input.len()).max(64).min(cap);
     let mut out: Vec<u8> = Vec::with_capacity(initial);
     // SAFETY: `decompress` only writes into `&mut out[out_pos..]`; we
     // truncate to `total_out` before handing `out` to any reader.
@@ -63,7 +83,7 @@ fn decompress_bulk(input: &[u8], zlib_header: bool) -> Result<Vec<u8>> {
         let in_pos = dec.total_in() as usize;
         let out_pos = dec.total_out() as usize;
         if out_pos == out.len() {
-            grow_uninit(&mut out);
+            grow_uninit(&mut out, cap)?;
         }
         match dec
             .decompress(
@@ -82,7 +102,7 @@ fn decompress_bulk(input: &[u8], zlib_header: bool) -> Result<Vec<u8>> {
                 // input, but we gave everything upfront). Grow unless we
                 // just made forward progress on `Ok`.
                 if (dec.total_out() as usize) == out_pos {
-                    grow_uninit(&mut out);
+                    grow_uninit(&mut out, cap)?;
                 }
             }
         }
@@ -91,53 +111,71 @@ fn decompress_bulk(input: &[u8], zlib_header: bool) -> Result<Vec<u8>> {
 
 #[inline]
 #[allow(clippy::uninit_vec)]
-fn grow_uninit(out: &mut Vec<u8>) {
-    let new_len = out.len().saturating_mul(2).max(out.len() + 1);
+fn grow_uninit(out: &mut Vec<u8>, cap: usize) -> Result<()> {
+    if out.len() >= cap {
+        return Err(Error::from_reason(format!(
+            "decompressed size exceeds max_output_size ({cap} bytes)"
+        )));
+    }
+    let new_len = out.len().saturating_mul(2).max(out.len() + 1).min(cap);
     out.reserve(new_len - out.len());
     // SAFETY: see `decompress_bulk` — the tail is written by `decompress`
     // before any read observes it; we truncate before return.
     unsafe { out.set_len(new_len) };
+    Ok(())
 }
 
 #[napi]
 pub fn deflate(data: Buffer, options: Option<InflateOptions>) -> Result<Buffer> {
-    let mut enc = ZlibEncoder::new(Vec::new(), compression_from(options));
+    let mut enc = ZlibEncoder::new(Vec::new(), compression_from(options.as_ref()));
     enc.write_all(&data).map_err(to_napi_err)?;
     let out = enc.finish().map_err(to_napi_err)?;
     Ok(out.into())
 }
 
 #[napi]
-pub fn inflate(data: Buffer) -> Result<Buffer> {
-    decompress_bulk(data.as_ref(), /* zlib_header = */ true).map(Into::into)
+pub fn inflate(data: Buffer, options: Option<InflateOptions>) -> Result<Buffer> {
+    let max = max_output_size_from(options.as_ref());
+    decompress_bulk(data.as_ref(), /* zlib_header = */ true, max).map(Into::into)
 }
 
 #[napi]
 pub fn deflate_raw(data: Buffer, options: Option<InflateOptions>) -> Result<Buffer> {
-    let mut enc = DeflateEncoder::new(Vec::new(), compression_from(options));
+    let mut enc = DeflateEncoder::new(Vec::new(), compression_from(options.as_ref()));
     enc.write_all(&data).map_err(to_napi_err)?;
     let out = enc.finish().map_err(to_napi_err)?;
     Ok(out.into())
 }
 
 #[napi]
-pub fn inflate_raw(data: Buffer) -> Result<Buffer> {
-    decompress_bulk(data.as_ref(), /* zlib_header = */ false).map(Into::into)
+pub fn inflate_raw(data: Buffer, options: Option<InflateOptions>) -> Result<Buffer> {
+    let max = max_output_size_from(options.as_ref());
+    decompress_bulk(data.as_ref(), /* zlib_header = */ false, max).map(Into::into)
 }
 
 #[napi]
 pub fn gzip(data: Buffer, options: Option<InflateOptions>) -> Result<Buffer> {
-    let mut enc = GzEncoder::new(Vec::new(), compression_from(options));
+    let mut enc = GzEncoder::new(Vec::new(), compression_from(options.as_ref()));
     enc.write_all(&data).map_err(to_napi_err)?;
     let out = enc.finish().map_err(to_napi_err)?;
     Ok(out.into())
 }
 
 #[napi]
-pub fn ungzip(data: Buffer) -> Result<Buffer> {
-    let mut dec = GzDecoder::new(data.as_ref());
-    let mut out = Vec::with_capacity(estimated_inflate_size(data.len()));
+pub fn ungzip(data: Buffer, options: Option<InflateOptions>) -> Result<Buffer> {
+    let max = max_output_size_from(options.as_ref());
+    let cap = (max.min(usize::MAX as u64)) as usize;
+    // Read up to `max + 1` bytes — if the +1 ever materialises, the
+    // stream wanted to produce more output than the cap allows.
+    let read_limit = max.saturating_add(1);
+    let mut dec = GzDecoder::new(data.as_ref()).take(read_limit);
+    let mut out = Vec::with_capacity(estimated_inflate_size(data.len()).min(cap));
     dec.read_to_end(&mut out).map_err(to_napi_err)?;
+    if out.len() as u64 > max {
+        return Err(Error::from_reason(format!(
+            "decompressed size exceeds max_output_size ({max} bytes)"
+        )));
+    }
     Ok(out.into())
 }
 
@@ -176,4 +214,9 @@ mod tests {
         let data: Vec<u8> = (0..1_000_000).map(|i| (i % 251) as u8).collect();
         roundtrip_zlib(&data);
     }
+
+    // The `max_output_size` cap is exercised end-to-end from the vitest
+    // suite (`__test__/index.spec.ts`) — covering it here would require
+    // calling `decompress_bulk` directly, which returns `napi::Result`
+    // and pulls napi runtime symbols into the test binary.
 }

--- a/crates/jose/package.json
+++ b/crates/jose/package.json
@@ -2,9 +2,11 @@
   "name": "@amigo-labs/jose",
   "version": "0.1.0",
   "description": "JOSE primitives — JWK key generation and RFC 7638 thumbprints",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "wrapper.js",
+  "types": "wrapper.d.ts",
   "files": [
+    "wrapper.js",
+    "wrapper.d.ts",
     "index.js",
     "index.d.ts",
     "README.md"

--- a/crates/jose/wrapper.d.ts
+++ b/crates/jose/wrapper.d.ts
@@ -1,0 +1,26 @@
+/** A JSON Web Key per RFC 7517. The shape varies by `kty` (OKP/EC/RSA/oct);
+ * the library treats it as opaque key material and only inspects the canonical
+ * required fields when computing thumbprints. */
+export type Jwk = Record<string, unknown>
+
+/** A JWK key-pair — both public and private representations of the same key. */
+export interface JwkKeyPair {
+  publicJwk: Jwk
+  privateJwk: Jwk
+}
+
+/**
+ * Generate a fresh Ed25519 key-pair as JWKs (RFC 8037 OKP form).
+ *
+ * Synchronous: Ed25519 key generation is microsecond-scale.
+ */
+export declare function generateEd25519KeyPair(): JwkKeyPair
+
+/**
+ * Compute the SHA-256 JWK thumbprint per RFC 7638.
+ *
+ * The thumbprint is a stable, kid-independent identifier for the key. The
+ * caller passes either a public or private JWK; only the canonical required
+ * fields are hashed (no `kid`, no `alg`, no private-key components).
+ */
+export declare function jwkThumbprint(jwk: Jwk): string

--- a/crates/jose/wrapper.js
+++ b/crates/jose/wrapper.js
@@ -1,0 +1,3 @@
+// Public-surface wrapper. Re-exports the auto-generated NAPI module
+// with a typed shape (see wrapper.d.ts).
+module.exports = require('./index.js')

--- a/crates/jwt/__conformance__/parity.spec.ts
+++ b/crates/jwt/__conformance__/parity.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Core parity smoke against jsonwebtoken@9. Algorithm matrix and
+ * RSA/ECDSA round-trips live in `upstream.spec.ts`; this file is the
+ * contract gate that every release must pass.
+ */
+import { describe, it, expect } from 'vitest'
+import * as amigo from '../wrapper.js'
+import jsonwebtoken from 'jsonwebtoken'
+
+const HS_SECRET = 'amigo-labs-test-secret-at-least-32-bytes-long-pad'
+
+describe('jwt — parity gate: HS256 cross-verify', () => {
+  it('amigo-signed verifies under jsonwebtoken', async () => {
+    const token = await amigo.sign({ sub: 'alice' }, HS_SECRET, { algorithm: 'HS256' })
+    const decoded = jsonwebtoken.verify(token, HS_SECRET, { algorithms: ['HS256'] }) as Record<
+      string,
+      unknown
+    >
+    expect(decoded.sub).toBe('alice')
+  })
+
+  it('jsonwebtoken-signed verifies under amigo', async () => {
+    const token = jsonwebtoken.sign({ sub: 'bob' }, HS_SECRET, { algorithm: 'HS256' })
+    const payload = (await amigo.verify(token, HS_SECRET, { algorithms: ['HS256'] })) as Record<
+      string,
+      unknown
+    >
+    expect(payload.sub).toBe('bob')
+  })
+
+  it('rejects tokens with tampered payload', async () => {
+    const token = await amigo.sign({ sub: 'alice' }, HS_SECRET, { algorithm: 'HS256' })
+    const [h, , s] = token.split('.')
+    const tampered = `${h}.${Buffer.from(JSON.stringify({ sub: 'eve' })).toString('base64url')}.${s}`
+    await expect(amigo.verify(tampered, HS_SECRET)).rejects.toThrow()
+  })
+
+  it('rejects "alg=none" attacks (matches jsonwebtoken)', async () => {
+    const noneToken =
+      Buffer.from('{"alg":"none","typ":"JWT"}').toString('base64url') +
+      '.' +
+      Buffer.from('{"sub":"eve"}').toString('base64url') +
+      '.'
+    await expect(amigo.verify(noneToken, HS_SECRET)).rejects.toThrow()
+  })
+})

--- a/crates/jwt/package.json
+++ b/crates/jwt/package.json
@@ -37,7 +37,7 @@
     "prepublishOnly": "napi pre-publish --skip-optional-publish --no-gh-release",
     "test": "vitest run __test__",
     "bench": "vitest bench",
-    "test:conformance": "vitest run __conformance__/fuzz.spec.ts",
+    "test:conformance": "vitest run __conformance__",
     "test:all": "vitest run",
     "test:upstream": "vitest run __conformance__/upstream.spec.ts"
   },

--- a/crates/minisearch/src/lib.rs
+++ b/crates/minisearch/src/lib.rs
@@ -114,7 +114,7 @@ impl MiniSearch {
     /// Single-FFI-crossing corpus ingest.
     #[napi(js_name = "addAll")]
     pub fn add_all(&self, docs: Vec<MiniDocument>) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         for doc in docs {
             let toks = inner.tokenize(&doc.text);
             inner.index.add(doc.id, toks);
@@ -123,14 +123,14 @@ impl MiniSearch {
 
     #[napi(js_name = "add")]
     pub fn add(&self, doc: MiniDocument) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let toks = inner.tokenize(&doc.text);
         inner.index.add(doc.id, toks);
     }
 
     #[napi(js_name = "search")]
     pub fn search(&self, query: String, options: Option<MiniSearchOptions>) -> Vec<MiniHit> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let opts = options.unwrap_or(MiniSearchOptions {
             limit: None,
             prefix: None,
@@ -178,7 +178,7 @@ impl MiniSearch {
     /// ranked by how many docs contain them.
     #[napi(js_name = "autoSuggest")]
     pub fn auto_suggest(&self, prefix: String, limit: Option<u32>) -> Vec<AutoSuggestion> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let mut out: Vec<AutoSuggestion> = prefix_match(&inner.index, &prefix)
             .into_iter()
             .map(|term| {
@@ -206,7 +206,11 @@ impl MiniSearch {
 
     #[napi(js_name = "size")]
     pub fn size(&self) -> u32 {
-        self.inner.lock().unwrap().index.len() as u32
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .index
+            .len() as u32
     }
 }
 

--- a/crates/nanoid/__conformance__/parity.spec.ts
+++ b/crates/nanoid/__conformance__/parity.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Core parity smoke against nanoid@5. The full structural-properties
+ * matrix lives in `upstream.spec.ts`; this file is the contract gate
+ * that every release must pass.
+ */
+import { describe, it, expect } from 'vitest'
+import { nanoid as amigoNanoid, customAlphabet as amigoCustomAlphabet } from '../wrapper.js'
+import { nanoid as upstreamNanoid } from 'nanoid'
+
+const DEFAULT_ALPHABET = /^[A-Za-z0-9_-]+$/
+
+describe('nanoid — parity gate', () => {
+  it('default length is 21', () => {
+    expect(amigoNanoid().length).toBe(21)
+    expect(upstreamNanoid().length).toBe(21)
+  })
+
+  it('default alphabet matches URL-safe', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(amigoNanoid()).toMatch(DEFAULT_ALPHABET)
+    }
+  })
+
+  it('respects custom size', () => {
+    for (const n of [1, 16, 32, 64]) {
+      expect(amigoNanoid(n).length).toBe(n)
+    }
+  })
+
+  it('no collisions in 1000 ids', () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 1000; i++) seen.add(amigoNanoid())
+    expect(seen.size).toBe(1000)
+  })
+
+  it('customAlphabet respects alphabet and size', () => {
+    const factory = amigoCustomAlphabet('AB', 8)
+    const id = factory()
+    expect(id.length).toBe(8)
+    expect(id).toMatch(/^[AB]+$/)
+  })
+})

--- a/crates/nanoid/package.json
+++ b/crates/nanoid/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "vitest run __test__",
     "bench": "vitest bench",
-    "test:conformance": "vitest run __conformance__/fuzz.spec.ts",
+    "test:conformance": "vitest run __conformance__",
     "test:all": "vitest run",
     "test:upstream": "vitest run __conformance__/upstream.spec.ts"
   },

--- a/crates/sanitize-html/__test__/index.spec.ts
+++ b/crates/sanitize-html/__test__/index.spec.ts
@@ -47,4 +47,29 @@ describe('sanitize-html', () => {
   it('isClean accepts safe HTML', () => {
     expect(isClean('hello world')).toBe(true)
   })
+
+  it('caps deeply-nested input via maxDepth', () => {
+    // 1000 levels of nesting; default maxDepth is 256 so the first 256
+    // levels emit, the rest unwrap.
+    const deep = '<div>'.repeat(1000) + 'x' + '</div>'.repeat(1000)
+    const out = sanitize(deep)
+    // Output remains finite and bounded; the unwrapped tail does not
+    // cause any process-level OOM.
+    expect(out.length).toBeGreaterThan(0)
+    // Count opening <div> tags in the output: with cap=256 there should
+    // be at most 256 of them.
+    const opens = (out.match(/<div>/g) ?? []).length
+    expect(opens).toBeLessThanOrEqual(256)
+  })
+
+  it('rejects oversize input via maxInputBytes', () => {
+    const oversize = '<p>x</p>'.repeat(2_000_000) // ~16 MB > 5 MiB default
+    expect(sanitize(oversize)).toBe('')
+  })
+
+  it('honours user-provided maxInputBytes override', () => {
+    const small = '<p>hello world</p>'
+    expect(sanitize(small, { maxInputBytes: 5 })).toBe('') // input larger than 5 bytes
+    expect(sanitize(small, { maxInputBytes: 0 })).toBe('<p>hello world</p>') // disabled
+  })
 })

--- a/crates/sanitize-html/index.d.ts
+++ b/crates/sanitize-html/index.d.ts
@@ -16,6 +16,19 @@ export interface SanitizeOptions {
    * Set by `compat.mjs` when the caller uses `allowedAttributes: false`.
    */
   allowAllAttributes?: boolean
+  /**
+   * Maximum nesting depth before a start tag is unwrapped (content kept,
+   * tag dropped) instead of emitted. Defaults to 256. A pathological
+   * `<div><div>…×100k…</div></div>` input no longer grows the frame
+   * stack without bound. Pass `0` to disable the cap.
+   */
+  maxDepth?: number
+  /**
+   * Hard cap on input length in bytes. Inputs longer than this are
+   * truncated to a deterministic empty string. Defaults to 5 MiB. Pass
+   * `0` to disable the cap.
+   */
+  maxInputBytes?: number
 }
 
 /**

--- a/crates/sanitize-html/npm/darwin-arm64/package.json
+++ b/crates/sanitize-html/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/sanitize-html-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "darwin"
   ],

--- a/crates/sanitize-html/npm/darwin-x64/package.json
+++ b/crates/sanitize-html/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/sanitize-html-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "darwin"
   ],

--- a/crates/sanitize-html/npm/linux-arm64-gnu/package.json
+++ b/crates/sanitize-html/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/sanitize-html-linux-arm64-gnu",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "linux"
   ],

--- a/crates/sanitize-html/npm/linux-x64-gnu/package.json
+++ b/crates/sanitize-html/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/sanitize-html-linux-x64-gnu",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "linux"
   ],

--- a/crates/sanitize-html/npm/linux-x64-musl/package.json
+++ b/crates/sanitize-html/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/sanitize-html-linux-x64-musl",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "linux"
   ],

--- a/crates/sanitize-html/npm/win32-x64-msvc/package.json
+++ b/crates/sanitize-html/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/sanitize-html-win32-x64-msvc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "win32"
   ],

--- a/crates/sanitize-html/src/lib.rs
+++ b/crates/sanitize-html/src/lib.rs
@@ -17,6 +17,15 @@ pub struct SanitizeOptions {
     /// When `true`, every attribute not an event handler passes through.
     /// Set by `compat.mjs` when the caller uses `allowedAttributes: false`.
     pub allow_all_attributes: Option<bool>,
+    /// Maximum nesting depth before a start tag is unwrapped (content kept,
+    /// tag dropped) instead of emitted. Defaults to 256. A pathological
+    /// `<div><div>…×100k…</div></div>` input no longer grows the frame
+    /// stack without bound. Pass `0` to disable the cap.
+    pub max_depth: Option<u32>,
+    /// Hard cap on input length in bytes. Inputs longer than this are
+    /// truncated to a deterministic empty string. Defaults to 5 MiB. Pass
+    /// `0` to disable the cap.
+    pub max_input_bytes: Option<u32>,
 }
 
 fn number_to_string(n: f64) -> String {

--- a/crates/sanitize-html/src/strict.rs
+++ b/crates/sanitize-html/src/strict.rs
@@ -187,11 +187,23 @@ fn emit_element(
     }
 }
 
+/// Same DoS guard as the fast path. See `v2::DEFAULT_MAX_INPUT_BYTES`.
+const DEFAULT_MAX_INPUT_BYTES: usize = 5 * 1024 * 1024;
+
 pub(crate) fn sanitize_impl(
     html: Option<Either<String, f64>>,
     options: Option<SanitizeOptions>,
 ) -> String {
+    let max_input_bytes = options
+        .as_ref()
+        .and_then(|o| o.max_input_bytes)
+        .map(|n| if n == 0 { usize::MAX } else { n as usize })
+        .unwrap_or(DEFAULT_MAX_INPUT_BYTES);
+
     let html = coerce_input(html);
+    if html.len() > max_input_bytes {
+        return String::new();
+    }
     let rules = Rules::from_options(&options);
 
     let opts = ParseOpts {

--- a/crates/sanitize-html/src/v2.rs
+++ b/crates/sanitize-html/src/v2.rs
@@ -8,6 +8,11 @@ use std::cell::RefCell;
 use crate::rules::{Rules, escape_attr, escape_text, is_void};
 use crate::{SanitizeOptions, coerce_input};
 
+/// DoS guards. Both can be overridden per-call via `SanitizeOptions`;
+/// pass `0` to disable.
+const DEFAULT_MAX_DEPTH: usize = 256;
+const DEFAULT_MAX_INPUT_BYTES: usize = 5 * 1024 * 1024;
+
 // ---------------------------------------------------------------------------
 // Tokenizer-based sanitization engine (fast path). Routes ~all real-world
 // calls. Behaviour:
@@ -42,6 +47,7 @@ struct SanitizingSink<'a> {
     rules: &'a Rules,
     out: RefCell<String>,
     stack: RefCell<Vec<Frame>>,
+    max_depth: usize,
 }
 
 impl<'a> SanitizingSink<'a> {
@@ -92,6 +98,22 @@ impl<'a> TokenSink for SanitizingSink<'a> {
                     }
 
                     if !self.rules.is_allowed_tag(&name) {
+                        if !is_void(&name) && !tag.self_closing {
+                            self.stack.borrow_mut().push(Frame {
+                                name,
+                                kind: FrameKind::Unwrap,
+                            });
+                        }
+                        return TokenSinkResult::Continue;
+                    }
+
+                    // Depth guard: once the frame stack hits `max_depth`, we
+                    // unwrap any further start tags (keep their content, drop
+                    // the tag) so deeply-nested input can't grow the stack
+                    // without bound. The check sits AFTER the allowlist /
+                    // drop-content branches so a deep `<script>` chain still
+                    // gets its content stripped.
+                    if self.max_depth > 0 && self.stack.borrow().len() >= self.max_depth {
                         if !is_void(&name) && !tag.self_closing {
                             self.stack.borrow_mut().push(Frame {
                                 name,
@@ -180,8 +202,11 @@ impl<'a> TokenSink for SanitizingSink<'a> {
                     let mut stack = self.stack.borrow_mut();
                     let pos = stack.iter().rposition(|f| f.name == name);
                     if let Some(idx) = pos {
-                        // `remove(idx)` shifted subsequent frames down by one,
-                        // so restore the invariant by popping extras.
+                        // Drain everything above the matching frame as
+                        // "extras" — these were opened after `idx` and never
+                        // closed, so we must implicitly close any that were
+                        // emitted. After the drain, the matched frame is the
+                        // last element, so a `pop()` retrieves it.
                         let extras: Vec<Frame> = stack.drain(idx + 1..).collect();
                         let frame = stack.pop().expect("frame at idx must exist");
                         drop(stack);
@@ -231,12 +256,30 @@ pub(crate) fn sanitize_impl(
     html: Option<Either<String, f64>>,
     options: Option<SanitizeOptions>,
 ) -> String {
+    let max_input_bytes = options
+        .as_ref()
+        .and_then(|o| o.max_input_bytes)
+        .map(|n| if n == 0 { usize::MAX } else { n as usize })
+        .unwrap_or(DEFAULT_MAX_INPUT_BYTES);
+    let max_depth = options
+        .as_ref()
+        .and_then(|o| o.max_depth)
+        .map(|n| n as usize)
+        .unwrap_or(DEFAULT_MAX_DEPTH);
+
     let html = coerce_input(html);
+    if html.len() > max_input_bytes {
+        // Oversized input is rejected outright rather than truncated mid-
+        // tag (which would re-introduce the unbalanced-markup case the
+        // implicit-close pass at the bottom of this function fixes).
+        return String::new();
+    }
     let rules = Rules::from_options(&options);
     let sink = SanitizingSink {
         rules: &rules,
         out: RefCell::new(String::with_capacity(html.len())),
         stack: RefCell::new(Vec::new()),
+        max_depth,
     };
     let tokenizer = Tokenizer::new(sink, TokenizerOpts::default());
     let buffer = BufferQueue::default();

--- a/crates/text-splitters/src/lib.rs
+++ b/crates/text-splitters/src/lib.rs
@@ -74,12 +74,24 @@ fn resolved(opts: &SplitterOptions) -> Result<(usize, usize, Sizer)> {
     Ok((chunk_size, chunk_overlap, sizer))
 }
 
-fn split_chars_recursive(text: &str, chunk_size: usize, chunk_overlap: usize) -> Vec<String> {
+/// `ChunkConfig::with_overlap` returns `Result` — text-splitter rejects
+/// `overlap >= size`. Every public entry-point validates this in
+/// `resolved()`, but a future caller bypassing validation would otherwise
+/// panic the host. Bubble the error up instead.
+fn overlap_err<E: std::fmt::Display>(e: E) -> Error {
+    Error::from_reason(format!("invalid chunk overlap: {e}"))
+}
+
+fn split_chars_recursive(
+    text: &str,
+    chunk_size: usize,
+    chunk_overlap: usize,
+) -> Result<Vec<String>> {
     let cfg = ChunkConfig::new(chunk_size)
         .with_overlap(chunk_overlap)
-        .unwrap();
+        .map_err(overlap_err)?;
     let splitter = TextSplitter::new(cfg);
-    splitter.chunks(text).map(String::from).collect()
+    Ok(splitter.chunks(text).map(String::from).collect())
 }
 
 fn split_tokens_recursive(
@@ -87,21 +99,25 @@ fn split_tokens_recursive(
     chunk_size: usize,
     chunk_overlap: usize,
     sizer: TiktokenSizer,
-) -> Vec<String> {
+) -> Result<Vec<String>> {
     let cfg = ChunkConfig::new(chunk_size)
         .with_sizer(sizer)
         .with_overlap(chunk_overlap)
-        .unwrap();
+        .map_err(overlap_err)?;
     let splitter = TextSplitter::new(cfg);
-    splitter.chunks(text).map(String::from).collect()
+    Ok(splitter.chunks(text).map(String::from).collect())
 }
 
-fn split_markdown_chars(text: &str, chunk_size: usize, chunk_overlap: usize) -> Vec<String> {
+fn split_markdown_chars(
+    text: &str,
+    chunk_size: usize,
+    chunk_overlap: usize,
+) -> Result<Vec<String>> {
     let cfg = ChunkConfig::new(chunk_size)
         .with_overlap(chunk_overlap)
-        .unwrap();
+        .map_err(overlap_err)?;
     let splitter = MarkdownSplitter::new(cfg);
-    splitter.chunks(text).map(String::from).collect()
+    Ok(splitter.chunks(text).map(String::from).collect())
 }
 
 fn split_markdown_tokens(
@@ -109,13 +125,13 @@ fn split_markdown_tokens(
     chunk_size: usize,
     chunk_overlap: usize,
     sizer: TiktokenSizer,
-) -> Vec<String> {
+) -> Result<Vec<String>> {
     let cfg = ChunkConfig::new(chunk_size)
         .with_sizer(sizer)
         .with_overlap(chunk_overlap)
-        .unwrap();
+        .map_err(overlap_err)?;
     let splitter = MarkdownSplitter::new(cfg);
-    splitter.chunks(text).map(String::from).collect()
+    Ok(splitter.chunks(text).map(String::from).collect())
 }
 
 /// RecursiveCharacterTextSplitter — the 80% API.
@@ -123,11 +139,10 @@ fn split_markdown_tokens(
 pub fn split_text(text: String, options: Option<SplitterOptions>) -> Result<Vec<String>> {
     let opts = options.unwrap_or_default();
     let (size, overlap, sizer) = resolved(&opts)?;
-    let chunks = match sizer {
+    match sizer {
         Sizer::Chars => split_chars_recursive(&text, size, overlap),
         Sizer::Tiktoken(s) => split_tokens_recursive(&text, size, overlap, s),
-    };
-    Ok(chunks)
+    }
 }
 
 /// Batch — one FFI crossing for N docs.
@@ -138,7 +153,7 @@ pub fn split_text_batch(
 ) -> Result<Vec<Vec<String>>> {
     let opts = options.unwrap_or_default();
     let (size, overlap, sizer) = resolved(&opts)?;
-    let out = match sizer {
+    match sizer {
         Sizer::Chars => texts
             .into_iter()
             .map(|t| split_chars_recursive(&t, size, overlap))
@@ -147,8 +162,7 @@ pub fn split_text_batch(
             .into_iter()
             .map(|t| split_tokens_recursive(&t, size, overlap, s.clone()))
             .collect(),
-    };
-    Ok(out)
+    }
 }
 
 /// Markdown-aware splitter: respects heading/paragraph/list boundaries.
@@ -156,11 +170,10 @@ pub fn split_text_batch(
 pub fn split_markdown(text: String, options: Option<SplitterOptions>) -> Result<Vec<String>> {
     let opts = options.unwrap_or_default();
     let (size, overlap, sizer) = resolved(&opts)?;
-    let chunks = match sizer {
+    match sizer {
         Sizer::Chars => split_markdown_chars(&text, size, overlap),
         Sizer::Tiktoken(s) => split_markdown_tokens(&text, size, overlap, s),
-    };
-    Ok(chunks)
+    }
 }
 
 #[napi(js_name = "splitMarkdownBatch")]
@@ -170,7 +183,7 @@ pub fn split_markdown_batch(
 ) -> Result<Vec<Vec<String>>> {
     let opts = options.unwrap_or_default();
     let (size, overlap, sizer) = resolved(&opts)?;
-    let out = match sizer {
+    match sizer {
         Sizer::Chars => texts
             .into_iter()
             .map(|t| split_markdown_chars(&t, size, overlap))
@@ -179,8 +192,7 @@ pub fn split_markdown_batch(
             .into_iter()
             .map(|t| split_markdown_tokens(&t, size, overlap, s.clone()))
             .collect(),
-    };
-    Ok(out)
+    }
 }
 
 /// Pure character-length counter.

--- a/crates/xxhash/npm/darwin-arm64/package.json
+++ b/crates/xxhash/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/xxhash-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "darwin"
   ],

--- a/crates/xxhash/npm/darwin-x64/package.json
+++ b/crates/xxhash/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/xxhash-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "darwin"
   ],

--- a/crates/xxhash/npm/linux-arm64-gnu/package.json
+++ b/crates/xxhash/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/xxhash-linux-arm64-gnu",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "linux"
   ],

--- a/crates/xxhash/npm/linux-x64-gnu/package.json
+++ b/crates/xxhash/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/xxhash-linux-x64-gnu",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "linux"
   ],

--- a/crates/xxhash/npm/linux-x64-musl/package.json
+++ b/crates/xxhash/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/xxhash-linux-x64-musl",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "linux"
   ],

--- a/crates/xxhash/npm/win32-x64-msvc/package.json
+++ b/crates/xxhash/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-labs/xxhash-win32-x64-msvc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "os": [
     "win32"
   ],

--- a/crates/zip/__conformance__/parity.spec.ts
+++ b/crates/zip/__conformance__/parity.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * Core interop gate against adm-zip@0.5. The full case matrix and the
+ * yauzl-based async tests live in `upstream.spec.ts`; this file is the
+ * contract gate that every release must pass.
+ */
+import { describe, it, expect } from 'vitest'
+import { ZipReader, ZipWriter } from '../index.js'
+import AdmZip from 'adm-zip'
+
+describe('zip — parity gate: amigo ↔ adm-zip interop', () => {
+  it('amigo-written archive reads under adm-zip', () => {
+    const w = new ZipWriter()
+    w.add('hello.txt', Buffer.from('hello world', 'utf-8'))
+    w.add('nested/file.txt', Buffer.from('nested content', 'utf-8'))
+    const buf = w.finalize()
+
+    const ar = new AdmZip(buf)
+    const got: Record<string, string> = {}
+    for (const e of ar.getEntries()) {
+      got[e.entryName] = e.getData().toString('utf-8')
+    }
+    expect(got).toEqual({
+      'hello.txt': 'hello world',
+      'nested/file.txt': 'nested content',
+    })
+  })
+
+  it('adm-zip-written archive reads under amigo', () => {
+    const ar = new AdmZip()
+    ar.addFile('a.txt', Buffer.from('A', 'utf-8'))
+    ar.addFile('b.txt', Buffer.from('B', 'utf-8'))
+    const buf = ar.toBuffer()
+
+    const r = ZipReader.fromBuffer(buf)
+    const out: Record<string, string> = {}
+    for (const e of r.extractAll()) {
+      out[e.name] = Buffer.from(e.data).toString('utf-8')
+    }
+    expect(out).toEqual({ 'a.txt': 'A', 'b.txt': 'B' })
+  })
+
+  it('reports BigInt sizes for entries', () => {
+    const w = new ZipWriter()
+    w.add('payload', Buffer.from('hello'))
+    const r = ZipReader.fromBuffer(w.finalize())
+    const entry = r.entries()[0]
+    expect(typeof entry.size).toBe('bigint')
+    expect(entry.size).toBe(5n)
+  })
+})

--- a/crates/zip/index.d.ts
+++ b/crates/zip/index.d.ts
@@ -37,8 +37,13 @@ export interface ZipEntryData {
 
 export interface ZipEntryInfo {
   name: string
-  size: number
-  compressedSize: number
+  /**
+   * Uncompressed size in bytes. Exposed as `BigInt` because legitimate
+   * ZIP entries can exceed 4 GiB (zip64). JS callers must use
+   * `Number(entry.size)` if they want a plain number.
+   */
+  size: bigint
+  compressedSize: bigint
   isDir: boolean
   compression: string
 }

--- a/crates/zip/index.d.ts
+++ b/crates/zip/index.d.ts
@@ -38,11 +38,16 @@ export interface ZipEntryData {
 export interface ZipEntryInfo {
   name: string
   /**
-   * Uncompressed size in bytes. Exposed as `BigInt` because legitimate
-   * ZIP entries can exceed 4 GiB (zip64). JS callers must use
-   * `Number(entry.size)` if they want a plain number.
+   * Uncompressed size in bytes. Exposed as `bigint` because legitimate
+   * ZIP entries can exceed 4 GiB (zip64).
+   *
+   * Casting to `number` (`Number(entry.size)`) is only safe when the
+   * caller knows the value fits in `Number.MAX_SAFE_INTEGER` (2^53 − 1,
+   * ≈ 9 PiB). Above that the conversion silently rounds; prefer keeping
+   * the value as `bigint` when handling untrusted archives.
    */
   size: bigint
+  /** Compressed size in bytes. Same `bigint` semantics as `size`. */
   compressedSize: bigint
   isDir: boolean
   compression: string

--- a/crates/zip/package.json
+++ b/crates/zip/package.json
@@ -35,7 +35,7 @@
     "prepublishOnly": "napi pre-publish --skip-optional-publish --no-gh-release",
     "test": "vitest run __test__",
     "bench": "vitest bench",
-    "test:conformance": "vitest run __conformance__/fuzz.spec.ts",
+    "test:conformance": "vitest run __conformance__",
     "test:all": "vitest run",
     "test:upstream": "vitest run __conformance__/upstream.spec.ts"
   },

--- a/crates/zip/src/lib.rs
+++ b/crates/zip/src/lib.rs
@@ -25,9 +25,14 @@ fn prealloc_size(claimed: u64) -> usize {
 pub struct ZipEntryInfo {
     pub name: String,
     /// Uncompressed size in bytes. Exposed as `BigInt` because legitimate
-    /// ZIP entries can exceed 4 GiB (zip64). JS callers must use
-    /// `Number(entry.size)` if they want a plain number.
+    /// ZIP entries can exceed 4 GiB (zip64).
+    ///
+    /// Casting to `Number` (`Number(entry.size)`) is only safe when the
+    /// caller knows the value fits in `Number.MAX_SAFE_INTEGER` (2^53 −
+    /// 1, ≈ 9 PiB). Above that the conversion silently rounds; prefer
+    /// keeping the value as a `bigint` when handling untrusted archives.
     pub size: BigInt,
+    /// Compressed size in bytes. Same `BigInt` semantics as `size` above.
     pub compressed_size: BigInt,
     pub is_dir: bool,
     pub compression: String,

--- a/crates/zip/src/lib.rs
+++ b/crates/zip/src/lib.rs
@@ -10,11 +10,25 @@ fn to_err<E: std::fmt::Display>(e: E) -> Error {
     Error::from_reason(e.to_string())
 }
 
+/// Cap the per-entry pre-allocation independent of what the ZIP central
+/// directory claims. A crafted archive can advertise a 100 GB entry to
+/// trigger an `OOM` on `Vec::with_capacity` *before* any decompressed
+/// bytes are read. Real entries that exceed this still decompress fine
+/// — `Vec::read_to_end` grows past the initial capacity as needed.
+const MAX_PREALLOC_PER_ENTRY: usize = 256 * 1024 * 1024;
+
+fn prealloc_size(claimed: u64) -> usize {
+    claimed.min(MAX_PREALLOC_PER_ENTRY as u64) as usize
+}
+
 #[napi(object)]
 pub struct ZipEntryInfo {
     pub name: String,
-    pub size: u32,
-    pub compressed_size: u32,
+    /// Uncompressed size in bytes. Exposed as `BigInt` because legitimate
+    /// ZIP entries can exceed 4 GiB (zip64). JS callers must use
+    /// `Number(entry.size)` if they want a plain number.
+    pub size: BigInt,
+    pub compressed_size: BigInt,
     pub is_dir: bool,
     pub compression: String,
 }
@@ -42,8 +56,8 @@ fn entries_from<R: Read + std::io::Seek>(r: R) -> Result<Vec<ZipEntryInfo>> {
         let f = ar.by_index(i).map_err(to_err)?;
         out.push(ZipEntryInfo {
             name: f.name().to_string(),
-            size: f.size().min(u32::MAX as u64) as u32,
-            compressed_size: f.compressed_size().min(u32::MAX as u64) as u32,
+            size: BigInt::from(f.size()),
+            compressed_size: BigInt::from(f.compressed_size()),
             is_dir: f.is_dir(),
             compression: format!("{:?}", f.compression()),
         });
@@ -54,7 +68,7 @@ fn entries_from<R: Read + std::io::Seek>(r: R) -> Result<Vec<ZipEntryInfo>> {
 fn read_from<R: Read + std::io::Seek>(r: R, name: &str) -> Result<Vec<u8>> {
     let mut ar = ZipArchive::new(r).map_err(to_err)?;
     let mut f = ar.by_name(name).map_err(to_err)?;
-    let mut out = Vec::with_capacity(f.size() as usize);
+    let mut out = Vec::with_capacity(prealloc_size(f.size()));
     f.read_to_end(&mut out).map_err(to_err)?;
     Ok(out)
 }
@@ -116,7 +130,7 @@ fn extract_all_from<R: Read + std::io::Seek>(r: R) -> Result<Vec<ZipEntryData>> 
         if f.is_dir() {
             continue;
         }
-        let mut bytes = Vec::with_capacity(f.size() as usize);
+        let mut bytes = Vec::with_capacity(prealloc_size(f.size()));
         f.read_to_end(&mut bytes).map_err(to_err)?;
         out.push(ZipEntryData {
             name: f.name().to_string(),

--- a/docs/app.js
+++ b/docs/app.js
@@ -417,6 +417,10 @@ function wireReadme(pkg) {
     try {
       const res = await fetch(`readmes/${pkg.name}.html`);
       if (!res.ok) throw new Error(res.statusText);
+      // The fetched HTML is locally rendered from each crate's README via
+      // our own commonmark crate during the docs build — same-origin, no
+      // user-controlled content. Do NOT route untrusted markup through
+      // this assignment without sanitising it first.
       host.innerHTML = await res.text();
       loaded = true;
     } catch {

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -8,9 +8,9 @@ Each item lists the concrete artefact that proves it's fixed.
 
 ## 1. ~~`docs/perf-review.md` — missing post-ship verdicts~~ ✅ Done
 
-Added rows for bcrypt, commonmark, jose, and tiktoken to the "Nach-Sprint-Stand"
+Added rows for bcrypt, commonmark, jose, and tiktoken to the "Post-sprint state"
 table and updated the "Net:" tally. Portfolio is now **12 Green + 3 Yellow +
-1 faktisch-Green (nanoid)** out of 16 shipped crates.
+1 effectively-Green (nanoid)** out of 16 shipped crates.
 
 ## 2. ~~`@amigo-labs/jwt` — drop-in claim vs. `expiresIn` string limitation~~ ✅ Done
 

--- a/docs/perf-review/argon2.md
+++ b/docs/perf-review/argon2.md
@@ -4,16 +4,16 @@
 
 ## Verdict
 
-CPU-bound Password-Hashing — **1,37× vs. upstream `argon2` (C-bindings via node-gyp)**, **2,33× vs. `hash-wasm` WASM-build**. Upstream ist bereits nativ-kompiliert (argon2-C via node-gyp), deshalb ist die Margin die gesamte Phase-C/D-Ceiling dieses Paketes: Algorithm ist Argon2-2015-Spec, beide Seiten nutzen `blake2b`-Core-Loops, derselbe Algorithmus gibt keine Größenordnung her. Keep-as-is; kein Optimierungs-Sprint in Sicht, der über Messrauschen hinaus wirken würde.
+CPU-bound password hashing — **1.37× vs. upstream `argon2` (C bindings via node-gyp)**, **2.33× vs. `hash-wasm` WASM build**. Upstream is already natively compiled (argon2-C via node-gyp), so this margin represents the entire Phase-C/D ceiling for this package: the algorithm is the Argon2-2015 spec, both sides drive `blake2b` core loops over the same algorithm — no order-of-magnitude headroom is available. Keep-as-is; no optimization sprint in sight that would clear measurement noise.
 
 ## Classification rationale
 
-Argon2 ist der definitive **algorithm-ceiling-bound** Fall im Portfolio:
+Argon2 is the definitive **algorithm-ceiling-bound** case in the portfolio:
 
-1. **Upstream ist auch nativ.** `argon2` npm ist `node-gyp`-compiled C-Bindings zu libargon2. Wir kämpfen Rust-native vs. C-native an derselben Spec. Inner-Loop ist `blake2b`-Compress über 128-Byte-Blöcke, beide Seiten identisch vectorized.
-2. **Default-Config ist bewusst langsam.** Memory-cost 64 MiB, time-cost 3, parallelism 4 — Argon2 soll 100–500 ms pro Hash brauchen. FFI-Floor (109 ns) vs. 300 ms Compute = **0,00004 %** Share. Kein FFI-Hebel möglich.
-3. **hash-wasm ist die eigentliche Alternative.** 2,33× speedup vs. WASM-builds rechtfertigt das Paket portfolio-weit. WASM hat ~1,5× Overhead pro blake2b-round vs. native.
-4. **Yellow-statt-Green** weil 1,37× vs. der primären Drop-in-Alternative (`argon2` npm) unter dem 2×-Gate liegt. Nicht Red, weil eindeutig positive Margin plus der WASM-Case Green ist.
+1. **Upstream is also native.** The `argon2` npm package is `node-gyp`-compiled C bindings to libargon2. We're pitting Rust-native against C-native on the same spec. The inner loop is `blake2b` compress over 128-byte blocks, identically vectorised on both sides.
+2. **The default config is deliberately slow.** Memory cost 64 MiB, time cost 3, parallelism 4 — Argon2 is meant to take 100–500 ms per hash. FFI floor (109 ns) vs. 300 ms compute = **0.00004 %** share. No FFI lever to pull.
+3. **hash-wasm is the real alternative.** A 2.33× speedup vs. WASM builds justifies the package portfolio-wide. WASM has ~1.5× overhead per blake2b round vs. native.
+4. **Yellow rather than Green** because the 1.37× margin against the primary drop-in alternative (`argon2` npm) sits below the 2× gate. Not Red, because the margin is unambiguously positive and the WASM case is Green.
 
 ## Evidence
 
@@ -21,18 +21,18 @@ Argon2 ist der definitive **algorithm-ceiling-bound** Fall im Portfolio:
 
 | Scenario | @amigo-labs/argon2 | argon2 (npm, C) | hash-wasm | vs. argon2 | vs. hash-wasm |
 |---|---:|---:|---:|---:|---:|
-| hash (low-cost params) | 320,93 Hz | 234,39 Hz | 137,48 Hz | **1,37×** | **2,33×** |
-| verify | 321,38 Hz | — | — | (baseline) | — |
+| hash (low-cost params) | 320.93 Hz | 234.39 Hz | 137.48 Hz | **1.37×** | **2.33×** |
+| verify | 321.38 Hz | — | — | (baseline) | — |
 
-### Realistic use-case
+### Realistic use case
 
-Password-Hashing in Authentication-Flows. Eine Hash-Operation pro User-Registrierung / Login, nicht hot-loop. Default-Params (memory=64 MiB, time=3, parallelism=4) = ~300 ms. Serverseitig, nicht latency-kritisch unterhalb der Default-Cost-Konfiguration. Async-API (`hash()` gibt `AsyncTask` zurück) hält den Event-Loop frei — das ist der eigentliche Value vs. sync-only-upstream.
+Password hashing in authentication flows. One hash operation per user registration / login, not a hot loop. Default params (memory=64 MiB, time=3, parallelism=4) ≈ 300 ms. Server-side, not latency-critical below the default-cost configuration. The async API (`hash()` returns an `AsyncTask`) keeps the event loop free — that's the actual value vs. sync-only upstream.
 
 ### Benchmark gaps
 
-- **Verify-cross-bench fehlt.** Nur `@amigo-labs/argon2.verify_sync` gebenched — keine Zahlen vs. `argon2.verify` npm. Vor v0.2 nachziehen.
-- **High-cost-params nicht getestet.** `memory=256 MiB, time=10` (paranoid-server-config) würde die CPU-Margin klarstellen. Erwartbar dort ≈1,3× weil blake2b-dominant.
-- **Async-Pfad nicht direkt gemessen** (nur sync in Bench). Der Async-Overhead ist `AsyncTask` = Thread-Hop + Join — sub-millisekunden, vernachlässigbar gegen 300 ms Compute.
+- **Verify cross-bench is missing.** Only `@amigo-labs/argon2.verify_sync` is benched — no numbers vs. `argon2.verify` npm. Catch up before v0.2.
+- **High-cost params not tested.** `memory=256 MiB, time=10` (paranoid server config) would clarify the CPU margin. Expected ≈1.3× there because blake2b dominates.
+- **Async path not directly measured** (only sync in the bench). The async overhead is `AsyncTask` = thread hop + join — sub-millisecond, negligible against 300 ms compute.
 
 ### API surface
 
@@ -43,40 +43,40 @@ Password-Hashing in Authentication-Flows. Eine Hash-Operation pro User-Registrie
 #[napi] fn verify(hash: String, password: String) -> AsyncTask<VerifyTask>
 ```
 
-- Input `String` (Password) und `Option<Argon2Options>` (memory_cost, time_cost, parallelism, output_len). Output: PHC-String.
-- `AsyncTask`-Variante ist der Default-Hot-Path — offloaded auf Worker-Pool.
-- Keine Stateful-Class. Kein Callback-Boundary. Sauber.
+- Inputs: `String` (password) and `Option<Argon2Options>` (memory_cost, time_cost, parallelism, output_len). Output: PHC string.
+- The `AsyncTask` variant is the default hot path — offloaded to the worker pool.
+- No stateful class. No callback boundary. Clean.
 
 ### Bundle / binary size
 
-`docs/data.json`-`sizes`-Feld für argon2: etwa portfolio-mittleres Größenmaß (600–800 KB pro Target). `argon2 = { version = "0.5", features = ["std"] }` ist kompakt, keine SIMD-Features.
+The `sizes` field in `docs/data.json` for argon2 is roughly portfolio-median (600–800 KB per target). `argon2 = { version = "0.5", features = ["std"] }` is compact, no SIMD features.
 
-### FFI-overhead baseline
+### FFI overhead baseline
 
-Irrelevant — 300 ms-Compute pro Call absorbiert jede FFI-Grenze. Referenz: `docs/BASELINE.md:24` (noop = 109 ns).
+Irrelevant — 300 ms of compute per call absorbs every FFI boundary. Reference: `docs/BASELINE.md:24` (noop = 109 ns).
 
 ## Phase-C optimization checklist
 
 | # | Lever | Applicable | Notes |
 |---|---|---|---|
-| C.1 | Input-type minimization (`String` → `&str`, `Buffer`-overload) | ❌ not applicable | Password ist String-native; FFI-Share <0,001 % |
-| C.2 | Output-type minimization | ❌ not applicable | Output ist kurzer PHC-String |
-| C.3 | Batch API | ❌ not applicable | Niemand hasht Passwords in Batches — Use-Case-Mismatch |
-| C.4 | Stateful API (NAPI-Class mit reused Argon2-Config) | 🟡 marginal | `build_argon2()` kostet sub-µs; reuse lohnt nicht |
-| C.5 | Parallelization (rayon über Multiple-Inputs) | ❌ not applicable | Argon2 selbst ist parallelisiert intern (`parallelism=4`) |
-| C.6 | Algorithm swap (SIMD-blake2b) | 🟡 **potential**, uncertain | `blake2b_simd` crate hat AVX2-/NEON-Varianten. `argon2` crate v0.5 nutzt `blake2b` crate (scalar-default). Upgrade auf SIMD-Variante könnte 10–20 % bringen — nicht genug für Green-Upgrade, aber messbar. |
-| C.7 | Allocator tuning | ❌ not applicable | Argon2-Memory-Allokation ist user-controlled `memory_cost` |
-| C.8 | Bundle-size (LTO, features) | ✅ already done | Workspace-profile mit lto=true, strip=symbols |
+| C.1 | Input-type minimisation (`String` → `&str`, `Buffer` overload) | ❌ not applicable | Password is string-native; FFI share <0.001 % |
+| C.2 | Output-type minimisation | ❌ not applicable | Output is a short PHC string |
+| C.3 | Batch API | ❌ not applicable | Nobody hashes passwords in batches — use-case mismatch |
+| C.4 | Stateful API (NAPI class with reused Argon2 config) | 🟡 marginal | `build_argon2()` costs sub-µs; reuse doesn't pay |
+| C.5 | Parallelisation (rayon over multiple inputs) | ❌ not applicable | Argon2 is itself internally parallelised (`parallelism=4`) |
+| C.6 | Algorithm swap (SIMD blake2b) | 🟡 **potential**, uncertain | The `blake2b_simd` crate has AVX2/NEON variants. `argon2` v0.5 uses the `blake2b` crate (scalar default). Upgrading to the SIMD variant could buy 10–20 % — not enough for a Green upgrade, but measurable. |
+| C.7 | Allocator tuning | ❌ not applicable | Argon2 memory allocation is user-controlled via `memory_cost` |
+| C.8 | Bundle size (LTO, features) | ✅ already done | Workspace profile with lto=true, strip=symbols |
 
 ## Action plan
 
-**Keep-as-is.** Yellow bleibt Yellow, algorithmisch ceiling-limited. Drei kleine Maintenance-Items:
+**Keep-as-is.** Yellow stays Yellow, algorithmically ceiling-limited. Three small maintenance items:
 
-1. **Verify-cross-bench hinzufügen** (`argon2.verify` vs. `@amigo-labs/argon2.verify_sync`) — Doku-Sauberkeit vor v0.2.
-2. **High-cost-param-bench** als zweiter Szenario — schärft die CPU-vs-FFI-Klarstellung für User, die paranoid-configs fahren.
-3. **`blake2b_simd`-Spike als Fast-Follow** (nicht Sprint-Priorität). Erwartbar 1,37× → 1,5–1,6×, bleibt Yellow, ist Sign-of-Life für die Maintenance.
+1. **Add a verify cross-bench** (`argon2.verify` vs. `@amigo-labs/argon2.verify_sync`) — doc hygiene before v0.2.
+2. **High-cost-param bench** as a second scenario — sharpens the CPU-vs-FFI story for users running paranoid configs.
+3. **`blake2b_simd` spike as fast-follow** (not sprint priority). Expect 1.37× → 1.5–1.6×, still Yellow, but a sign of life for ongoing maintenance.
 
-Kein Phase-C-Sprint scheduled. Kein Phase-D-Risiko (kein Red-Drift denkbar ohne V8/libargon2-Änderung).
+No Phase-C sprint scheduled. No Phase-D risk (no Red drift conceivable absent a V8 / libargon2 change).
 
 ## References
 
@@ -85,4 +85,4 @@ Kein Phase-C-Sprint scheduled. Kein Phase-D-Risiko (kein Red-Drift denkbar ohne 
 - Lib: `crates/argon2/src/lib.rs`
 - Cargo: `crates/argon2/Cargo.toml`
 - `docs/packages.json` speedup field: `"1.37× faster"`
-- Summary row: `docs/perf-review.md` (Yellow, Nach-Sprint-Tabelle)
+- Summary row: `docs/perf-review.md` (Yellow, post-sprint table)

--- a/docs/perf-review/compute-cosine-similarity.md
+++ b/docs/perf-review/compute-cosine-similarity.md
@@ -4,65 +4,65 @@
 
 ## Verdict
 
-`compute-cosine-similarity` und die Geschwister-Pakete (`compute-dot-product`, `compute-euclidean-distance`, `compute-manhattan-distance`) haben den **archetypischen FFI-Drowns-SIMD-Shape**: zwei kleine-bis-mittelgroße f64-Arrays rein, eine f64 raus. Der Compute ist 10+ Jahren SIMD-fähig (AVX/NEON), ABER der FFI-Transport der Input-Arrays als `Float64Array` kostet für typische Embedding-Größen (dim=384–1536) mehr als die Distanz-Berechnung selbst. V8 hat die gleiche SIMD-Auto-Vectorization in TurboFan. Klassischer Black-Shape: kein Input-Size rettet das — noch größere Vektoren bleiben memory-bandwidth-bound und der JS-Loop hält mit dem Rust-Loop mit. Exakt die `deep-equal`-Lehre, nur auf Vektoren statt Objekten.
+`compute-cosine-similarity` and the sibling packages (`compute-dot-product`, `compute-euclidean-distance`, `compute-manhattan-distance`) hit the **archetypal FFI-drowns-SIMD shape**: two small-to-medium f64 arrays in, one f64 out. The compute has been SIMD-amenable for 10+ years (AVX/NEON), BUT the FFI transport of the input arrays as `Float64Array` costs more than the distance computation itself for typical embedding sizes (dim=384–1536). V8 has the same SIMD auto-vectorisation in TurboFan. Classic Black shape: no input size rescues it — even larger vectors stay memory-bandwidth-bound and the JS loop keeps up with the Rust loop. Exactly the `deep-equal` lesson, only on vectors instead of objects.
 
 ## JS package
 
-- **npm:** [`compute-cosine-similarity`](https://www.npmjs.com/package/compute-cosine-similarity) + Geschwister (`compute-dot-product`, `compute-cosine-distance`, `compute-euclidean-distance`, `compute-manhattan-distance`, `compute-jaccard-distance`, etc.)
-- **Downloads:** ~500k/Woche kombiniert für die Familie. Primäre Adoption durch ML/Embedding-Pipelines.
-- **Exports / API surface:** `similarity(a, b) → number`. Keine State, keine Optionen. Minimal.
-- **Typical input:** Zwei `Float64Array` (oder normale Arrays), typisch Länge 384 / 768 / 1536 (Embedding-Dimensions). Gelegentlich größer für Image-Features.
-- **Typical output:** `number` (scalar f64, Range -1..1 für Cosine).
-- **Realistic median use-case:** **RAG-Retrieval-Score** — ein Query-Embedding gegen hunderte bis tausende Doc-Embeddings, Top-K-Ergebnisse bestimmt durch Cosine-Score. Die Funktion wird in einer Hot-Loop gerufen (N Vergleiche pro Query). Zweiter Case: **Dedup-Check** in Embedding-Indexing (gegen alle bestehenden Embeddings clusters).
+- **npm:** [`compute-cosine-similarity`](https://www.npmjs.com/package/compute-cosine-similarity) + siblings (`compute-dot-product`, `compute-cosine-distance`, `compute-euclidean-distance`, `compute-manhattan-distance`, `compute-jaccard-distance`, etc.)
+- **Downloads:** ~500k/week combined for the family. Primary adoption through ML / embedding pipelines.
+- **Exports / API surface:** `similarity(a, b) → number`. No state, no options. Minimal.
+- **Typical input:** Two `Float64Array` (or plain arrays), typically length 384 / 768 / 1536 (embedding dimensions). Occasionally larger for image features.
+- **Typical output:** `number` (scalar f64, range -1..1 for cosine).
+- **Realistic median use case:** **RAG retrieval score** — one query embedding against hundreds-to-thousands of doc embeddings, top-K determined by cosine score. The function is called in a hot loop (N comparisons per query). Second case: **dedup check** in embedding indexing (compare against all existing embedding clusters).
 
 ## Rust replacement
 
-- **Candidate crate(s):** `ndarray` + `ndarray-rand` oder direkt `std::simd` (stable seit 1.72+). Für reine Cosine: `nalgebra` oder 10 Zeilen eigener Code mit `f64::mul_add`. Trivial, alle MIT/Apache, alles auto-vectorized.
+- **Candidate crate(s):** `ndarray` + `ndarray-rand` or directly `std::simd` (stable since 1.72+). For pure cosine: `nalgebra` or 10 lines of hand-rolled code with `f64::mul_add`. Trivial, all MIT/Apache, all auto-vectorised.
 - **Maintenance / license:** n/a — trivial
-- **Known gotchas / divergences:** Normalization-Edge-Cases (Vector-of-Zeros → Division durch Null). Identisch zu JS-Lib.
+- **Known gotchas / divergences:** Normalisation edge cases (vector-of-zeros → division by zero). Identical to the JS lib.
 
 ## BACKLOG check
 
-Vorhandener Eintrag in `BACKLOG.md` → "Ruled out — AI-category": "Two small arrays in, one float out — marshalling drowns SIMD. Same lesson as `deep-equal`." Review formalisiert mit Zahlen.
+Existing entry in `BACKLOG.md` → "Ruled out — AI-category": "Two small arrays in, one float out — marshalling drowns SIMD. Same lesson as `deep-equal`." Review formalises with numbers.
 
-Abgrenzung:
-- Gegen `docs/perf-review/deep-equal.md` (archived 🔴): identischer FFI-Floor-Trap. Two-Inputs-One-Scalar-Out ist die Gemeinsamkeit.
-- Gegen `docs/perf-review/hnswlib-node.md` (NO-GO): hnswlib macht dasselbe (Cosine oder L2 auf Vektor-Paaren) aber **amortisiert über einen Index** — ein Query ruft N Distanzen intern in Rust, nicht N × FFI-Crossings. Genau deshalb ist Index-API sinnvoll, Per-Pair-API nicht.
+Boundary:
+- vs. `docs/perf-review/deep-equal.md` (archived 🔴): identical FFI-floor trap. Two-inputs-one-scalar-out is the shared shape.
+- vs. `docs/perf-review/hnswlib-node.md` (NO-GO): hnswlib does the same thing (cosine or L2 over vector pairs) but **amortised over an index** — one query runs N distances internally in Rust, not N × FFI crossings. That's exactly why an index API is sensible while a per-pair API is not.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Trivial.** Cosine auf dim=1536: ~1 µs in JS (V8 mit SIMD), ~300–500 ns in Rust. Rust-Gewinn: ~500–700 ns pro Call. |
-| Input size distribution | Zwei `Float64Array` × (384..1536) × 8 B = 3–12 KB × 2 pro Call. Als `TypedArray` Buffer-Handle: ~180 ns flat (BASELINE.md:30). Aber: für JS-Arrays (nicht TypedArray) ist Marshalling 43 ns/Element × 1536 × 2 = **132 µs** — katastrophal. Nur mit expliziten `Float64Array`-Inputs tolerabel. |
+| Per-call algorithmic work | **Trivial.** Cosine on dim=1536: ~1 µs in JS (V8 with SIMD), ~300–500 ns in Rust. Rust gain: ~500–700 ns per call. |
+| Input size distribution | Two `Float64Array` × (384..1536) × 8 B = 3–12 KB × 2 per call. As a `TypedArray` buffer handle: ~180 ns flat (BASELINE.md:30). But: for plain JS arrays (not TypedArray) the marshalling is 43 ns/element × 1536 × 2 = **132 µs** — catastrophic. Only tolerable with explicit `Float64Array` inputs. |
 | Output size distribution | 1 × f64 → 8 B. Negligible. |
-| Reusable setup (stateful potential) | Null. Stateless-Function. |
-| Batch-usage realism | **Einziger möglicher Hebel:** `cosineBatch(query: Float64Array, corpus: Float64Array[], dim: number) → Float64Array` — ein Crossing pro N Paare. Das existiert aber als **NAPI-Class-API** bereits besser: `hnswlib`-style Index. Per-Pair-Package hat keinen Batch-Idiom. |
-| FFI-share estimate vs. Rust work | Mit `Float64Array`: ~30–50 %. Mit normalem Array: >99 %. |
+| Reusable setup (stateful potential) | None. Stateless function. |
+| Batch usage realism | **The only conceivable lever:** `cosineBatch(query: Float64Array, corpus: Float64Array[], dim: number) → Float64Array` — one crossing per N pairs. That already exists as a better-shaped **NAPI-class API**: `hnswlib`-style index. A per-pair package has no batch idiom. |
+| FFI-share estimate vs. Rust work | With `Float64Array`: ~30–50 %. With a plain array: >99 %. |
 
 ## Classification reasoning
 
-`compute-*`-Familie ist Lehrbuch-Black:
+The `compute-*` family is textbook Black:
 
-1. **V8 vectorized TurboFan-Code ist schnell.** `compute-cosine-similarity`'s Inner-Loop ist `sum += a[i] * b[i]`, auf `Float64Array`. TurboFan generiert AVX-Instructions. Abstand zu Rust-SIMD ist gering (2–3×).
+1. **V8 vectorised TurboFan code is fast.** `compute-cosine-similarity`'s inner loop is `sum += a[i] * b[i]` on `Float64Array`. TurboFan generates AVX instructions. The gap to Rust-SIMD is small (2–3×).
 
-2. **FFI-Fixkosten dominieren.** 109 ns Floor + 2× Buffer-Access + 1× Scalar-Return ≈ 300 ns auf 1-µs-Baseline. 30 % Fixkosten-Share. Speedup 1,2×–1,5× best case.
+2. **FFI fixed costs dominate.** 109 ns floor + 2 × buffer-access + 1 × scalar return ≈ 300 ns on a 1 µs baseline. ~30 % fixed-cost share. Best-case speedup 1.2×–1.5×.
 
-3. **Kein Batch-Idiom.** Users schreiben `corpus.map(doc => similarity(query, doc))` — JS-Loop über FFI-Calls = N × 300 ns FFI + N × 300 ns Rust-Compute = langsamer als reines JS (N × 1 µs).
+3. **No batch idiom.** Users write `corpus.map(doc => similarity(query, doc))` — JS loop over FFI calls = N × 300 ns FFI + N × 300 ns Rust compute = slower than pure JS (N × 1 µs).
 
-4. **Die Rust-Antwort auf diesen Use-Case ist HNSW/ANN-Index,** nicht Per-Pair-Function. Aber `hnswlib-node`/`faiss-node` sind bereits ruled-out als C++-wrapping (→ `docs/perf-review/hnswlib-node.md`). Es gibt keinen Portfolio-Slot für "flach Pair-Distance in Rust".
+4. **The Rust answer to this use case is HNSW / ANN index,** not a per-pair function. But `hnswlib-node` / `faiss-node` are already ruled out as C++-wrapping (→ `docs/perf-review/hnswlib-node.md`). There is no portfolio slot for "flat pair-distance in Rust."
 
-**Shape-Matching:**
-- 🔁 Wie `deep-equal` archived (small-work-per-call, FFI-dominated)
-- 🔁 Wie `mime` (Flacher Lookup-Stil)
-- ❌ Nicht wie `hnswlib`-style (Index-API ist der richtige Shape, aber der ist separately reviewed und abgelehnt aus anderem Grund)
+**Shape matching:**
+- 🔁 Like archived `deep-equal` (small work per call, FFI-dominated)
+- 🔁 Like `mime` (flat lookup style)
+- ❌ Not like `hnswlib`-style (the index API is the right shape, but reviewed separately and rejected for a different reason)
 
-**Benchmark-Gap-Flag:** Kein Spike nötig — architekturelle Analyse ist definitiv.
+**Benchmark-gap flag:** No spike needed — architectural analysis is definitive.
 
 ## If GO — proposed port
 
-Nicht empfohlen. Wer Vector-Similarity auf großem Corpus braucht, nutzt HNSW/Faiss (beide selbst bereits ruled-out aus Wrapper-Gründen). Aktuell: Pure-JS bleiben, oder eigene Rust-ANN-Impl (separates Portfolio-Thema).
+Not recommended. Whoever needs vector similarity over a large corpus uses HNSW / Faiss (both already ruled out for wrapper reasons). Today: stay pure-JS, or write our own Rust ANN impl (separate portfolio topic).
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/compute-cosine-similarity.md`.
+Archived 2026-04-21. Full review: `docs/perf-review/compute-cosine-similarity.md`.

--- a/docs/perf-review/core-js.md
+++ b/docs/perf-review/core-js.md
@@ -4,33 +4,33 @@
 
 ## Verdict
 
-`core-js` ist eine **Polyfill-Library für JavaScript-Standards** (ECMAScript, Web APIs). Sie liefert JS-Implementierungen von `Promise`, `Array.prototype.flat`, `Object.fromEntries`, `String.prototype.replaceAll`, `globalThis`, etc. für alte Browser/Node-Versionen. Das ist **strukturell nicht Rust-portbar**:
+`core-js` is a **polyfill library for JavaScript standards** (ECMAScript, Web APIs). It ships JS implementations of `Promise`, `Array.prototype.flat`, `Object.fromEntries`, `String.prototype.replaceAll`, `globalThis` and friends for old browsers / Node versions. That is **structurally not Rust-portable**:
 
-1. Polyfills sind per Definition **JavaScript-Code** der in der JS-Runtime läuft — da sind keine FFI-Grenzen relevant.
-2. Moderne Node.js (18+) hat alle diese APIs nativ. core-js ist nur für alte Browser-Bundles oder Legacy-Environments nötig.
-3. Der Use-Case ist Browser-shimming. Wir sind Node-only.
+1. Polyfills are by definition **JavaScript code** that runs inside the JS runtime — there is no FFI boundary to put on the hot path.
+2. Modern Node.js (18+) has every one of these APIs natively. core-js is only needed for old browser bundles or legacy environments.
+3. The use case is browser shimming. We are Node-only.
 
-Außerdem: Der core-js-Maintainer (Denis Pushkarev) war 2023 in einem Rechtsfall und die Library ist finanziell unterbesetzt. Aber das ist nicht der Ablehnungs-Grund — der Ablehnungs-Grund ist, dass Polyfills **strukturell nicht zu Rust passen**.
+In addition: the core-js maintainer (Denis Pushkarev) was caught up in a legal case in 2023 and the library is financially under-resourced. But that is not the rejection reason — the rejection reason is that polyfills **don't structurally fit Rust**.
 
 ## JS package
 
 - **npm:** [`core-js`](https://www.npmjs.com/package/core-js)
-- **Downloads:** ~60M/Woche (transitiv durch jeden babel-compiled Bundle)
+- **Downloads:** ~60M/week (transitive through every babel-compiled bundle)
 
 ## Rust replacement
 
-Nicht zutreffend. Polyfills sind Runtime-Shims für JS-Standards. Rust kann das **Konzept** nicht ersetzen.
+Not applicable. Polyfills are runtime shims for JS standards. Rust cannot replace the **concept**.
 
 ## BACKLOG check
 
-Eintrag in `BACKLOG.md` → "Deprecated / superseded": "Don't touch." Review bestätigt.
+Entry in `BACKLOG.md` → "Deprecated / superseded": "Don't touch." Review confirms.
 
 ## Classification reasoning
 
-1. **Shape-Mismatch.** Polyfills ergänzen die JS-Runtime-Surface. Das ist kein Compute-Problem, kein FFI-Problem — es ist "diese Node/Browser-Version hat Feature X nicht, core-js installiert es via Prototype-Patching".
-2. **Modern-Node macht es obsolet.** Node 18+ hat alle Polyfill-Targets nativ.
-3. **Browser-only Use-Case.** Wir sind Node. Zero Überschneidung.
+1. **Shape mismatch.** Polyfills extend the JS runtime surface. That's not a compute problem, not an FFI problem — it's "this Node/browser version doesn't have feature X, core-js installs it via prototype patching".
+2. **Modern Node makes it obsolete.** Node 18+ has every polyfill target natively.
+3. **Browser-only use case.** We are Node. Zero overlap.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/core-js.md`.
+Archived 2026-04-21. Full review: `docs/perf-review/core-js.md`.

--- a/docs/perf-review/csv.md
+++ b/docs/perf-review/csv.md
@@ -4,13 +4,13 @@
 
 ## Verdict
 
-Parity-Green über alle drei Size-Buckets — **2,39×–5,22× vs. `csv-parse` (sync)** und **1,52×–1,88× vs. `papaparse`**. Der Phase-C-Fix (Commit `ecf8408`) routet `parse()` jetzt durch `parseToJson + JSON.parse`, was die frühere Yellow-Grenze auf plain-`parse()` eliminiert hat — beide Pfade messen jetzt identisch. BurntSushi's `csv` crate ist eine der ausgereiftesten Rust-Parser-Libraries im Ökosystem; FFI-Overhead ist bei 10k-Rows-Scale <1 % (Buffer-in, JSON-String-out).
+Parity Green across all three size buckets — **2.39×–5.22× vs. `csv-parse` (sync)** and **1.52×–1.88× vs. `papaparse`**. The Phase-C fix (commit `ecf8408`) now routes `parse()` through `parseToJson + JSON.parse`, eliminating the earlier Yellow margin on plain `parse()` — both paths now measure identically. BurntSushi's `csv` crate is one of the most mature Rust parser libraries in the ecosystem; FFI overhead at 10k-row scale is <1 % (Buffer in, JSON string out).
 
 ## Classification rationale
 
-1. **Parser-Baseline ist relativ langsam.** `csv-parse` (sync) nutzt eine state-machine in JS, `papaparse` eine custom-tokenizer; beide CPU-bound ohne SIMD. BurntSushi `csv` nutzt memchr-gestützte Field-Detection plus ein zero-copy-Reader-Pattern.
-2. **`parseToJson`-Pfad war der Phase-C-Hebel.** Ursprüngliche `parse()` gab `Vec<Vec<String>>` zurück — 100k Rows × 5 Cols × Marshalling-Overhead war messbar. Aktuelle Implementation: Rust baut direkt JSON-String, JS macht `JSON.parse` auf dem Output. **Ein** FFI-Crossing statt 500k.
-3. **Alle drei Buckets Green.** Kein Bimodal-Problem. Speedup skaliert mit Input-Size (größer = mehr Rust-Work relativ zu FFI-Transport).
+1. **Parser baseline is relatively slow.** `csv-parse` (sync) uses a state machine in JS, `papaparse` a custom tokenizer; both CPU-bound without SIMD. BurntSushi `csv` uses memchr-backed field detection plus a zero-copy reader pattern.
+2. **The `parseToJson` path was the Phase-C lever.** The original `parse()` returned `Vec<Vec<String>>` — 100k rows × 5 cols × marshalling overhead was measurable. Current implementation: Rust builds a JSON string directly, JS does `JSON.parse` on the output. **One** FFI crossing instead of 500k.
+3. **All three buckets Green.** No bimodal problem. Speedup scales with input size (larger = more Rust work relative to FFI transport).
 
 ## Evidence
 
@@ -18,19 +18,19 @@ Parity-Green über alle drei Size-Buckets — **2,39×–5,22× vs. `csv-parse` 
 
 | Scenario | @amigo-labs/csv | parseToJson | csv-parse | papaparse | vs. csv-parse | vs. papaparse |
 |---|---:|---:|---:|---:|---:|---:|
-| 100 rows × 5 cols | 11 892 Hz | 12 395 Hz | 4 968 Hz | 7 832 Hz | **2,39×** | **1,52×** |
-| 10 000 rows × 5 cols | 177,3 Hz | 177,7 Hz | 45,3 Hz | 97,2 Hz | **3,91×** | **1,82×** |
-| 100 000 rows × 10 cols | 10,37 Hz | 10,35 Hz | 1,99 Hz | 5,51 Hz | **5,22×** | **1,88×** |
+| 100 rows × 5 cols | 11 892 Hz | 12 395 Hz | 4 968 Hz | 7 832 Hz | **2.39×** | **1.52×** |
+| 10 000 rows × 5 cols | 177.3 Hz | 177.7 Hz | 45.3 Hz | 97.2 Hz | **3.91×** | **1.82×** |
+| 100 000 rows × 10 cols | 10.37 Hz | 10.35 Hz | 1.99 Hz | 5.51 Hz | **5.22×** | **1.88×** |
 
-### Realistic use-case
+### Realistic use case
 
-**ETL / Data-Import** — CSV-Upload aus User-Forms, Log-File-Analysis, Spreadsheet-Export-Pipelines. Median-Workload: 10 KB – 10 MB CSV, 10–100k Rows. Ein Parse-Call pro File, deterministic Output-Shape. Zweiter Use-Case: **CLI-Tooling** (`csv`-Util-Pipes), dort kleinere Inputs aber höhere Call-Frequency — 100-Row-Bucket relevant.
+**ETL / data import** — CSV uploads from user forms, log-file analysis, spreadsheet-export pipelines. Median workload: 10 KB – 10 MB CSV, 10–100k rows. One parse call per file, deterministic output shape. Second use case: **CLI tooling** (`csv` util pipes), where inputs are smaller but call frequency is higher — the 100-row bucket matters there.
 
 ### Benchmark gaps
 
-- **`stringify`-Pfad nicht gebenched** (Row-Array → CSV-String). Phase-C-Äquivalent zum parseToJson-Hebel nicht verifiziert. Vor v0.2 nachziehen.
-- **`parseWithHeaders` nicht separat gebenched.** Konvention in npm-`csv-parse`: `{columns: true}` ist der Default-Use-Case in Produktion. Wir haben die API, aber keine Messung.
-- **Edge-cases** (CRLF/LF-Mix, Quoted-Delimiter, UTF-8-BOM) nicht als Bench-Szenario — parity via `__conformance__/upstream.spec.ts` abgedeckt, aber perf-separat wäre sinnvoll.
+- **`stringify` path not benched** (row array → CSV string). Phase-C equivalent of the parseToJson lever not verified. Catch up before v0.2.
+- **`parseWithHeaders` not separately benched.** The npm `csv-parse` convention `{columns: true}` is the default production use case. We have the API, no measurement.
+- **Edge cases** (CRLF/LF mix, quoted delimiter, UTF-8 BOM) not as bench scenario — parity covered via `__conformance__/upstream.spec.ts`, but a perf-only split would be useful.
 
 ### API surface
 
@@ -43,42 +43,42 @@ Parity-Green über alle drei Size-Buckets — **2,39×–5,22× vs. `csv-parse` 
 #[napi(js_name = "parseToJson")] fn parse_to_json(input: Buffer, options: ...) -> Result<String>
 ```
 
-- Input `Buffer` durchgehend (zero-copy-Transport).
-- `parse()` ist intern identisch mit `parseToJson + JSON.parse` (Commit `ecf8408`).
-- `countRows()` ist der Shortcut für Row-Count ohne Array-Aufbau — pure Rust, Zero-Array-FFI.
-- `parseToJson()` ist der exponierte Hot-Path — User kann `JSON.parse` selbst terminieren und streamen.
+- `Buffer` input throughout (zero-copy transport).
+- `parse()` is internally identical to `parseToJson + JSON.parse` (commit `ecf8408`).
+- `countRows()` is the shortcut for row counting without array construction — pure Rust, zero array FFI.
+- `parseToJson()` is the exposed hot path — the user can `JSON.parse` and stream themselves.
 
 ### Bundle / binary size
 
-BurntSushi `csv` crate ohne `serde`-Feature. Vermutlich 300–500 KB per Target — small. `docs/data.json`-`sizes`-Feld für exakte Zahl.
+BurntSushi `csv` crate without the `serde` feature. Likely 300–500 KB per target — small. `docs/data.json`'s `sizes` field has the exact number.
 
 ### FFI-overhead baseline
 
-- 100k-Row-Bucket: Input-Buffer ~5 MB via Buffer-Handle ~180 ns transport. Output JSON-String ~8 MB via UTF-8→UTF-16-Konversion bei 0,35 ns/byte = ~2,8 ms. Auf ~100 ms Rust-Parse = **2,8 % FFI-Share**. Tolerabel.
-- 100-Row-Bucket: FFI ~30 µs auf ~80 µs Rust = 27 %. Dort wäre Buffer-Output-Variante ein Theorie-Hebel, aber aktueller 2,39×-Speedup ist bereits Green.
+- 100k-row bucket: input buffer ~5 MB via buffer handle ~180 ns transport. Output JSON string ~8 MB via UTF-8→UTF-16 conversion at 0.35 ns/byte = ~2.8 ms. On ~100 ms of Rust parse = **2.8 % FFI share**. Tolerable.
+- 100-row bucket: FFI ~30 µs on ~80 µs Rust = 27 %. A buffer-output variant would be a theoretical lever there, but the current 2.39× speedup is already Green.
 
 ## Phase-C optimization checklist
 
 | # | Lever | Applicable | Notes |
 |---|---|---|---|
-| C.1 | Input-type minimization | ✅ already done | `Buffer` durchgehend, zero-copy |
-| C.2 | Output-type minimization (String JSON statt Vec<Vec<String>>) | ✅ already done | Commit `ecf8408` |
-| C.3 | Batch API | ❌ not applicable | Ein-Call-per-File ist das Idiom |
-| C.4 | Stateful API (CsvParser-Class) | 🟡 marginal | Wenn User wiederholt mit identischen Options parst, kleine Build-Opts-Wins. Sub-prozent. |
-| C.5 | Parallelization | ❌ not applicable | CSV ist sequentieller Parse |
-| C.6 | Algorithm swap (`qsv`-style simd-csv) | 🟡 potential | `csv-async` crate hat SIMD-Experimente. Wenn 10× vs. BurntSushi messbar, Sprint-würdig. Aktuell 5,22× bei 100k — genug Headroom |
+| C.1 | Input-type minimisation | ✅ already done | `Buffer` throughout, zero-copy |
+| C.2 | Output-type minimisation (string JSON instead of Vec<Vec<String>>) | ✅ already done | Commit `ecf8408` |
+| C.3 | Batch API | ❌ not applicable | One-call-per-file is the idiom |
+| C.4 | Stateful API (CsvParser class) | 🟡 marginal | If users repeatedly parse with identical options, small build-opts wins. Sub-percent. |
+| C.5 | Parallelisation | ❌ not applicable | CSV is a sequential parse |
+| C.6 | Algorithm swap (`qsv`-style simd-csv) | 🟡 potential | The `csv-async` crate has SIMD experiments. If 10× vs. BurntSushi is measurable, sprint-worthy. Currently 5.22× at 100k — enough headroom. |
 | C.7 | Allocator tuning | ❌ not applicable | — |
-| C.8 | Bundle-size | ✅ already done | Workspace-profile |
+| C.8 | Bundle size | ✅ already done | Workspace profile |
 
 ## Action plan
 
-**Keep-as-is.** Green über alle Buckets, Phase-C-Hebel bereits gezogen.
+**Keep-as-is.** Green across every bucket, Phase-C lever already pulled.
 
 Maintenance:
 
-1. **`stringify`-Bench hinzufügen** — symmetrischer Pfad zu parse.
-2. **`parseWithHeaders`-Bench** — primärer Produktions-Use-Case, verdient eigene Messung.
-3. **SIMD-CSV-Spike** (Phase-C.6) nur als Fast-Follow falls 10×-Upgrade portfolio-politisch gewünscht. Aktuell kein Druck.
+1. **Add a `stringify` bench** — symmetric path to parse.
+2. **`parseWithHeaders` bench** — the primary production use case, deserves its own measurement.
+3. **SIMD-CSV spike** (Phase-C.6) only as fast-follow if a 10× upgrade is portfolio-political. No pressure right now.
 
 ## References
 
@@ -87,4 +87,4 @@ Maintenance:
 - Lib: `crates/csv/src/lib.rs`
 - Cargo: `crates/csv/Cargo.toml`
 - Phase-C commit: `ecf8408` (`parse()` → `parseToJson + JSON.parse`)
-- `docs/packages.json` speedup: `"1.52–1.88× faster"` (vs. papaparse — konservative Zahl)
+- `docs/packages.json` speedup: `"1.52–1.88× faster"` (vs. papaparse — conservative figure)

--- a/docs/perf-review/deepmerge.md
+++ b/docs/perf-review/deepmerge.md
@@ -4,14 +4,14 @@
 
 ## Verdict
 
-**3,38×–5,55× vs. `deepmerge` npm** über alle drei Szenarien (flat / deep / large-arrays). Das ist eines der überraschenderen Green-Verdikte im Portfolio — deepmerge wirkt oberflächlich wie ein `deep-equal`-Antipattern (zwei JS-Objekte rein, ein JS-Objekt raus), aber die Object-Traversal + Allokations-Arbeit ist in Rust signifikant schneller als V8's Object-Prototype-Walking, selbst mit FFI-Overhead durch `serde_json::Value`-Marshalling.
+**3.38×–5.55× vs. `deepmerge` npm** across all three scenarios (flat / deep / large-arrays). One of the more surprising Green verdicts in the portfolio — deepmerge looks superficially like a `deep-equal` antipattern (two JS objects in, one JS object out), but the object traversal + allocation work is significantly faster in Rust than V8's object-prototype walking, even after FFI overhead from `serde_json::Value` marshalling.
 
 ## Classification rationale
 
-1. **Object-Allokation ist der eigentliche Bottleneck in JS.** V8 alloziert jede `{...}`-Spread-Kopie als neuen Shape-Descriptor. Tief geschachtelte Objects triggern Hidden-Class-Transitions pro Ebene. Rust `serde_json::Map` ist ein flat HashMap-backed-Structure — Insert-Kosten sind konstant.
-2. **Array-Concat-Skalierung** (1000-item) ist der größte Win (4,91×). deepmerge-npm ruft `Array.prototype.concat` in einer Schleife über die Keys = wiederholte Array-Allokation.
-3. **FFI-Transport ist der Kosten-Punkt, aber amortisiert.** Wir marshallen zwei JS-Objects über `serde_json::Value` rein und einen raus. Das ist `Vec<Object>`-ähnlicher FFI-Cost (siehe `docs/post-mortems/xml.md`), aber einmal pro Call — die Rust-Merge-Arbeit dominiert.
-4. **Prototype-Pollution-Protection als Nebenprodukt.** Rust-seitige `__proto__`/`constructor`/`prototype`-Filterung ist security-relevant und in der deepmerge-npm-Version ein wiederkehrender CVE-Target.
+1. **Object allocation is the real bottleneck in JS.** V8 allocates every `{...}` spread copy as a new shape descriptor. Deeply-nested objects trigger hidden-class transitions per level. Rust `serde_json::Map` is a flat HashMap-backed structure — insert cost is constant.
+2. **Array-concat scaling** (1000 items) is the biggest win (4.91×). deepmerge-npm calls `Array.prototype.concat` in a loop over keys = repeated array allocation.
+3. **FFI transport is the cost driver, but amortised.** We marshal two JS objects in via `serde_json::Value` and one out. That's `Vec<Object>`-style FFI cost (see `docs/post-mortems/xml.md`), but once per call — Rust merge work dominates.
+4. **Prototype-pollution protection as a side-effect.** Rust-side `__proto__` / `constructor` / `prototype` filtering is security-relevant and a recurring CVE target in deepmerge-npm.
 
 ## Evidence
 
@@ -19,19 +19,19 @@
 
 | Scenario | @amigo-labs/deepmerge | deepmerge npm | Speedup |
 |---|---:|---:|---:|
-| flat 4-key objects | 3 353 331 Hz | 992 663 Hz | **3,38×** |
-| deep (10 levels) | 210 618 Hz | 37 983 Hz | **5,55×** |
-| 1000-item arrays | 3 564 Hz | 725 Hz | **4,91×** |
+| flat 4-key objects | 3 353 331 Hz | 992 663 Hz | **3.38×** |
+| deep (10 levels) | 210 618 Hz | 37 983 Hz | **5.55×** |
+| 1000-item arrays | 3 564 Hz | 725 Hz | **4.91×** |
 
-### Realistic use-case
+### Realistic use case
 
-**Config-Merging** — CLI-Defaults + User-Config + Project-Config + Env-Overrides. Typische Object-Größe: 5–50 Keys, 2–5 Levels tief. Mehrfach pro Process-Start gerufen. Zweiter Use-Case: **Deep-Clone via `merge(target={}, source)`** — Idiom in Vue/React-State-Management und Vanilla-JS.
+**Config merging** — CLI defaults + user config + project config + env overrides. Typical object size: 5–50 keys, 2–5 levels deep. Called multiple times per process start. Second use case: **deep clone via `merge(target={}, source)`** — idiomatic in Vue / React state management and vanilla JS.
 
 ### Benchmark gaps
 
-- **`mergeAll`-Pfad** (Variadic-Merge) nicht gebenched. API exponiert `merge_all_json(values: Vec<Value>)` aber kein Bench-Slot.
-- **Extreme-deep (50+ Levels) nicht getestet.** Meist künstlich, aber testbar für Stack-Depth.
-- **Rich-Type-Handling** (Date, RegExp via JS-Wrapper) nicht in Perf-Bench (ist `__conformance__`-Thema).
+- **`mergeAll` path** (variadic merge) not benched. The API exposes `merge_all_json(values: Vec<Value>)` but no bench slot.
+- **Extreme-deep (50+ levels) not tested.** Mostly artificial, but testable for stack depth.
+- **Rich-type handling** (Date, RegExp via JS wrapper) not in the perf bench (it's a `__conformance__` topic).
 
 ### API surface
 
@@ -40,42 +40,42 @@
 #[napi] fn merge_all_json(values: Vec<Value>, options: Option<DeepmergeOptions>) -> Value
 ```
 
-- `Value` = `serde_json::Value` — Objects/Arrays/Primitives. Rich-Types (Date, RegExp, Map, Set) werden in JS-Wrapper-Layer abgefangen (README dokumentiert).
-- `DeepmergeOptions.array_merge`: `'concat'` (default) oder `'overwrite'`.
-- Prototype-Pollution-Filter hart eingebaut: `FORBIDDEN = ["__proto__", "constructor", "prototype"]` werden beim Merge ignoriert.
+- `Value` = `serde_json::Value` — objects / arrays / primitives. Rich types (Date, RegExp, Map, Set) are intercepted in the JS wrapper layer (documented in the README).
+- `DeepmergeOptions.array_merge`: `'concat'` (default) or `'overwrite'`.
+- Prototype-pollution filter is hard-built-in: `FORBIDDEN = ["__proto__", "constructor", "prototype"]` are ignored during merge.
 
 ### Bundle / binary size
 
-`serde_json` ist die einzige nennenswerte Dep. ~400–600 KB pro Target.
+`serde_json` is the only notable dep. ~400–600 KB per target.
 
 ### FFI-overhead baseline
 
-- Flat 4-key-Objekt: 2× Input-Marshalling + 1× Output ≈ 1–3 µs bei 100-Byte-Objekten. Auf 300 ns Rust-Merge-Work = ~5×. Aber JS-Äquivalent (deepmerge-npm) braucht selbst ~1 µs für dieselben Objekte. Netto: 3,38× Win.
-- Deep 10-Level: Input ~2 KB JSON + Output ~2 KB. FFI ~10 µs auf ~5 ms Rust-Work = 0,2 %. Dominant Rust.
-- 1000-Array: Input 2× 8 KB, Output 16 KB. FFI ~50 µs auf 300 µs Rust. ~17 %. Grenzwertig, aber 4,91× Margin hält.
+- Flat 4-key object: 2× input marshalling + 1× output ≈ 1–3 µs on 100-byte objects. On 300 ns of Rust merge work = ~5×. But the JS equivalent (deepmerge-npm) itself takes ~1 µs for the same objects. Net: 3.38× win.
+- Deep 10-level: input ~2 KB JSON + output ~2 KB. FFI ~10 µs on ~5 ms of Rust work = 0.2 %. Rust dominates.
+- 1000-array: input 2× 8 KB, output 16 KB. FFI ~50 µs on 300 µs Rust. ~17 %. Borderline, but the 4.91× margin holds.
 
 ## Phase-C optimization checklist
 
 | # | Lever | Applicable | Notes |
 |---|---|---|---|
-| C.1 | Input-type minimization (Buffer statt Value?) | ❌ not applicable | User-API ist JS-Object nativ; Buffer-Overload würde bedeuten JSON-stringify auf Caller-Seite, das verlagert die Arbeit |
-| C.2 | Output-type minimization | ❌ not applicable | — |
-| C.3 | Batch API (`merge_all_json`) | ✅ already done | Exponiert, nicht gebenched aber API da |
+| C.1 | Input-type minimisation (Buffer instead of Value?) | ❌ not applicable | User API is JS object native; a Buffer overload would mean JSON.stringify on the caller side — that just shifts the work |
+| C.2 | Output-type minimisation | ❌ not applicable | — |
+| C.3 | Batch API (`merge_all_json`) | ✅ already done | Exposed, not benched but the API exists |
 | C.4 | Stateful API | ❌ not applicable | — |
-| C.5 | Parallelization | ❌ not applicable | Merge ist sequenziell |
-| C.6 | Algorithm swap (simd-json statt serde_json) | 🟡 potential | `simd-json` für Input-Parse würde FFI-Share senken, aber Parse ist bereits V8-seitig (NAPI liefert `Value` fertig-deserialisiert). Nicht direkt anwendbar. |
-| C.7 | Allocator tuning (bumpalo für Merge-Allocs) | 🟡 marginal | `serde_json::Map` nutzt BTreeMap-backed. Austausch gegen Bump-Arena würde Merge-Intermediates beschleunigen. Unbekannter Gewinn. |
-| C.8 | Bundle-size | ✅ already done | Workspace-profile |
+| C.5 | Parallelisation | ❌ not applicable | Merge is sequential |
+| C.6 | Algorithm swap (simd-json instead of serde_json) | 🟡 potential | `simd-json` for input parse would lower the FFI share, but parsing already happens V8-side (NAPI hands us a deserialised `Value`). Not directly applicable. |
+| C.7 | Allocator tuning (bumpalo for merge allocs) | 🟡 marginal | `serde_json::Map` is BTreeMap-backed. Swapping in a bump arena would speed up merge intermediates. Unknown gain. |
+| C.8 | Bundle size | ✅ already done | Workspace profile |
 
 ## Action plan
 
-**Keep-as-is.** Green über alle Szenarien, keine offene Front.
+**Keep-as-is.** Green across every scenario, no open front.
 
 Maintenance:
 
-1. **`mergeAll`-Bench hinzufügen** — API exponiert aber nicht gemessen.
-2. **Rich-Type-Wrapper-Test-Docs** (Date/RegExp in JS-Layer) dokumentieren — teilweise im README, aber Edge-Cases könnten ausgebaut werden.
-3. **bumpalo-Spike als Fast-Follow** wenn Größen-Regressionen in späteren Node-Versionen auftreten.
+1. **Add a `mergeAll` bench** — API exposed but not measured.
+2. **Document rich-type wrapper tests** (Date / RegExp in the JS layer) — partially in the README, but edge cases could be expanded.
+3. **bumpalo spike as fast-follow** if size regressions appear in later Node versions.
 
 ## References
 

--- a/docs/perf-review/encoding.md
+++ b/docs/perf-review/encoding.md
@@ -1,17 +1,17 @@
 # Perf-Review: `@amigo-labs/encoding`
 
-> **Status:** 🟢 Green (post-Phase-C, nach shift_jis-Re-Messung) · **Reviewed:** 2026-04-21 · **Version:** 0.1.0
+> **Status:** 🟢 Green (post-Phase-C, after the shift_jis re-measurement) · **Reviewed:** 2026-04-21 · **Version:** 0.1.0
 
 ## Verdict
 
-Ein **spezifikum**-lastiges Paket. Die meisten Encodings (UTF-8 / UTF-16LE/BE / Latin-1 / Windows-1252) haben hand-optimierte Rust-Pfade, die direkt gegen `Buffer`-Input/Output laufen — daher der **959×-gegen-iconv-lite-Win auf Latin-1 10MB-decode** (33,95×), der wahrscheinlich extremste Einzel-Win im Portfolio. UTF-8 läuft über V8-Fast-Path (Parity bis leicht schneller). Shift_JIS ist der einzige weak-point mit **0,56× (1,8× langsamer)** — encoding_rs' Shift_JIS-Decoder ist der gemeinsame Bottleneck; iconv-lite nutzt eine custom Lookup-Table die bei kleineren Inputs überlegen ist. Die `perf-review.md`-Zeile 38 dokumentiert das als akzeptable Divergenz weil alle anderen Encodings dominant gewinnen.
+A **specifics**-heavy package. Most encodings (UTF-8 / UTF-16LE/BE / Latin-1 / Windows-1252) have hand-optimised Rust paths that run directly against `Buffer` input/output — that's where the **959×-against-iconv-lite Latin-1 10 MB decode win** (33.95×) comes from, probably the most extreme single win in the portfolio. UTF-8 runs through the V8 fast path (parity to slightly faster). Shift_JIS is the only weak point at **0.56× (1.8× slower)** — encoding_rs' Shift_JIS decoder is the shared bottleneck; iconv-lite uses a custom lookup table that wins on smaller inputs. `perf-review.md:38` documents this as an acceptable divergence because every other encoding wins decisively.
 
 ## Classification rationale
 
-1. **Hand-optimierte Hot-Paths für die Common-Encodings.** UTF-16LE/BE, Latin-1 strict, Windows-1252 strict: custom Rust-Funktionen die direkt auf `Vec<u8>`/`Buffer` arbeiten, keine encoding_rs-Abstraktion. UTF-8 nutzt short-circuit (NAPI liefert bereits UTF-8, keine Konversion nötig).
-2. **iconv-lite-Parity-Semantik.** Wichtige Divergenzen vs. encoding_rs-Default (die WHATWG-web-form-Behavior) sind explizit gepatcht: `latin1` = strict ISO-8859-1 (nicht windows-1252-Alias), UTF-16-Varianten = raw byte orderings (nicht UTF-8-encoded), unmappable-Chars = `?`-Byte (nicht `&#NNN;`-HTML-Entity).
-3. **Shift_JIS-Pfad geht durch encoding_rs.** encoding_rs' Shift_JIS-Decoder-State-Machine hat einen konstanten Per-Byte-Overhead. iconv-lite nutzt eine pre-computed 2-Byte-Lookup-Table die bei 100KB schneller ist. Phase-C-Analyse: `docs/perf-review.md:38` dokumentiert das als acceptable trade-off, Status auf Green wegen Rest-Win.
-4. **10MB-Latin1-Win stammt aus der Output-Buffer-Strategie.** iconv-lite allokiert per-char; unser `decode_latin1_strict` pre-alloziert `input.len() * 2` und schreibt direkt Bytes statt char-per-char.
+1. **Hand-optimised hot paths for the common encodings.** UTF-16LE/BE, Latin-1 strict, Windows-1252 strict: custom Rust functions that operate directly on `Vec<u8>` / `Buffer`, no encoding_rs abstraction. UTF-8 uses a short-circuit (NAPI already hands us UTF-8, no conversion needed).
+2. **iconv-lite parity semantics.** The important divergences from encoding_rs default (the WHATWG web-form behaviour) are explicitly patched: `latin1` = strict ISO-8859-1 (not a windows-1252 alias), UTF-16 variants = raw byte orderings (not UTF-8-encoded), unmappable chars = `?` byte (not `&#NNN;` HTML entity).
+3. **Shift_JIS path goes through encoding_rs.** encoding_rs' Shift_JIS decoder state machine has a constant per-byte overhead. iconv-lite uses a pre-computed 2-byte lookup table that wins at 100 KB. Phase-C analysis: `docs/perf-review.md:38` documents this as an acceptable trade-off, status Green thanks to the residual win.
+4. **The 10 MB Latin-1 win comes from the output-buffer strategy.** iconv-lite allocates per-char; our `decode_latin1_strict` pre-allocates `input.len() * 2` and writes raw bytes instead of char-per-char.
 
 ## Evidence
 
@@ -19,22 +19,22 @@ Ein **spezifikum**-lastiges Paket. Die meisten Encodings (UTF-8 / UTF-16LE/BE / 
 
 | Scenario | @amigo-labs/encoding | iconv-lite | Buffer.from (Node builtin) | vs. iconv-lite |
 |---|---:|---:|---:|---:|
-| encode utf-8 small | 3 734 051 Hz | 1 786 671 Hz | 3 733 212 Hz | **2,09×** |
-| encode utf-8 100 KB | 19 644 Hz | 19 844 Hz | 18 375 Hz | **0,99×** (parity) |
-| encode utf-8 10 MB | 222,3 Hz | 222,6 Hz | 225,9 Hz | **1,00×** (parity) |
-| decode utf-16le 100 KB | 52 479 Hz | 54 245 Hz | — | **0,97×** (parity) |
-| **decode latin1 10 MB** | 959,5 Hz | 28,26 Hz | — | **33,95×** |
-| decode shift_jis 100 KB | 1 094 Hz | 1 971 Hz | — | **0,56×** (weak spot) |
+| encode utf-8 small | 3 734 051 Hz | 1 786 671 Hz | 3 733 212 Hz | **2.09×** |
+| encode utf-8 100 KB | 19 644 Hz | 19 844 Hz | 18 375 Hz | **0.99×** (parity) |
+| encode utf-8 10 MB | 222.3 Hz | 222.6 Hz | 225.9 Hz | **1.00×** (parity) |
+| decode utf-16le 100 KB | 52 479 Hz | 54 245 Hz | — | **0.97×** (parity) |
+| **decode latin1 10 MB** | 959.5 Hz | 28.26 Hz | — | **33.95×** |
+| decode shift_jis 100 KB | 1 094 Hz | 1 971 Hz | — | **0.56×** (weak spot) |
 
-### Realistic use-case
+### Realistic use case
 
-**Byte-to-String / String-to-Byte** an I/O-Grenzen: File-Reading mit non-UTF-8-Encoding, HTTP-Body mit Charset-Header, Legacy-System-Integration. Median: 1 KB – 1 MB pro Call. Encoding-Diversität ist bi-modal: **95 % der Produktions-Calls sind UTF-8** (dort sind wir Parity durch Short-Circuit), der Rest verteilt sich auf Latin-1 (dominant-Win) und CJK-Familie (Shift_JIS weak, andere OK).
+**Byte-to-string / string-to-byte** at I/O boundaries: file reading with non-UTF-8 encoding, HTTP body with charset header, legacy-system integration. Median: 1 KB – 1 MB per call. Encoding diversity is bimodal: **95 % of production calls are UTF-8** (we're at parity through the short-circuit there), with the remainder split between Latin-1 (dominant win) and the CJK family (Shift_JIS weak, others OK).
 
 ### Benchmark gaps
 
-- **UTF-16BE-Decode nicht gebenched** (nur UTF-16LE). Die BE-Variante nutzt denselben `decode_utf16_inner` — erwartbar gleiche Perf.
-- **GBK/Big5/EUC-KR decode** nicht gebenched. Alle nutzen encoding_rs ähnlich Shift_JIS; erwartbar ähnlich weak. Dokumentations-Gap.
-- **Encode non-UTF-8 Pfade** (latin1, shift_jis, windows-1252) nicht gebenched. Nur decode-Seite + UTF-8-encode gemessen.
+- **UTF-16BE decode not benched** (only UTF-16LE). The BE variant uses the same `decode_utf16_inner` — expected same perf.
+- **GBK / Big5 / EUC-KR decode** not benched. All use encoding_rs similarly to Shift_JIS; expected similarly weak. Documentation gap.
+- **Non-UTF-8 encode paths** (latin1, shift_jis, windows-1252) not benched. Only the decode side + UTF-8 encode are measured.
 
 ### API surface
 
@@ -44,43 +44,43 @@ Ein **spezifikum**-lastiges Paket. Die meisten Encodings (UTF-8 / UTF-16LE/BE / 
 #[napi] fn decode(input: Buffer, encoding: String) -> Result<String>
 ```
 
-- Input/Output-Types sind asymmetrisch: String-Input für encode (NAPI liefert UTF-8 String), Buffer-Output; Buffer-Input für decode, String-Output.
-- Iconv-lite-Aliases (`utf8`, `cp932`, `cp1252`, …) werden normalisiert via `normalise_label`.
-- 4 Non-WHATWG-Pfade mit iconv-lite-Semantik: UTF-16LE/BE, Latin-1-strict, Windows-1252-strict.
-- UTF-8 hat Short-Circuit-Pfad (`is_utf8_label`) der encoding_rs komplett umgeht.
+- Input/output types are asymmetric: String input for encode (NAPI hands us a UTF-8 string), Buffer output; Buffer input for decode, String output.
+- iconv-lite aliases (`utf8`, `cp932`, `cp1252`, …) are normalised via `normalise_label`.
+- 4 non-WHATWG paths with iconv-lite semantics: UTF-16LE/BE, Latin-1 strict, Windows-1252 strict.
+- UTF-8 has a short-circuit path (`is_utf8_label`) that bypasses encoding_rs entirely.
 
 ### Bundle / binary size
 
-`encoding_rs` ist recht groß (~800 KB – 1,2 MB mit allen Tabellen). Das ist der Preis für 80+ Encodings. Pro Target kompakt mit `lto=true, strip=symbols`.
+`encoding_rs` is fairly large (~800 KB – 1.2 MB with all tables). That's the price for 80+ encodings. Compact per target with `lto=true, strip=symbols`.
 
 ### FFI-overhead baseline
 
-- 10 MB-decode-Latin1: Input-Buffer ~10 MB via Handle ~180 ns. Output-String bis zu 20 MB (2× expansion) via UTF-8→UTF-16-Konversion ~7 ms. Auf ~1 ms Rust-decode = **87 % FFI-Share!** Trotzdem 34× schneller als iconv-lite weil iconv-lite's JS-Loop sowieso deutlich langsamer ist als unser Rust+FFI zusammen.
-- 100 KB shift_jis: FFI ~35 µs auf ~900 µs Rust = 4 %. Not the bottleneck — der Decoder selbst ist langsam.
+- 10 MB Latin-1 decode: input buffer ~10 MB via handle ~180 ns. Output string up to 20 MB (2× expansion) via UTF-8→UTF-16 conversion ~7 ms. On ~1 ms of Rust decode = **87 % FFI share!** Still 34× faster than iconv-lite because iconv-lite's JS loop is so much slower than our Rust + FFI combined.
+- 100 KB Shift_JIS: FFI ~35 µs on ~900 µs Rust = 4 %. Not the bottleneck — the decoder itself is slow.
 
 ## Phase-C optimization checklist
 
 | # | Lever | Applicable | Notes |
 |---|---|---|---|
-| C.1 | Input-type minimization | ✅ already done | `Buffer` decode-Side, UTF-8-short-circuit im encode |
-| C.2 | Output-type minimization | ✅ already done | Direct-Byte-Writer in `decode_latin1_strict` etc. |
-| C.3 | Batch API | 🟡 potential | `encodeMany(strings, encoding)` könnte für Log-Processing-Workloads relevant sein. Unklar ob Produktions-Demand existiert |
-| C.4 | Stateful API (pre-selected-encoding class) | ❌ not applicable | Encoding-Lookup-Cost ist sub-µs |
-| C.5 | Parallelization (rayon für 10MB+) | 🟡 potential | Latin-1-decode ist embarassingly parallelisierbar. 2× auf 10MB denkbar via chunked-parallel. Messen wenn Produktions-Workload das rechtfertigt |
-| C.6 | Algorithm swap für Shift_JIS | 🟡 **open** | `encoding` crate (rust-encoding, unmaintained) hatte Lookup-Table-Decoder. Oder Custom-Table. Sprint-Kandidat falls 2× Shift_JIS portfolio-relevant ist — aktuell nicht |
-| C.7 | Allocator tuning | ✅ already done | Pre-alloc-Heuristiken in allen Hot-Paths |
-| C.8 | Bundle-size | ✅ already done | `encoding_rs` ohne zusätzliche Features |
+| C.1 | Input-type minimisation | ✅ already done | `Buffer` on the decode side, UTF-8 short-circuit on encode |
+| C.2 | Output-type minimisation | ✅ already done | Direct-byte writer in `decode_latin1_strict` etc. |
+| C.3 | Batch API | 🟡 potential | `encodeMany(strings, encoding)` could matter for log-processing workloads. Unclear whether production demand exists |
+| C.4 | Stateful API (pre-selected-encoding class) | ❌ not applicable | Encoding lookup cost is sub-µs |
+| C.5 | Parallelisation (rayon for 10 MB+) | 🟡 potential | Latin-1 decode is embarrassingly parallelisable. 2× on 10 MB plausible via chunked parallel. Measure when production workload justifies it |
+| C.6 | Algorithm swap for Shift_JIS | 🟡 **open** | The `encoding` crate (rust-encoding, unmaintained) had a lookup-table decoder. Or a custom table. Sprint candidate if 2× Shift_JIS becomes portfolio-relevant — currently it isn't |
+| C.7 | Allocator tuning | ✅ already done | Pre-alloc heuristics in every hot path |
+| C.8 | Bundle size | ✅ already done | `encoding_rs` without extra features |
 
 ## Action plan
 
-**Keep-as-is.** Green-Klassifikation bestätigt durch die 34× Latin-1-Win.
+**Keep-as-is.** Green classification confirmed by the 34× Latin-1 win.
 
 Maintenance:
 
-1. **Encode-Pfade benchen** (latin1, shift_jis, windows-1252) — decode-Seite ist gemessen, encode nicht.
-2. **CJK-Familie erweitern** — GBK/Big5/EUC-KR als Separate Bench-Slots um Shift_JIS-Divergenz zu isolieren.
-3. **Shift_JIS-Custom-Decoder als Fast-Follow-Experiment** falls CJK-Heavy-Workloads portfolio-relevant werden.
-4. **UTF-16BE-Decode-Bench** als Symmetrie-Kontrolle.
+1. **Bench encode paths** (latin1, shift_jis, windows-1252) — the decode side is measured, encode isn't.
+2. **Extend the CJK family** — GBK / Big5 / EUC-KR as separate bench slots so the Shift_JIS divergence is isolated.
+3. **Custom Shift_JIS decoder as fast-follow experiment** if CJK-heavy workloads become portfolio-relevant.
+4. **UTF-16BE decode bench** as a symmetry sanity check.
 
 ## References
 
@@ -88,5 +88,5 @@ Maintenance:
 - Bench: `crates/encoding/__bench__/index.bench.ts`
 - Lib: `crates/encoding/src/lib.rs`
 - Cargo: `crates/encoding/Cargo.toml`
-- Phase-C Status-Update: `docs/perf-review.md:38` ("Update 2026-04-19 (Perf-Sprint)")
+- Phase-C status update: `docs/perf-review.md:38` ("Update 2026-04-19 (perf sprint)")
 - `docs/packages.json` speedup: `"up to 34× faster / 1.8× slower"`

--- a/docs/perf-review/har-validator.md
+++ b/docs/perf-review/har-validator.md
@@ -4,28 +4,28 @@
 
 ## Verdict
 
-`har-validator` validiert HAR (HTTP Archive)-Dateien gegen JSON-Schema. Das Paket ist **seit 2020 deprecated** (Maintainer hat es explicit markiert). Der letzte meaningful Release war 2019. Es wurde nur noch transitiv durch `request` (selbst deprecated) gepullt. Mit `request` weg ist `har-validator` effektiv orphan. Außerdem: JSON-Schema-Validation ist in der `ajv`-Kategorie (→ `docs/perf-review/ajv.md`, Parity too expensive — codegen-vs-interpreter unterschiedliche Philosophien). Doppelt-Black.
+`har-validator` validates HAR (HTTP Archive) files against a JSON Schema. The package has been **deprecated since 2020** (the maintainer marked it explicitly). The last meaningful release was 2019. It has only been pulled in transitively by `request` (also deprecated). With `request` gone, `har-validator` is effectively orphaned. On top of that: JSON-Schema validation falls into the `ajv` category (→ `docs/perf-review/ajv.md`, parity too expensive — codegen-vs-interpreter philosophies don't reconcile). Doubly Black.
 
 ## JS package
 
 - **npm:** [`har-validator`](https://www.npmjs.com/package/har-validator)
-- **Downloads:** ~5M/Woche (reine Legacy-Transitive, sinkt stetig)
-- **Status:** Deprecated, unmaintained. [GitHub-Status](https://github.com/ahmadnassri/node-har-validator).
+- **Downloads:** ~5M/week (pure legacy transitive, declining steadily)
+- **Status:** Deprecated, unmaintained. [GitHub status](https://github.com/ahmadnassri/node-har-validator).
 
 ## Rust replacement
 
-Nicht zutreffend. HAR ist ein Nischen-Format; Schema-Validation ist `ajv`-Shape, bereits NO-GO.
+Not applicable. HAR is a niche format; schema validation is the `ajv` shape, already NO-GO.
 
 ## BACKLOG check
 
-Eintrag in `BACKLOG.md` → "Deprecated / superseded": "Don't touch." Review bestätigt.
+Entry in `BACKLOG.md` → "Deprecated / superseded": "Don't touch." Review confirms.
 
 ## Classification reasoning
 
-1. **Upstream deprecated seit Jahren.** Kein Port-Case.
-2. **Orphan durch `request`-Deprecation.** Hauptgrund der Adoption war transitiv über `request`; mit `request` formal deprecated fällt har-validator mit.
-3. **Schema-Validation-Shape-Kategorie ist bereits NO-GO** (`ajv.md`). Selbst wenn jemand das rettet, haben wir den Shape-Kill bereits dokumentiert.
+1. **Upstream has been deprecated for years.** No port case.
+2. **Orphaned by `request` deprecation.** The main reason for adoption was transitive pull-through `request`; with `request` formally deprecated, har-validator falls with it.
+3. **Schema-validation shape category is already NO-GO** (`ajv.md`). Even if someone resurrected it, the shape kill is already documented.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/har-validator.md`.
+Archived 2026-04-21. Full review: `docs/perf-review/har-validator.md`.

--- a/docs/perf-review/langchain.md
+++ b/docs/perf-review/langchain.md
@@ -4,76 +4,76 @@
 
 ## Verdict
 
-`langchain` ist **Orchestrations-Framework**, nicht Compute-Engine. Der Wert liegt in Abstraktionen (Runnable, Chain, Agent, RetrievalQAChain, AgentExecutor, Callbacks, Memory, OutputParsers) die Benutzer-JS-Code kombinieren und über Netzwerk-I/O (LLM-Calls, Vector-DBs, Tool-APIs) orchestrieren. **Kein nennenswerter Compute lebt hier.** Alle Hot-Paths sind entweder:
+`langchain` is an **orchestration framework**, not a compute engine. The value lies in abstractions (Runnable, Chain, Agent, RetrievalQAChain, AgentExecutor, callbacks, memory, output parsers) that combine user JS code and orchestrate it over network I/O (LLM calls, vector DBs, tool APIs). **No meaningful compute lives here.** All hot paths are either:
 
-1. **Netzwerk-I/O** (LLM-Provider-Calls, Vector-DB-Queries, Tool-APIs) — dominiert, wie in `docs/perf-review/openai.md`.
-2. **User-Callback-Ausführung** (Agent-Tool-Auswahl, Chain-Step-Transformations) — JS-Code-Execution über die FFI-Grenze ist der `remark`/`cheerio`-Callback-Antipattern.
-3. **Spec-Surface** (Runnable/Chain-Interface) ändert sich wöchentlich und wird in Python getrieben. Parity-Tail ist unbegrenzt.
+1. **Network I/O** (LLM provider calls, vector-DB queries, tool APIs) — dominates, as in `docs/perf-review/openai.md`.
+2. **User callback execution** (agent tool selection, chain step transformations) — running JS code across the FFI boundary is the `remark` / `cheerio` callback antipattern.
+3. **Spec surface** (Runnable / chain interface) changes weekly and is driven by the Python project. The parity tail is unbounded.
 
 ## JS package
 
 - **npm:**
-  - [`langchain`](https://www.npmjs.com/package/langchain) (~2M/Woche)
-  - [`@langchain/core`](https://www.npmjs.com/package/@langchain/core) (~2M/Woche, plus viele Sub-Pakete: `@langchain/openai`, `@langchain/anthropic`, `@langchain/community`, ...)
-- **Downloads:** ~4M/Woche kombiniert (BACKLOG-Zahl bestätigt)
-- **Exports / API surface (enorm):**
-  - `Runnable` Interface mit `.invoke`, `.batch`, `.stream`, `.pipe`, `.withConfig`, `.withRetry`, `.withFallbacks`, `.bind`
+  - [`langchain`](https://www.npmjs.com/package/langchain) (~2M/week)
+  - [`@langchain/core`](https://www.npmjs.com/package/@langchain/core) (~2M/week, plus many sub-packages: `@langchain/openai`, `@langchain/anthropic`, `@langchain/community`, ...)
+- **Downloads:** ~4M/week combined (BACKLOG figure confirmed)
+- **Exports / API surface (enormous):**
+  - `Runnable` interface with `.invoke`, `.batch`, `.stream`, `.pipe`, `.withConfig`, `.withRetry`, `.withFallbacks`, `.bind`
   - `PromptTemplate`, `ChatPromptTemplate`, `FewShotPromptTemplate`
-  - Chain-Types: `LLMChain`, `ConversationChain`, `RetrievalQAChain`, `MapReduceChain`, `StuffDocumentsChain`
+  - Chain types: `LLMChain`, `ConversationChain`, `RetrievalQAChain`, `MapReduceChain`, `StuffDocumentsChain`
   - Agents: `AgentExecutor`, `createReactAgent`, `createStructuredChatAgent`, `createToolCallingAgent`
-  - `OutputParser`-Familie (String, JSON, Structured, Pydantic-equivalent, ...)
-  - `Memory`-Familie (Buffer, Summary, Vector, Entity, ...)
-  - `Callback`-System für Tracing/Observability
-  - Plus: Integrations für ~50+ LLM-Provider, ~40+ Vector-Stores, ~50+ Tool-APIs, ~30+ Document-Loaders
-- **Typical input:** User-Messages, Prompt-Variables, Documents, Tools — alles in JS-Objekt-Form
-- **Typical output:** LLM-Responses, Agent-Actions, Intermediate-Steps — alles in JS-Objekt-Form
-- **Realistic median use-case:** **RAG-App-Orchestration** — User-Query → Embedding-Lookup (API-Call) → Prompt-Template-Fill → LLM-Call (API-Call) → Output-Parse → Response. Oder **Agent-Loop**: LLM-Call → Tool-Call-Extract → User-Code für Tool-Execution → Zurück zu LLM. **Jede Schritt** ist entweder Netzwerk oder User-Callback.
+  - `OutputParser` family (string, JSON, structured, Pydantic-equivalent, ...)
+  - `Memory` family (buffer, summary, vector, entity, ...)
+  - `Callback` system for tracing / observability
+  - Plus: integrations for ~50+ LLM providers, ~40+ vector stores, ~50+ tool APIs, ~30+ document loaders
+- **Typical input:** User messages, prompt variables, documents, tools — all in JS-object form
+- **Typical output:** LLM responses, agent actions, intermediate steps — all in JS-object form
+- **Realistic median use case:** **RAG-app orchestration** — user query → embedding lookup (API call) → prompt-template fill → LLM call (API call) → output parse → response. Or **agent loop**: LLM call → tool-call extract → user code for tool execution → back to LLM. **Every step** is either network or user callback.
 
 ## Rust replacement
 
-- **Candidate crate(s):** `rig` (Rust-LLM-Framework von Playgrounds), `llm-chain` — existieren, aber **andere** API, nicht Drop-in-Parity. Keine Rust-Implementation der langchain-Python-API.
-- **Maintenance / license:** Irrelevant — Drop-in-Port ist nicht möglich.
-- **Known gotchas / divergences:** **Gesamte Surface** ist Divergenz-Fläche.
+- **Candidate crate(s):** `rig` (Rust LLM framework from Playgrounds), `llm-chain` — exist, but **different** API, not drop-in parity. No Rust implementation of the langchain Python API.
+- **Maintenance / license:** Irrelevant — drop-in port is not possible.
+- **Known gotchas / divergences:** **The entire surface** is divergence area.
 
 ## BACKLOG check
 
-Vorhandener Eintrag in `BACKLOG.md` → "Ruled out — AI-category": "Callback-graph orchestration with unbounded async surface — parity tail never ends." Review formalisiert und archiviert.
+Existing entry in `BACKLOG.md` → "Ruled out — AI-category": "Callback-graph orchestration with unbounded async surface — parity tail never ends." Review formalises and archives.
 
-Abgrenzung:
-- Gegen `docs/perf-review/remark.md` (🔴 Parity): langchain IS diese Kategorie, aber auf Prompt-Level statt Markdown-Level. Identische Lehre.
-- Gegen `docs/perf-review/openai.md` (⚫ Black): langchain ruft diese HTTP-Clients intern. Ein Tier oberhalb.
-- Gegen `docs/perf-review/cheerio.md` (🔴 Parity): Chain-API-Antipattern auf App-Level statt DOM-Level.
-- Gegen `@langchain/textsplitters` (🟡 GO, `docs/perf-review/langchain__textsplitters.md`): sub-paket, **isolated** (keine Callbacks, keine Chains — pure Text-Transformation). Das ist der einzige Teil des langchain-Ökosystems, der portbar ist.
+Boundary:
+- vs. `docs/perf-review/remark.md` (🔴 parity): langchain IS this category, but on prompt level instead of Markdown level. Identical lesson.
+- vs. `docs/perf-review/openai.md` (⚫ Black): langchain calls these HTTP clients internally. One tier above.
+- vs. `docs/perf-review/cheerio.md` (🔴 parity): chain-API antipattern on app level rather than DOM level.
+- vs. `@langchain/textsplitters` (🟡 GO, `docs/perf-review/langchain__textsplitters.md`): sub-package, **isolated** (no callbacks, no chains — pure text transformation). It's the only part of the langchain ecosystem that is portable.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Null algorithmisch.** Was "passiert" ist Orchestrierung: Promise-Resolution, Object-Traversal, Template-String-Fill, Callback-Invocation. Alles V8-native-schnell. |
-| Input size distribution | Variabel, aber irrelevant — kein Compute-dominierter Hot-Path. |
-| Output size distribution | Variabel. |
-| Reusable setup (stateful potential) | Chain-Construction könnte "compiled" werden — aber der `.invoke`-Call selbst bleibt Orchestration-over-Network. |
-| Batch-usage realism | `.batch()` existiert bereits im langchain-API. Batch-Execution ist N parallele Netzwerk-Calls, nicht Rust-beschleunigbar. |
-| FFI-share estimate vs. Rust work | **Nicht definierbar** — es gibt keinen "Rust Work" ohne Callback-in-JS und keinen klaren Hot-Path. |
+| Per-call algorithmic work | **None algorithmically.** What "happens" is orchestration: promise resolution, object traversal, template-string fill, callback invocation. All V8-native fast. |
+| Input size distribution | Variable, but irrelevant — no compute-dominated hot path. |
+| Output size distribution | Variable. |
+| Reusable setup (stateful potential) | Chain construction could be "compiled" — but the `.invoke` call itself remains orchestration-over-network. |
+| Batch usage realism | `.batch()` already exists in the langchain API. Batch execution is N parallel network calls, not Rust-accelerable. |
+| FFI-share estimate vs. Rust work | **Not definable** — there is no "Rust work" without callbacks-into-JS, and no clear hot path. |
 
 ## Classification reasoning
 
-1. **Keine Compute-Surface.** langchain dispatcht Arbeit an andere Systeme (LLMs, Vektor-DBs, Tools). Nichts, was schneller in Rust läuft als in JS.
+1. **No compute surface.** langchain dispatches work to other systems (LLMs, vector DBs, tools). Nothing that runs faster in Rust than in JS.
 
-2. **Callback-Graph über FFI = Antipattern.** Jeder `Runnable.invoke` kann User-Code aufrufen (OutputParser, Callback, Retrieval-Filter, Memory-Load, Tool-Handler). Diese Funktionen über FFI zu reichen = unbegrenzt viele Crossings pro Chain-Execution.
+2. **Callback graph over FFI = antipattern.** Every `Runnable.invoke` may call user code (OutputParser, callback, retrieval filter, memory load, tool handler). Routing those functions across FFI = unbounded crossings per chain execution.
 
-3. **Spec-Surface ist instabil.** Python-langchain released alle 2–4 Tage. JS-langchain mirrors. Unser Port wäre nie bei v1 — permanent chase.
+3. **Spec surface is unstable.** Python langchain ships every 2–4 days. JS langchain mirrors. Our port would never reach v1 — permanent chase.
 
-4. **Der `@langchain/textsplitters`-Cut.** Die einzige sub-isolierte Komponente des Ökosystems ist Text-Splitting (pure String-Transformation, keine Callbacks). Die haben wir separately reviewed und als GO Yellow klassifiziert. Alles andere in langchain ist entweder Netzwerk-Orchestration oder Callback-Graph.
+4. **The `@langchain/textsplitters` cut.** The only sub-isolated component of the ecosystem is text splitting (pure string transformation, no callbacks). We've reviewed it separately and classified it as GO Yellow. Everything else in langchain is either network orchestration or callback graph.
 
-**Shape-Matching:**
-- 🔁 Wie `remark` (Plugin-Graph-Orchestration)
-- 🔁 Wie `openai` / `anthropic-ai` / `cohere-ai` (wrapped I/O)
-- 🔁 Wie `cheerio` (Chain-API auf anderem Level)
-- ✅ Einzige Ausnahme: Text-Splitting-Sub-Modul → eigener GO-Pfad
+**Shape matching:**
+- 🔁 Like `remark` (plugin-graph orchestration)
+- 🔁 Like `openai` / `anthropic-ai` / `cohere-ai` (wrapped I/O)
+- 🔁 Like `cheerio` (chain API on a different level)
+- ✅ Sole exception: text-splitters sub-module → its own GO path
 
-**Benchmark-Gap-Flag:** Absurdes Concept.
+**Benchmark-gap flag:** Absurd by construction.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/langchain.md`. Der portable Sub-Scope (Text-Splitters) lebt unter `docs/perf-review/langchain__textsplitters.md` als separater GO-Kandidat.
+Archived 2026-04-21. Full review: `docs/perf-review/langchain.md`. The portable sub-scope (text-splitters) lives under `docs/perf-review/langchain__textsplitters.md` as a separate GO candidate.

--- a/docs/perf-review/moment.md
+++ b/docs/perf-review/moment.md
@@ -4,33 +4,33 @@
 
 ## Verdict
 
-`moment` ist seit 2020 **legacy** (upstream erklärt). Die Moment-Maintainer empfehlen explizit die Migration zu `date-fns`, `dayjs`, `luxon` oder dem nativen `Temporal`-API. Ein Port wäre:
+`moment` has been **legacy** since 2020 (per upstream). The Moment maintainers explicitly recommend migrating to `date-fns`, `dayjs`, `luxon` or the native `Temporal` API. A port would mean:
 
-1. Replicating a library the upstream recommends abandoning
-2. Hinter einer wachsenden User-Migration-Bewegung (seit 5+ Jahren aktiv)
-3. Ohne Perf-Hebel — die Moment-Alternativen (dayjs 2 KB, date-fns tree-shakeable) sind bereits klein und schnell.
+1. Replicating a library the upstream recommends abandoning.
+2. Sitting behind a growing user-migration trend (active for 5+ years).
+3. Without a perf lever — the Moment alternatives (dayjs at 2 KB, date-fns tree-shakeable) are already small and fast.
 
 ## JS package
 
 - **npm:** [`moment`](https://www.npmjs.com/package/moment)
-- **Downloads:** ~15M/Woche (sinkend, aber noch hoch durch Legacy-Codebases)
-- **Status:** Upstream "in maintenance mode" seit September 2020. Keine neuen Features, nur Bug-Fixes. [Offizieller Migration-Guide](https://momentjs.com/docs/#/-project-status/).
+- **Downloads:** ~15M/week (declining, but still high through legacy codebases)
+- **Status:** Upstream "in maintenance mode" since September 2020. No new features, only bug fixes. [Official migration guide](https://momentjs.com/docs/#/-project-status/).
 
 ## Rust replacement
 
-- **Candidate crate(s):** `chrono`, `time`, `jiff` — alle deutlich besser pflegbar als ein moment-parity-Port wäre. Würde man Date-Handling nativ brauchen: direkter `@amigo-labs/datetime`-Port via `jiff` wäre eigener Kandidat, aber **nicht** mit Moment-API-Parity.
-- **Maintenance / license:** Alle MIT, aktiv.
+- **Candidate crate(s):** `chrono`, `time`, `jiff` — all considerably more maintainable than a Moment-parity port would be. If we ever wanted native date handling: a direct `@amigo-labs/datetime` port via `jiff` would be its own candidate, but **not** with Moment-API parity.
+- **Maintenance / license:** All MIT, active.
 
 ## BACKLOG check
 
-Eintrag in `BACKLOG.md` → "Deprecated / superseded": "Don't touch." Review bestätigt.
+Entry in `BACKLOG.md` → "Deprecated / superseded": "Don't touch." Review confirms.
 
 ## Classification reasoning
 
-1. **Upstream deprecated.** Moment-Maintainer empfehlen Alternativen. Ein Rust-Clone würde deprecation hinter sich her schleppen.
-2. **API-Baggage.** Moment's mutable-API (`m.add(1, 'day')` mutiert) ist der Grund für den ursprünglichen Community-Wechsel. Parity = Replication of bad API.
-3. **Zero Portfolio-Wert.** Jedes Projekt, das sich bewusst modernisiert, wählt date-fns/dayjs/Temporal über Moment.
+1. **Upstream deprecated.** The Moment maintainers recommend alternatives. A Rust clone would inherit the deprecation.
+2. **API baggage.** Moment's mutable API (`m.add(1, 'day')` mutates) is the original reason for the community switch. Parity = replicating a bad API.
+3. **Zero portfolio value.** Any project that consciously modernises picks date-fns / dayjs / Temporal over Moment.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/moment.md`. Wenn Date-Handling als Portfolio-Thema aufkommt: separates Review für `@amigo-labs/datetime` basierend auf `jiff`, kein Moment-Port.
+Archived 2026-04-21. Full review: `docs/perf-review/moment.md`. If date handling becomes a portfolio topic: separate review for `@amigo-labs/datetime` based on `jiff`, no Moment port.

--- a/docs/perf-review/onnxruntime-node.md
+++ b/docs/perf-review/onnxruntime-node.md
@@ -4,64 +4,64 @@
 
 ## Verdict
 
-Beide Pakete sind bereits **native C++-Bindings** (ONNX Runtime und Facebook-Faiss), wrapped via node-addon-api. Ein Re-Wrap via NAPI-RS läuft Rust-Bindings gegen dieselben C++-Kern-Libraries — Null Perf-Gewinn möglich. Exakt dieselbe Lehre wie `hnswlib-node` (2026-04-21 re-kategorisiert): Rust-Code ist nicht schneller als optimierter C++-Code wenn sie denselben Algorithmus implementieren. Und für `onnxruntime-node` ist der eigentliche Compute ohnehin in C++/CUDA/CoreML — unser Binding würde Millisekunden-auf-Millisekunden sparen gegen Sekunden-long-Inference-Calls = statistisches Rauschen.
+Both packages are already **native C++ bindings** (ONNX Runtime and Facebook Faiss), wrapped via node-addon-api. A re-wrap via NAPI-RS would run Rust bindings against the same C++ core libraries — zero perf gain possible. Exactly the same lesson as `hnswlib-node` (re-categorised on 2026-04-21): Rust code is not faster than optimised C++ code when both implement the same algorithm. And for `onnxruntime-node` the actual compute is in C++ / CUDA / CoreML anyway — our binding would save milliseconds against second-long inference calls = statistical noise.
 
 ## JS package
 
 - **npm:**
-  - [`onnxruntime-node`](https://www.npmjs.com/package/onnxruntime-node) (~400k/Woche) — offizielles Microsoft-Binding zu ONNX Runtime C++
-  - [`faiss-node`](https://www.npmjs.com/package/faiss-node) (~10k/Woche) — Binding zu Facebook-Faiss C++
-- **Downloads:** ~410k/Woche kombiniert (BACKLOG-Zahl bestätigt)
+  - [`onnxruntime-node`](https://www.npmjs.com/package/onnxruntime-node) (~400k/week) — official Microsoft binding to ONNX Runtime C++
+  - [`faiss-node`](https://www.npmjs.com/package/faiss-node) (~10k/week) — binding to Facebook Faiss C++
+- **Downloads:** ~410k/week combined (BACKLOG figure confirmed)
 - **Exports / API surface:**
-  - `onnxruntime-node`: `InferenceSession.create(path)` + `.run(feeds)` — ein-Inference-Call ruft C++-Model-Forward
-  - `faiss-node`: `new IndexFlatL2(d)` + `.add(vectors)` + `.search(vector, k)` — Vector-Index mit Search
-- **Typical input:** Model-Path (einmal laden), Input-Tensoren (pro Call). Für Embedding-Model: 1 Text → 1 f32-Vector der Dimension D.
-- **Typical output:** Output-Tensor(en), typisch f32-Arrays.
-- **Realistic median use-case:** **Embedding-Generation** (Text → Vector), **Classification**, **Re-Ranking**. Inference-Time dominiert: 10 ms – 2 s pro Call je nach Modellgröße. FFI-Overhead ist im <1 %-Bereich **jeder** Binding-Variante.
+  - `onnxruntime-node`: `InferenceSession.create(path)` + `.run(feeds)` — one inference call invokes the C++ model forward
+  - `faiss-node`: `new IndexFlatL2(d)` + `.add(vectors)` + `.search(vector, k)` — vector index with search
+- **Typical input:** Model path (loaded once), input tensors (per call). For an embedding model: 1 text → 1 f32 vector of dimension D.
+- **Typical output:** Output tensor(s), typically f32 arrays.
+- **Realistic median use case:** **Embedding generation** (text → vector), **classification**, **re-ranking**. Inference time dominates: 10 ms – 2 s per call depending on model size. FFI overhead is in the <1 % range for **any** binding variant.
 
 ## Rust replacement
 
 - **Candidate crate(s):**
-  - `ort` (ONNX Runtime Rust binding) — genau dieselbe C++-Lib unter der Haube
-  - `faiss-rs` oder direkter Binding über `cxx`/`autocxx` — wieder dieselbe C++-Lib
-- **Maintenance / license:** Beide aktiv. Aber: Sie wrappen dieselben C++-Libraries wie die npm-Pakete.
-- **Known gotchas / divergences:** **Keine algorithmischen** — dieselbe C++-Engine. Lediglich API-Shape-Unterschiede zwischen npm und Rust-Binding.
+  - `ort` (ONNX Runtime Rust binding) — exactly the same C++ lib under the hood
+  - `faiss-rs` or a direct binding via `cxx` / `autocxx` — same C++ lib again
+- **Maintenance / license:** Both active. But: they wrap the same C++ libraries that the npm packages do.
+- **Known gotchas / divergences:** **None algorithmically** — same C++ engine. Only API-shape differences between npm and the Rust binding.
 
 ## BACKLOG check
 
-Vorhandener Eintrag in `BACKLOG.md` → "Ruled out — AI-category": "Already native bindings over C++ libraries — re-wrapping a wrapper adds maintenance without speedup." Review formalisiert und archiviert.
+Existing entry in `BACKLOG.md` → "Ruled out — AI-category": "Already native bindings over C++ libraries — re-wrapping a wrapper adds maintenance without speedup." Review formalises and archives.
 
-Abgrenzung:
-- Gegen `docs/perf-review/hnswlib-node.md` (NO-GO, 2026-04-21): **identische Kategorie**. Hnswlib-node, onnxruntime-node, faiss-node sind drei Instanzen derselben Lehre — "nativer-Wrapper einer C++-Lib, keine Rust-Gewinnmarge."
-- Gegen `docs/perf-review/xenova-transformers.md` (falls erstellt): @xenova/transformers wrapped onnxruntime-node — noch eine Ebene darüber. Siehe dort.
+Boundary:
+- vs. `docs/perf-review/hnswlib-node.md` (NO-GO, 2026-04-21): **identical category**. hnswlib-node, onnxruntime-node, faiss-node are three instances of the same lesson — "native wrapper of a C++ lib, no Rust margin to be had."
+- vs. `docs/perf-review/xenova-transformers.md` (if created): @xenova/transformers wraps onnxruntime-node — one more layer above. See there.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Massiv.** Inference 10 ms – 2 s. FFI-Share (100–200 ns) ist <0,001 %. |
-| Input size distribution | Tensor als Float32Array: zero-copy via TypedArray-Buffer. Flat. |
-| Output size distribution | Tensor als Float32Array: zero-copy. Flat. |
-| Reusable setup (stateful potential) | **Zentral.** Model-Load beim Start, viele Inference-Calls danach. Genau das, was npm-Binding bereits tut. |
-| Batch-usage realism | Ja, als Rust-seitiger `run_batch(inputs)` — aber onnxruntime-node hat das bereits, und der Gewinn käme von C++-Batch-Inference, nicht von FFI-Elimination. |
-| FFI-share estimate vs. Rust work | <0,001 % in allen Szenarien. **Aber** das bedeutet: Rust-Port hat **keinen** messbaren Gewinn über npm-Original. |
+| Per-call algorithmic work | **Massive.** Inference 10 ms – 2 s. FFI share (100–200 ns) is <0.001 %. |
+| Input size distribution | Tensor as Float32Array: zero-copy via TypedArray buffer. Flat. |
+| Output size distribution | Tensor as Float32Array: zero-copy. Flat. |
+| Reusable setup (stateful potential) | **Central.** Model load on startup, many inference calls afterwards. Exactly what the npm binding already does. |
+| Batch usage realism | Yes, as a Rust-side `run_batch(inputs)` — but onnxruntime-node already has it, and the win would come from C++-side batch inference, not from eliminating FFI. |
+| FFI-share estimate vs. Rust work | <0.001 % in every scenario. **But** that means: a Rust port has **no** measurable gain over the npm original. |
 
 ## Classification reasoning
 
-1. **Beide Pakete sind bereits native C++.** onnxruntime-node nutzt ONNX Runtime C++ (Microsoft, SIMD-accelerated, GPU-fähig via CUDA/DirectML/CoreML). faiss-node nutzt Facebook-Faiss C++ (hochoptimiert für Vector-Similarity-Search). Kein JS-Code im Hot-Path.
+1. **Both packages are already native C++.** onnxruntime-node uses ONNX Runtime C++ (Microsoft, SIMD-accelerated, GPU-capable via CUDA/DirectML/CoreML). faiss-node uses Facebook Faiss C++ (highly optimised for vector similarity search). No JS code on the hot path.
 
-2. **Rust-Bindings wrappen dieselben C++-Libs.** `ort` ist ein Rust-Wrapper um ONNX Runtime C++. `faiss-rs` um Faiss C++. **Keine** Rust-Implementation ist algorithmisch schneller.
+2. **Rust bindings wrap the same C++ libs.** `ort` is a Rust wrapper around ONNX Runtime C++. `faiss-rs` around Faiss C++. **No** Rust implementation is algorithmically faster.
 
-3. **Wir haben keinen Grund, ein Wrapper von einem Wrapper zu sein.** Die npm-Originale sind von Microsoft/Meta gewartet, haben vollständige Plattform-Coverage, CUDA-Support, plus-minus vollständige Parity mit dem C++-Upstream. Unser `@amigo-labs/onnxruntime` wäre ein viertes Rad am Wagen mit keinem Unique-Selling-Point außer "wurde in Rust gewrapped."
+3. **No reason for us to be a wrapper of a wrapper.** The npm originals are maintained by Microsoft / Meta, ship full platform coverage, CUDA support, and ±complete parity with the C++ upstream. Our `@amigo-labs/onnxruntime` would be a fourth wheel with no unique selling point beyond "now wrapped in Rust."
 
-4. **DX-Argument greift nicht.** onnxruntime-node hat zuverlässige Prebuilds. faiss-node hat bekannte Build-Probleme auf manchen Plattformen — aber das löst man durch **Fork-and-Add-Prebuilds**, nicht durch Rust-Re-Implementation.
+4. **DX argument doesn't bite.** onnxruntime-node has reliable prebuilts. faiss-node has known build issues on some platforms — but the fix is **fork-and-add-prebuilds**, not a Rust re-implementation.
 
-**Shape-Matching:**
-- 🔁 Wie `hnswlib-node` (2026-04-21 ruled out, same lesson exactly)
-- 🔁 Wie Re-Wrapping jeder etablierten C++-Lib — kein Gewinn
+**Shape matching:**
+- 🔁 Like `hnswlib-node` (ruled out 2026-04-21, exactly the same lesson)
+- 🔁 Like re-wrapping any established C++ lib — no gain
 
-**Benchmark-Gap-Flag:** Kein Spike nötig. Wenn jemand einen Microbench fährt, wird er das Messrauschen messen.
+**Benchmark-gap flag:** No spike needed. Anyone running a microbench will measure measurement noise.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/onnxruntime-node.md`. Präzedenzfall: `docs/perf-review/hnswlib-node.md`.
+Archived 2026-04-21. Full review: `docs/perf-review/onnxruntime-node.md`. Precedent: `docs/perf-review/hnswlib-node.md`.

--- a/docs/perf-review/openai.md
+++ b/docs/perf-review/openai.md
@@ -4,68 +4,68 @@
 
 ## Verdict
 
-Alle drei Pakete sind **HTTP-Clients** — sie serialisieren JSON, schicken Requests an REST-APIs, deserialisieren Streaming-Responses. **Null Compute-Surface außerhalb von I/O**. Der Hot-Path ist `fetch` / `https.request` → Netzwerk → Parse JSON → Callback/Stream. Netzwerk-Latency dominiert (50 ms – mehrere Sekunden) um Größenordnungen über jedem FFI-Overhead. Ein Rust-Port würde vielleicht 10–50 µs JSON-Parse-Zeit sparen auf 500 ms Netzwerk-Roundtrip = **0,01 % Gewinn**. Perfektes Black-Shape.
+All three packages are **HTTP clients** — they serialise JSON, send requests to REST APIs, deserialise streaming responses. **Zero compute surface outside I/O.** The hot path is `fetch` / `https.request` → network → parse JSON → callback / stream. Network latency dominates (50 ms – several seconds) by orders of magnitude over any FFI overhead. A Rust port might save 10–50 µs of JSON-parse time on a 500 ms network round-trip = **0.01 % gain**. A perfect Black shape.
 
 ## JS package
 
 - **npm:**
-  - [`openai`](https://www.npmjs.com/package/openai) (~20M/Woche)
-  - [`@anthropic-ai/sdk`](https://www.npmjs.com/package/@anthropic-ai/sdk) (~3M/Woche)
-  - [`cohere-ai`](https://www.npmjs.com/package/cohere-ai) (~200k/Woche)
-- **Downloads:** ~30M/Woche kombiniert (BACKLOG-Zahl bestätigt)
+  - [`openai`](https://www.npmjs.com/package/openai) (~20M/week)
+  - [`@anthropic-ai/sdk`](https://www.npmjs.com/package/@anthropic-ai/sdk) (~3M/week)
+  - [`cohere-ai`](https://www.npmjs.com/package/cohere-ai) (~200k/week)
+- **Downloads:** ~30M/week combined (BACKLOG figure confirmed)
 - **Exports / API surface:**
-  - Alle drei haben **Resource-Client-Pattern**: `client.chat.completions.create({...})`, `client.messages.create({...})`, `client.embeddings.create({...})`
-  - Streaming-Variante mit async-Iterators: `for await (const chunk of stream)`
-  - Retries, Rate-Limiting, Error-Normalization
-  - Typed-Responses über TypeScript-generated-types
-- **Typical input:** Request-Objekt (Model-Name, Messages-Array, Params). JSON-Serialisierung einmal pro Request.
-- **Typical output:** Response-Objekt (Content, Token-Usage, Metadata). JSON-Parse einmal pro Response (oder pro Stream-Chunk).
-- **Realistic median use-case:** **LLM-Request-Pattern** — ein App-Server macht N Chat/Completion-Calls pro Request, jeder Call ist 200 ms – 30 s Netzwerk-IO. Streaming-Variante: Chunk kommt alle ~50 ms, 10–1000 Chunks pro Response.
+  - All three follow a **resource-client pattern**: `client.chat.completions.create({...})`, `client.messages.create({...})`, `client.embeddings.create({...})`
+  - Streaming variant with async iterators: `for await (const chunk of stream)`
+  - Retries, rate-limiting, error normalisation
+  - Typed responses via TypeScript-generated types
+- **Typical input:** Request object (model name, messages array, params). One JSON serialisation per request.
+- **Typical output:** Response object (content, token usage, metadata). One JSON parse per response (or per stream chunk).
+- **Realistic median use case:** **LLM request pattern** — an app server makes N chat/completion calls per request, each call is 200 ms – 30 s of network I/O. Streaming variant: chunks every ~50 ms, 10–1000 chunks per response.
 
 ## Rust replacement
 
 - **Candidate crate(s):**
-  - `async-openai`, `anthropic-sdk-rust`, `cohere-rust` — existieren, würden wir re-wrappen
-  - Oder direkt `reqwest` + manuell Typed-Request/Response-Structs — trivial, 500-1000 LOC pro Provider
-- **Maintenance / license:** Egal — kein messbarer Gewinn
-- **Known gotchas / divergences:** API-Spec-Updates pro Provider: OpenAI released alle 2–4 Wochen API-Änderungen, Anthropic ähnlich. Ein Drop-in-Port müsste laufend nachziehen. Maintenance-Tail ist das eigentliche Problem.
+  - `async-openai`, `anthropic-sdk-rust`, `cohere-rust` — exist, we'd be re-wrapping them
+  - Or directly `reqwest` + hand-rolled typed request/response structs — trivial, 500–1000 LOC per provider
+- **Maintenance / license:** Doesn't matter — no measurable gain
+- **Known gotchas / divergences:** API-spec updates per provider: OpenAI ships API changes every 2–4 weeks, Anthropic similarly. A drop-in port would have to chase them constantly. The maintenance tail is the actual problem.
 
 ## BACKLOG check
 
-Vorhandener Eintrag in `BACKLOG.md` → "Ruled out — AI-category": "HTTP + JSON clients — zero compute surface, pure I/O." Review formalisiert und archiviert.
+Existing entry in `BACKLOG.md` → "Ruled out — AI-category": "HTTP + JSON clients — zero compute surface, pure I/O." Review formalises and archives.
 
-Abgrenzung:
-- Gegen `docs/perf-review/tough-cookie.md` (NO-GO, Parity too expensive): HTTP-adjacent, aber tough-cookie hat **stateful Jar-Semantik** mit Compute. openai/anthropic sind reiner Wire-Protocol.
-- Gegen `request` (Deprecated npm — wurde formal abgekündigt): HTTP-Client, dieselbe I/O-dominanz.
+Boundary:
+- vs. `docs/perf-review/tough-cookie.md` (NO-GO, parity too expensive): HTTP-adjacent, but tough-cookie has **stateful jar semantics** with compute. openai/anthropic are pure wire-protocol.
+- vs. `request` (deprecated npm — formally archived): HTTP client, same I/O dominance.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Null im Rust-Sinn.** Was "passiert" ist: JSON-stringify (~10–50 µs für ~10 KB Payload), HTTPS-Request-Open (~50–500 ms TLS-Handshake erstmal, gecached danach), Netzwerk-RTT (~50–30 000 ms), JSON-parse (~20–100 µs pro Response). |
-| Input size distribution | Request-Body 1–50 KB. |
-| Output size distribution | Response-Body 1–500 KB (oder unbegrenzt im Streaming-Fall). |
-| Reusable setup (stateful potential) | HTTP-Connection-Pool-Reuse ist Standard, beide Libs machen das bereits. Keine Rust-spezifische Verbesserung. |
-| Batch-usage realism | OpenAI hat Batch-API (separate REST-Endpoint, `batches.create`). Das ist Netzwerk-Feature, nicht Client-Feature. |
-| FFI-share estimate vs. Rust work | Irrelevant — der "Rust-Work" ist Mikrosekunden-JSON-Ops auf Sekunden-Netzwerk-Latency. 99,99 % IO-Zeit. |
+| Per-call algorithmic work | **Zero in the Rust sense.** What "happens" is: JSON.stringify (~10–50 µs for a ~10 KB payload), HTTPS request open (~50–500 ms TLS handshake first, cached afterwards), network RTT (~50–30 000 ms), JSON.parse (~20–100 µs per response). |
+| Input size distribution | Request body 1–50 KB. |
+| Output size distribution | Response body 1–500 KB (or unbounded in streaming). |
+| Reusable setup (stateful potential) | HTTP connection-pool reuse is standard, both libs already do it. No Rust-specific improvement. |
+| Batch usage realism | OpenAI has a Batch API (separate REST endpoint, `batches.create`). That's a network feature, not a client feature. |
+| FFI-share estimate vs. Rust work | Irrelevant — the "Rust work" is microsecond-scale JSON ops on second-scale network latency. 99.99 % I/O time. |
 
 ## Classification reasoning
 
-1. **Netzwerk-Latency dominiert.** Selbst der schnellste LLM-Provider-Call (OpenAI GPT-4o-mini, simple prompt) ist 200–500 ms End-to-End. Ein Rust-Port der JSON-Parsing um 50 µs beschleunigt = 0,01 % Gewinn, unmessbar.
+1. **Network latency dominates.** Even the fastest LLM-provider call (OpenAI GPT-4o-mini, simple prompt) is 200–500 ms end-to-end. A Rust port that speeds up JSON parsing by 50 µs = 0.01 % gain, unmeasurable.
 
-2. **Keine Compute-Surface.** JSON-stringify/parse ist V8-native (extrem schnell auf kleinen Payloads). `simd-json` in Rust bringt auf 10 KB Payload <100 µs Gewinn. Irrelevant vor Netzwerk.
+2. **No compute surface.** JSON.stringify/parse is V8-native (extremely fast on small payloads). `simd-json` in Rust delivers <100 µs on 10 KB payloads. Irrelevant against the network.
 
-3. **Maintenance-Tail ist kostenlos-teuer.** OpenAI API Added `tools`, `parallel_tool_calls`, `reasoning_effort`, `response_format`, `service_tier`, etc. in kurzer Abfolge. Anthropic fügt `cache_control`, `thinking`, `system`-Array-Variants hinzu. Unser Port müsste laufend nachziehen oder User würden auf Features verzichten. Aufwand ohne Gewinn.
+3. **The maintenance tail is free-but-expensive.** The OpenAI API added `tools`, `parallel_tool_calls`, `reasoning_effort`, `response_format`, `service_tier` and friends in short order. Anthropic adds `cache_control`, `thinking`, `system`-array variants. Our port would have to chase or users would lose features. Effort with no gain.
 
-4. **TypeScript-Types sind der primäre Value.** Die SDK-Libs liefern Typed-API-Surfaces. Wir würden das auch tun müssen, aber das geht TypeScript-seitig — keine Rust-Hilfe.
+4. **TypeScript types are the primary value.** The SDK libs ship typed API surfaces. We would have to do the same, but that lives on the TypeScript side — no Rust help available.
 
-**Shape-Matching:**
-- 🔁 Wie `request` / `node-fetch`-Äquivalent (pure HTTP-I/O, no compute)
-- 🔁 Wie `langchain` (spec-driven parity surface)
-- ❌ Nicht wie `@amigo-labs/jwt` (das hat echten Crypto-Compute)
+**Shape matching:**
+- 🔁 Like `request` / `node-fetch` equivalents (pure HTTP I/O, no compute)
+- 🔁 Like `langchain` (spec-driven parity surface)
+- ❌ Not like `@amigo-labs/jwt` (which has real crypto compute)
 
-**Benchmark-Gap-Flag:** Absurdes Concept — der Bench würde Netzwerk-Latency messen.
+**Benchmark-gap flag:** Absurd by construction — the bench would measure network latency.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/openai.md`. Gilt analog für alle HTTP-Client-SDKs (Anthropic, Cohere, Mistral, Gemini, etc.) und allgemein für Netzwerk-I/O-Pakete.
+Archived 2026-04-21. Full review: `docs/perf-review/openai.md`. Applies analogously to all HTTP-client SDKs (Anthropic, Cohere, Mistral, Gemini, etc.) and to network-I/O packages in general.

--- a/docs/perf-review/request.md
+++ b/docs/perf-review/request.md
@@ -4,28 +4,28 @@
 
 ## Verdict
 
-`request` wurde Februar 2020 **formal deprecated** vom Maintainer. Das Paket ist seit 5+ Jahren nur noch wegen Legacy-Code auf npm. Plus: selbst ohne Deprecation wäre es HTTP-I/O, also `openai`/`anthropic-ai`-Kategorie (→ `docs/perf-review/openai.md`) — zero compute surface, pure network.
+`request` was **formally deprecated** by the maintainer in February 2020. The package has been on npm purely for legacy code for 5+ years. On top of that: even without the deprecation it would still be HTTP I/O — i.e. the `openai`/`anthropic-ai` category (→ `docs/perf-review/openai.md`) — zero compute surface, pure network.
 
 ## JS package
 
 - **npm:** [`request`](https://www.npmjs.com/package/request)
-- **Downloads:** ~8M/Woche (sinkend, reines Legacy)
-- **Status:** Formal deprecated Februar 2020. Maintainer: "The request module is going to be archived. There will be no more new releases."
+- **Downloads:** ~8M/week (declining, pure legacy)
+- **Status:** Formally deprecated February 2020. Maintainer: "The request module is going to be archived. There will be no more new releases."
 
 ## Rust replacement
 
-- `reqwest` (Rust-HTTP-Client) existiert — aber der eigentliche Punkt ist: **kein HTTP-Client braucht einen Rust-Port**, weil Netzwerk-Latency um Größenordnungen über jedem Client-Code liegt. Siehe `docs/perf-review/openai.md`.
+- `reqwest` (Rust HTTP client) exists — but the real point is: **no HTTP client needs a Rust port**, because network latency is orders of magnitude above any client-side code. See `docs/perf-review/openai.md`.
 
 ## BACKLOG check
 
-Eintrag in `BACKLOG.md` → "Deprecated / superseded": "Don't touch." Review bestätigt.
+Entry in `BACKLOG.md` → "Deprecated / superseded": "Don't touch." Review confirms.
 
 ## Classification reasoning
 
-1. **Upstream deprecated seit 2020.** Null Argument für Clone.
-2. **HTTP-I/O-Shape ist Black allgemein.** Siehe `openai.md`.
-3. **Moderne Alternativen.** `undici` (Node built-in), `axios`, `got`, `ky`, `ofetch` — alle aktive JS-Alternativen. Keine Lücke.
+1. **Upstream deprecated since 2020.** Zero argument for cloning.
+2. **HTTP-I/O shape is Black across the board.** See `openai.md`.
+3. **Modern alternatives.** `undici` (Node built-in), `axios`, `got`, `ky`, `ofetch` — all active JS alternatives. No gap to fill.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/request.md`. Allgemeine HTTP-Client-Black-Shape dokumentiert in `docs/perf-review/openai.md`.
+Archived 2026-04-21. Full review: `docs/perf-review/request.md`. The general HTTP-client Black shape is documented in `docs/perf-review/openai.md`.

--- a/docs/perf-review/stopword.md
+++ b/docs/perf-review/stopword.md
@@ -4,60 +4,60 @@
 
 ## Verdict
 
-`stopword.removeStopwords(tokens, stopWordsList) → filteredTokens` ist **Hashset-Lookup in einer Schleife** — die `mime`-Kategorie. Für jedes Token wird ein Set-`has()`-Call gegen die Stopword-Liste ausgeführt; V8's Map/Set-Implementation ist auf native-Geschwindigkeit getuned und FFI-Floor + Array-Marshalling pro Call würden das 3–10× langsamer machen als pure JS. Es gibt kein Input-Size-Rescue: mehr Tokens bedeutet mehr Array-Marshalling-Kosten, proportional zum Compute. Dieselbe Lehre wie `mime-types`/`dotenv`.
+`stopword.removeStopwords(tokens, stopWordsList) → filteredTokens` is **a hashset lookup in a loop** — the `mime` category. For each token a `Set.has()` call runs against the stopword list; V8's Map/Set implementation is tuned to native-speed and the FFI floor + per-call array marshalling would make this 3–10× slower than pure JS. There is no input-size rescue: more tokens means more array-marshalling cost, proportional to the compute. Same lesson as `mime-types` / `dotenv`.
 
 ## JS package
 
 - **npm:** [`stopword`](https://www.npmjs.com/package/stopword)
-- **Downloads:** ~1M/Woche
+- **Downloads:** ~1M/week
 - **Exports / API surface:**
   - `removeStopwords(tokens: string[], list?: string[]) → string[]`
-  - Pre-built Sprach-Listen: `stopword.eng`, `stopword.deu`, `stopword.fra`, ... (50+ Sprachen)
-- **Typical input:** `string[]` von 10–10 000 Tokens. Stopword-Liste (optional) von 50–500 Wörtern. Median ~100 Tokens.
-- **Typical output:** Gefiltertes `string[]`, typisch 40–70 % der Input-Länge (Stopwords entfernt).
-- **Realistic median use-case:** **NLP-Preprocessing für Search-Index** — nach Tokenization, vor Stemmer, Stopwords raus. Ruft typischerweise in Doc-Processing-Loop: für jedes Dokument einmal `removeStopwords(tokens, eng)`. Second case: **Query-Preprocessing** in Search-Frontends.
+  - Pre-built language lists: `stopword.eng`, `stopword.deu`, `stopword.fra`, ... (50+ languages)
+- **Typical input:** `string[]` of 10–10 000 tokens. Stopword list (optional) of 50–500 words. Median ~100 tokens.
+- **Typical output:** Filtered `string[]`, typically 40–70 % of the input length (stopwords removed).
+- **Realistic median use case:** **NLP preprocessing for a search index** — after tokenization, before the stemmer, strip stopwords. Typically called in a doc-processing loop: once per document via `removeStopwords(tokens, eng)`. Second case: **query preprocessing** in search frontends.
 
 ## Rust replacement
 
-- **Candidate crate(s):** Trivial — `FxHashSet<&str>` aus embedded-Liste, `.filter(|t| !set.contains(t)).collect()`. Rust-Side 20 Zeilen.
+- **Candidate crate(s):** Trivial — `FxHashSet<&str>` from an embedded list, `.filter(|t| !set.contains(t)).collect()`. ~20 lines on the Rust side.
 - **Maintenance / license:** n/a
-- **Known gotchas / divergences:** Sprach-Listen-Divergenz — `stopword.eng` ist leicht anders als NLTK's oder spaCy's englische Liste. Parity = wörtlich die `stopword`-Listen embedden (sind schon public domain).
+- **Known gotchas / divergences:** Language-list divergence — `stopword.eng` is slightly different from NLTK's or spaCy's English list. Parity = embed the `stopword` lists verbatim (they are already public domain).
 
 ## BACKLOG check
 
-Vorhandener Eintrag in `BACKLOG.md` → "Ruled out — AI-category": "Hashset lookup per call — lookup-style FFI trap, same as `mime`." Review formalisiert und archiviert.
+Existing entry in `BACKLOG.md` → "Ruled out — AI-category": "Hashset lookup per call — lookup-style FFI trap, same as `mime`." Review formalises and archives.
 
-Abgrenzung:
-- Gegen `docs/perf-review/mime.md` (⚫ Black): identischer Shape — Set-Lookup-Call. Einziger Unterschied: `stopword` filtert ein Array statt ein Single-Lookup zu machen, was FFI-Output-Marshalling hinzufügt (Array-out = schlimmer, nicht besser).
-- Gegen `docs/perf-review/natural.md` (GO, Batch-Only-Subset): Stemmer in Rust integriert Stopword-Filter **Rust-intern** in `tokenizeAndStem(text, {stopwords: true})` — kein FFI-Crossing pro Filter. Das ist der richtige Shape, nicht standalone stopword-Package.
+Boundary:
+- vs. `docs/perf-review/mime.md` (⚫ Black): identical shape — set-lookup call. Only difference: `stopword` filters an array instead of doing a single lookup, which adds FFI output marshalling (array-out = worse, not better).
+- vs. `docs/perf-review/natural.md` (GO, batch-only subset): the Rust stemmer integrates the stopword filter **internally** in `tokenizeAndStem(text, {stopwords: true})` — no FFI crossing per filter. That's the right shape, not a standalone stopword package.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Trivial.** 100 Tokens × Set-Lookup: ~3–5 µs JS, ~1 µs Rust. Δ ≈ 2–4 µs. |
-| Input size distribution | `Vec<String>` Input: 100 × ~200 ns = **20 µs FFI-Transport** auf 100 Tokens. Dominiert Rust-Compute komplett. |
-| Output size distribution | `Vec<String>` Output: ~60–70 Strings × 200 ns = **12–14 µs Marshalling**. Weiterer Overhead. |
-| Reusable setup (stateful potential) | Irrelevant (Stopword-Liste ist embedded, statisch). |
-| Batch-usage realism | Null — die Call IS der Batch (ein Array, ein Filter). Kein nächster-Ebene-Batch denkbar. |
-| FFI-share estimate vs. Rust work | ~30 µs Transport auf ~1 µs Compute = **3000 %** Overhead. Strukturell Black. |
+| Per-call algorithmic work | **Trivial.** 100 tokens × set-lookup: ~3–5 µs JS, ~1 µs Rust. Δ ≈ 2–4 µs. |
+| Input size distribution | `Vec<String>` input: 100 × ~200 ns = **20 µs of FFI transport** on 100 tokens. Completely dominates Rust compute. |
+| Output size distribution | `Vec<String>` output: ~60–70 strings × 200 ns = **12–14 µs marshalling**. Further overhead. |
+| Reusable setup (stateful potential) | Irrelevant (stopword list is embedded, static). |
+| Batch usage realism | Zero — the call IS the batch (one array, one filter). No next-level batch is conceivable. |
+| FFI-share estimate vs. Rust work | ~30 µs transport on ~1 µs of compute = **3000 %** overhead. Structurally Black. |
 
 ## Classification reasoning
 
-1. **V8 Set-Lookup ist native-speed.** `Set.prototype.has` ist auf V8-Hot-Path kompiliert. `Array.prototype.filter` mit einer Set-Lookup-Callback ist monomorphic und vectorized.
+1. **V8 Set lookup is native speed.** `Set.prototype.has` is compiled on the V8 hot path. `Array.prototype.filter` with a set-lookup callback is monomorphic and vectorised.
 
-2. **Array-in-Array-out ist die `Vec<String>`-Falle.** `docs/BASELINE.md:32` zeigt 43 ns/Element für u32-Arrays — `String`-Marshalling ist mindestens 2–3× so teuer (UTF-Konv plus Length-Prefix). 100 Tokens-Input + Output-Filter = **~30 µs pure FFI-Transport** auf ~1 µs Rust-Compute.
+2. **Array-in / array-out is the `Vec<String>` trap.** `docs/BASELINE.md:32` shows 43 ns/element for u32 arrays — `String` marshalling is at least 2–3× as expensive (UTF conversion plus length prefix). 100 tokens in + filtered output = **~30 µs of pure FFI transport** on ~1 µs of Rust compute.
 
-3. **Integration bei `@amigo-labs/stemmer` ist der richtige Shape.** Dort ist Stopword-Removal ein Boolean-Flag im `tokenizeAndStem(text, {stopwords: true})`-Call, Rust-intern geloopt. Input: ein Text-String (substantielles Compute). Output: eine Token-Liste. Ein FFI-Crossing für den Gesamt-Pfad Tokenize+Stopword+Stem.
+3. **Integration into `@amigo-labs/stemmer` is the right shape.** There, stopword removal is a boolean flag on `tokenizeAndStem(text, {stopwords: true})`, looped Rust-internally. Input: one text string (substantial compute). Output: a token list. One FFI crossing for the full tokenize + stopword + stem path.
 
-**Shape-Matching:**
-- 🔁 Wie `mime` / `mime-types` (Lookup-Style)
-- 🔁 Wie `dotenv` (kurzer V8-JIT-Parser)
-- 🔁 Wie `deep-equal` archived (Trivial-Work, FFI-dominated)
-- ❌ Integration in `@amigo-labs/stemmer` ist der richtige Weg
+**Shape matching:**
+- 🔁 Like `mime` / `mime-types` (lookup style)
+- 🔁 Like `dotenv` (short V8-JIT parser)
+- 🔁 Like the archived `deep-equal` (trivial work, FFI-dominated)
+- ❌ Integration into `@amigo-labs/stemmer` is the right path
 
-**Benchmark-Gap-Flag:** Kein Spike nötig — FFI-Transport-Mathematik ist eindeutig.
+**Benchmark-gap flag:** No spike needed — the FFI-transport math is unambiguous.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/stopword.md`. Die Funktion ist integriert in `@amigo-labs/stemmer` (siehe `docs/perf-review/natural.md`).
+Archived 2026-04-21. Full review: `docs/perf-review/stopword.md`. The functionality is integrated into `@amigo-labs/stemmer` (see `docs/perf-review/natural.md`).

--- a/docs/perf-review/string-similarity.md
+++ b/docs/perf-review/string-similarity.md
@@ -4,67 +4,67 @@
 
 ## Verdict
 
-Drei Pakete, identische Lehre: **kurz-String-dominante Levenshtein/Dice-Coefficient-Berechnungen**, und wir haben diese Lehre bereits gemessen in `docs/post-mortems/levenshtein.md` (0,13× auf 10k-chars nach Phase-C-Spike, archiviert 2026-04-19). Der hier geplante Port würde identische Traps treffen: UTF-16↔UTF-8-Konversion an beiden Input-Strings kostet pro Call mehr als die eigentliche Distance-Berechnung. `fastest-levenshtein` ist besonders tödlich, weil es selbst in JS ~1 µs für kurze Strings braucht — FFI-Floor alleine ist 10–20 % Overhead davon, und die eigentliche Rust-SIMD-Beschleunigung (`triple_accel`) bringt darüber keinen Wind.
+Three packages, identical lesson: **short-string-dominant Levenshtein / Dice-coefficient computations** — a lesson we have already measured in `docs/post-mortems/levenshtein.md` (0.13× on 10k chars after the Phase-C spike, archived 2026-04-19). A port here would hit the same traps: UTF-16↔UTF-8 conversion on both input strings costs more per call than the actual distance computation. `fastest-levenshtein` is especially deadly because it already takes ~1 µs in JS for short strings — the FFI floor alone is 10–20 % overhead on top, and Rust SIMD acceleration (`triple_accel`) adds nothing beyond that.
 
 ## JS package
 
 - **npm:**
-  - [`string-similarity`](https://www.npmjs.com/package/string-similarity) (~10M/Woche) — Dice-Coefficient auf Bigrams
-  - [`leven`](https://www.npmjs.com/package/leven) (~300k/Woche) — Levenshtein, pure JS
-  - [`fastest-levenshtein`](https://www.npmjs.com/package/fastest-levenshtein) (~2M/Woche) — Levenshtein, hand-optimized JS
-- **Downloads:** ~12M/Woche kombiniert (BACKLOG-Zahl "~10M" bestätigt als konservativ)
+  - [`string-similarity`](https://www.npmjs.com/package/string-similarity) (~10M/week) — Dice coefficient on bigrams
+  - [`leven`](https://www.npmjs.com/package/leven) (~300k/week) — Levenshtein, pure JS
+  - [`fastest-levenshtein`](https://www.npmjs.com/package/fastest-levenshtein) (~2M/week) — Levenshtein, hand-optimised JS
+- **Downloads:** ~12M/week combined (BACKLOG figure of "~10M" confirmed as conservative)
 - **Exports / API surface:**
   - `string-similarity`: `compareTwoStrings(s1, s2) → number` (Dice, 0..1), `findBestMatch(main, candidates) → {bestMatch, ratings}`
   - `leven(s1, s2) → number` (Levenshtein edit distance)
   - `fastest-levenshtein.distance(s1, s2) → number`, `.closest(str, arr) → string`
-- **Typical input:** Zwei Strings. **Korpus ist short-string-dominant:** Fuzzy-Match gegen Suchergebnisse (8–30 Zeichen), Typo-Korrektur (5–20 Zeichen), Namen-Match (10–40 Zeichen). Längere Strings sind Ausnahme.
-- **Typical output:** Number (edit distance oder similarity score 0..1).
-- **Realistic median use-case:** **Fuzzy-Suche in Autosuggest** (User tippt, gegen bekannte Terme matchen), **Typo-Tolerance in CLI-Tools** ("Did you mean X?"), **Name-Matching** in Recordslinkage. Fast immer **Hot-Loop gegen Array von Kandidaten**: `candidates.map(c => distance(input, c))`. Median-Input-Länge <20 Zeichen.
+- **Typical input:** Two strings. **Corpus is short-string-dominant:** fuzzy match against search results (8–30 chars), typo correction (5–20 chars), name match (10–40 chars). Longer strings are the exception.
+- **Typical output:** Number (edit distance or similarity score 0..1).
+- **Realistic median use case:** **Fuzzy search in autosuggest** (user types, match against known terms), **typo tolerance in CLI tools** ("did you mean X?"), **name matching** in record linkage. Almost always a **hot loop against an array of candidates**: `candidates.map(c => distance(input, c))`. Median input length <20 chars.
 
 ## Rust replacement
 
-- **Candidate crate(s):** `triple_accel` (SIMD-Levenshtein), `strsim` (ohne SIMD), `rapidfuzz` (Python-port, Fuzzy-Match-Suite)
-- **Maintenance / license:** Alle MIT, aktiv
-- **Known gotchas / divergences:** Keine Semantik-Divergenzen — Levenshtein/Dice sind mathematisch eindeutig
+- **Candidate crate(s):** `triple_accel` (SIMD Levenshtein), `strsim` (no SIMD), `rapidfuzz` (Python port, fuzzy-match suite)
+- **Maintenance / license:** All MIT, active
+- **Known gotchas / divergences:** No semantic divergence — Levenshtein and Dice are mathematically unambiguous
 
 ## BACKLOG check
 
-Vorhandener Eintrag in `BACKLOG.md` → "Ruled out — AI-category": "Short-string dominant corpus — repeats the `levenshtein` failure exactly (see `docs/perf-review/levenshtein.md`)." Review formalisiert und archiviert.
+Existing entry in `BACKLOG.md` → "Ruled out — AI-category": "Short-string dominant corpus — repeats the `levenshtein` failure exactly (see `docs/perf-review/levenshtein.md`)." Review formalises and archives.
 
-Abgrenzung:
-- Gegen `docs/perf-review/levenshtein.md` + `docs/post-mortems/levenshtein.md` (archived 🔴, **gemessen**): dieselbe Paket-Kategorie, und wir haben die Mess-Daten: 0,13× auf 10k-chars nach Phase-C-Spike. Der Post-Mortem ist der Präzedenzfall.
-- Gegen `docs/perf-review/deep-equal.md` (archived 🔴): architektonisch identisch (two-small-strings-in, scalar-out).
+Boundary:
+- vs. `docs/perf-review/levenshtein.md` + `docs/post-mortems/levenshtein.md` (archived 🔴, **measured**): same package category, and we have the measurements: 0.13× on 10k chars after the Phase-C spike. The post-mortem is the precedent.
+- vs. `docs/perf-review/deep-equal.md` (archived 🔴): architecturally identical (two-small-strings-in, scalar-out).
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Trivial bis klein.** Levenshtein 10-char-Strings: ~100 ns JS, ~50 ns Rust. Plus FFI-Floor 109 ns + 2× UTF-Konv ~100 ns = **Rust-Call ≥260 ns**. Speedup 0,4×. |
-| Input size distribution | **Kritisch klein.** Median <20 Zeichen. UTF-Konv ist dominanter Kostenpunkt relativ zum Compute. Gemessen in `levenshtein`-Post-Mortem. |
+| Per-call algorithmic work | **Trivial to small.** Levenshtein on 10-char strings: ~100 ns JS, ~50 ns Rust. Plus FFI floor 109 ns + 2× UTF conv ~100 ns = **Rust call ≥260 ns**. Speedup 0.4×. |
+| Input size distribution | **Critically small.** Median <20 chars. UTF conversion dominates cost relative to compute. Measured in the `levenshtein` post-mortem. |
 | Output size distribution | 1 × number. Negligible. |
-| Reusable setup (stateful potential) | Null. |
-| Batch-usage realism | **Hoch für `findBestMatch`-Shape** — ein Query gegen N Kandidaten kann als `findBestMatch(query, candidates: string[]) → {idx, score}` via ein-Crossing gebaut werden. ABER: (a) das ist die Form die in `string-similarity` bereits existiert und `@amigo-labs/levenshtein` hat das nach C-Spike getestet → 1,5× Gate bei 10k verfehlt → archived. Nicht zu reproduzieren. |
-| FFI-share estimate vs. Rust work | >100 % auf short-strings. Gemessen. |
+| Reusable setup (stateful potential) | None. |
+| Batch usage realism | **High for the `findBestMatch` shape** — one query against N candidates can be wrapped as `findBestMatch(query, candidates: string[]) → {idx, score}` via a single crossing. BUT: (a) that is the form already provided by `string-similarity` and `@amigo-labs/levenshtein` did test it after the C spike → 1.5× gate at 10k missed → archived. Not reproducible. |
+| FFI-share estimate vs. Rust work | >100 % on short strings. Measured. |
 
 ## Classification reasoning
 
-Wir haben diese Lehre **gemessen**, nicht nur vorhergesagt:
+We have **measured** this lesson, not just predicted it:
 
-1. **`@amigo-labs/levenshtein` war genau dieser Port.** 0,13× auf 10k-chars, 0,60× auf 10-chars, 1,10× auf 100-chars (nur 1 Messung über 1×, Rest Red). Deprecated in 0.2.0, archiviert 2026-04-19. Full Post-Mortem: `docs/post-mortems/levenshtein.md`.
+1. **`@amigo-labs/levenshtein` was exactly this port.** 0.13× on 10k chars, 0.60× on 10 chars, 1.10× on 100 chars (only 1 measurement above 1×, the rest Red). Deprecated in 0.2.0, archived 2026-04-19. Full post-mortem: `docs/post-mortems/levenshtein.md`.
 
-2. **`fastest-levenshtein` war schon unsere Baseline** — der Name sagt es. Pure JS, hochoptimiert. Der Abstand zu Rust-SIMD-`triple_accel` ist messbar klein nach FFI-Overhead.
+2. **`fastest-levenshtein` was already our baseline** — the name says it. Pure JS, highly optimised. The gap to Rust-SIMD `triple_accel` is measurably small after FFI overhead.
 
-3. **`string-similarity`'s Dice-Coefficient** ist minimal komplexer (Bigram-Set-Intersection), aber dieselbe Größenordnung von Compute. Gleiche FFI-Mathematik.
+3. **`string-similarity`'s Dice coefficient** is marginally more complex (bigram set intersection), but the same compute order of magnitude. Same FFI math.
 
-4. **Batch-API als Rettung wurde versucht.** Spike auf Buffer-Input (`lev_bytes(a: Buffer, b: Buffer)`) dokumentiert in `docs/perf-review/levenshtein.md` unter "Gate ≥1,5× bei 10k chars verfehlt". Keine Headroom.
+4. **Batch API as a rescue was tried.** Spike on buffer input (`lev_bytes(a: Buffer, b: Buffer)`) documented in `docs/perf-review/levenshtein.md` under "Gate ≥1.5× at 10k chars missed". No headroom.
 
-**Shape-Matching:**
-- 🔁 Wie `@amigo-labs/levenshtein` archived — **genau dieselbe Kategorie**
-- 🔁 Wie `compute-cosine-similarity` (Two-Inputs-One-Scalar-Out, FFI-drowns-Compute)
-- 🔁 Wie `deep-equal` archived
+**Shape matching:**
+- 🔁 Like archived `@amigo-labs/levenshtein` — **exactly the same category**
+- 🔁 Like `compute-cosine-similarity` (two-inputs-one-scalar-out, FFI-drowns-compute)
+- 🔁 Like archived `deep-equal`
 
-**Benchmark-Gap-Flag:** Kein Spike nötig — der `levenshtein`-Spike ist der Präzedenzfall.
+**Benchmark-gap flag:** No spike needed — the `levenshtein` spike is the precedent.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/string-similarity.md`. Präzedenz: `docs/post-mortems/levenshtein.md`.
+Archived 2026-04-21. Full review: `docs/perf-review/string-similarity.md`. Precedent: `docs/post-mortems/levenshtein.md`.

--- a/docs/perf-review/xenova-transformers.md
+++ b/docs/perf-review/xenova-transformers.md
@@ -4,69 +4,69 @@
 
 ## Verdict
 
-`@xenova/transformers` ist eine **Abstraktionsschicht oberhalb** von ONNX Runtime Web (für Browser) und ONNX Runtime Node (für Server). Sie emuliert Hugging-Face-Transformers-Python-API mit Pipelines (`pipeline('sentiment-analysis')`), Tokenizer-Spec-Parity (BPE/WordPiece/SentencePiece), und Pre/Post-Processing. Der **eigentliche Compute** (Model-Forward-Pass) läuft in ORT C++/WASM — und ORT selbst ist in `docs/perf-review/onnxruntime-node.md` als NO-GO archiviert. Ein Port hier würde:
+`@xenova/transformers` is an **abstraction layer above** ONNX Runtime Web (for browsers) and ONNX Runtime Node (for servers). It emulates the Hugging-Face Transformers Python API with pipelines (`pipeline('sentiment-analysis')`), tokenizer-spec parity (BPE / WordPiece / SentencePiece), and pre/post-processing. The **actual compute** (model forward pass) runs inside ORT C++ / WASM — and ORT itself is archived as NO-GO in `docs/perf-review/onnxruntime-node.md`. A port here would:
 
-1. Die ORT-Backend-Frage nicht lösen (immer noch C++-wrapped).
-2. Eine **parity-reiche Python-API** emulieren müssen (hundert Pipelines, dutzend Tokenizer-Algorithmen).
-3. Sich gegen den Upstream (Xenova/Hugging Face) profilieren, der wöchentliche Spec-Updates nachzieht.
+1. Not solve the ORT-backend question (still C++-wrapped).
+2. Have to emulate a **parity-rich Python API** (a hundred pipelines, a dozen tokenizer algorithms).
+3. Compete with the upstream (Xenova / Hugging Face) which chases weekly spec updates.
 
-Das kombiniert die `onnxruntime-node`-Black-Shape (Native-Wrapper) mit dem `langchain`-Parity-Tail (Spec-driven Surface).
+That combines the `onnxruntime-node` Black shape (native wrapper) with the `langchain` parity tail (spec-driven surface).
 
 ## JS package
 
 - **npm:** [`@xenova/transformers`](https://www.npmjs.com/package/@xenova/transformers)
-- **Downloads:** ~500k/Woche (BACKLOG-Zahl bestätigt)
+- **Downloads:** ~500k/week (BACKLOG figure confirmed)
 - **Exports / API surface:**
-  - `pipeline(task, model?, options?)` → high-level Task-Runner. Tasks: `'text-classification'`, `'token-classification'`, `'feature-extraction'`, `'fill-mask'`, `'summarization'`, `'translation'`, `'text-generation'`, `'image-classification'`, `'automatic-speech-recognition'`, `'object-detection'`, ... 20+ Tasks
-  - Direct Access: `AutoModel`, `AutoTokenizer`, `AutoProcessor`, `AutoConfig` — lädt Modelle und Tokenizer
-  - Tokenizer-Familien: `BpeTokenizer`, `WordPieceTokenizer`, `SentencePieceBpeTokenizer`, `UnigramTokenizer`, plus alle Model-Specific Subklassen (BERT, GPT-2, Llama, Whisper, etc.)
-- **Typical input:** Je nach Task — Text, Image-Buffer, Audio-Samples
-- **Typical output:** Je nach Task — Scores, Embeddings, Generated-Text, Transcription
-- **Realistic median use-case:** **Browser-side ML** ist der eigentliche Use-Case von transformers.js (WASM-ORT im Browser). Node-Use-Case ist sekundär (man würde normalerweise direkt Python/ORT für Server-Inference nutzen). Inference-Time dominiert (hundert Millisekunden – Sekunden).
+  - `pipeline(task, model?, options?)` → high-level task runner. Tasks: `'text-classification'`, `'token-classification'`, `'feature-extraction'`, `'fill-mask'`, `'summarization'`, `'translation'`, `'text-generation'`, `'image-classification'`, `'automatic-speech-recognition'`, `'object-detection'`, ... 20+ tasks
+  - Direct access: `AutoModel`, `AutoTokenizer`, `AutoProcessor`, `AutoConfig` — load models and tokenizers
+  - Tokenizer families: `BpeTokenizer`, `WordPieceTokenizer`, `SentencePieceBpeTokenizer`, `UnigramTokenizer`, plus all model-specific subclasses (BERT, GPT-2, Llama, Whisper, etc.)
+- **Typical input:** Depends on task — text, image buffer, audio samples
+- **Typical output:** Depends on task — scores, embeddings, generated text, transcription
+- **Realistic median use case:** **Browser-side ML** is the actual use case of transformers.js (WASM-ORT in the browser). The Node use case is secondary (one would normally use Python / ORT directly for server inference). Inference time dominates (hundreds of milliseconds – seconds).
 
 ## Rust replacement
 
-- **Candidate crate(s):** Es gibt **keine** Full-Transformers-Parity-Rust-Crate. `ort`-Rust wrappt ORT selbst, `candle-transformers` (Huggingface) ist Pure-Rust aber andere API und andere Model-Coverage. Ein Port würde eigener Code sein, ~10 000 LOC, hunderte Tokenizer-Spec-Details.
-- **Maintenance / license:** n/a (kein direkter Kandidat)
-- **Known gotchas / divergences:** **Komplette Parity** mit Hugging-Face-Python-Transformers ist die Existenz-Berechtigung von transformers.js. Wir können das nicht ohne massiven Ongoing-Aufwand matchen.
+- **Candidate crate(s):** There is **no** full-transformers-parity Rust crate. `ort`-Rust wraps ORT itself, `candle-transformers` (Hugging Face) is pure Rust but a different API and different model coverage. A port would be our own code, ~10 000 LOC, hundreds of tokenizer spec details.
+- **Maintenance / license:** n/a (no direct candidate)
+- **Known gotchas / divergences:** **Complete parity** with Hugging-Face Python Transformers is the entire reason transformers.js exists. We can't match it without massive ongoing effort.
 
 ## BACKLOG check
 
-Vorhandener Eintrag in `BACKLOG.md` → "Ruled out — AI-category": "ORT-WASM based, spec-driven parity surface, bound by ORT not by us." Review formalisiert und archiviert.
+Existing entry in `BACKLOG.md` → "Ruled out — AI-category": "ORT-WASM based, spec-driven parity surface, bound by ORT not by us." Review formalises and archives.
 
-Abgrenzung:
-- Gegen `docs/perf-review/onnxruntime-node.md` (⚫): xenova-transformers ist eine Abstraktion DARÜBER. Das Problem ist eine Ebene schlimmer (doppelte Wrapping-Falle plus Spec-Parity).
-- Gegen `docs/perf-review/langchain.md` (falls erstellt) / BACKLOG-`langchain`: Spec-driven Parity-Surface ist der gleiche Typus.
-- Gegen `docs/perf-review/tiktoken.md` (🟢 shipped): Zusammenhang — der Tokenizer-Teil **ist** potentiell portbar pro Model-Familie (wie wir es für OpenAI-BPE mit `@amigo-labs/tiktoken` getan haben). Aber das ist **nicht** "@xenova/transformers porten" — das ist "für jedes neue Model-Tokenizer-Pattern ein eigenes @amigo-labs-Paket." Portfolio-Maßstab anders.
+Boundary:
+- vs. `docs/perf-review/onnxruntime-node.md` (⚫): xenova-transformers is an abstraction ABOVE that. The problem is one level worse (double-wrapping trap plus spec parity).
+- vs. `docs/perf-review/langchain.md` (if created) / BACKLOG `langchain`: spec-driven parity surface is the same type.
+- vs. `docs/perf-review/tiktoken.md` (🟢 shipped): related — the tokenizer part **is** potentially portable per model family (the way we did the OpenAI BPE in `@amigo-labs/tiktoken`). But that is **not** "porting @xenova/transformers" — it would be "one separate @amigo-labs package per new model tokenizer pattern." Different portfolio scale.
 
 ## FFI-overhead prediction
 
 | Factor | Assessment |
 |---|---|
-| Per-call algorithmic work | **Massiv** — Model-Forward ist der 99 %-Kostenpunkt, läuft in ORT-Backend. Preprocess/Tokenize ist <1 %. |
-| Input size distribution | Text-Inputs, Image-Buffers. |
-| Output size distribution | Embeddings / Scores / Strings. |
-| Reusable setup (stateful potential) | **Maximal** — Model-Load einmal, viele Inference. Tokenizer-Build einmal, viele Encode-Calls. |
-| Batch-usage realism | Ja, aber nur relevant wenn ORT Batch unterstützt (tut es). Unser Port bringt keinen Hebel hier. |
-| FFI-share estimate vs. Rust work | <1 %. Nicht das Problem — Gewinn-Margin ist das Problem (~0). |
+| Per-call algorithmic work | **Massive** — model forward is the 99 % cost driver, runs in the ORT backend. Preprocess / tokenise is <1 %. |
+| Input size distribution | Text inputs, image buffers. |
+| Output size distribution | Embeddings / scores / strings. |
+| Reusable setup (stateful potential) | **Maximal** — model load once, many inferences. Tokenizer build once, many encode calls. |
+| Batch usage realism | Yes, but only relevant if ORT supports batches (it does). Our port adds no lever here. |
+| FFI-share estimate vs. Rust work | <1 %. Not the problem — the win margin is the problem (~0). |
 
 ## Classification reasoning
 
-1. **Der 99 %-Hot-Path ist ORT-Backend-Inference.** Das ist C++/WASM und kein Rust-Port drückt die Zahlen.
+1. **The 99 % hot path is ORT-backend inference.** That is C++ / WASM and no Rust port moves the numbers.
 
-2. **Tokenizer-Parity wäre Month-of-Work.** transformers.js implementiert BPE, WordPiece, SentencePiece-Unigram, SentencePiece-BPE, plus Model-Specific-Pre/Post-Processing. Huggingface pflegt diese Spec-Detail laufend. Rust-`tokenizers` crate (von HF selbst!) ist die beste Option — aber dann sind wir wieder nur Re-Wrapper eines bestehenden native-Codes.
+2. **Tokenizer parity would be a month of work.** transformers.js implements BPE, WordPiece, SentencePiece Unigram, SentencePiece BPE, plus model-specific pre/post-processing. Hugging Face maintains these spec details continuously. The Rust `tokenizers` crate (from HF themselves!) is the best option — but then we're again just re-wrapping existing native code.
 
-3. **Huggingface hat bereits `tokenizers` (Rust).** Der Rust-Core für Tokenization existiert und HF pflegt ihn. Uns fehlt der Bedarf, das zu rewrappen.
+3. **Hugging Face already has `tokenizers` (Rust).** The Rust core for tokenisation exists and HF maintains it. We have no need to re-wrap it.
 
-4. **Pipeline-Abstraction ist Python-API-Emulation.** Sinnvoll für Browser (wo Python nicht verfügbar ist). Node-Server-User fahren eher direkt Python oder nutzen Serving-Layer wie Triton.
+4. **The pipeline abstraction is Python-API emulation.** Useful for browsers (where Python isn't available). Node-server users tend to drive Python directly or use a serving layer like Triton.
 
-**Shape-Matching:**
-- 🔁 Wie `onnxruntime-node` (wrapped native)
-- 🔁 Wie `langchain` (spec-driven parity, unbounded surface)
-- ❌ Nicht wie `@amigo-labs/tiktoken` (wir portierten ein **einzelnes** Tokenizer-Pattern — cl100k_base, o200k — nicht die ganze Tokenizer-Familie)
+**Shape matching:**
+- 🔁 Like `onnxruntime-node` (wrapped native)
+- 🔁 Like `langchain` (spec-driven parity, unbounded surface)
+- ❌ Not like `@amigo-labs/tiktoken` (we ported a **single** tokenizer pattern — cl100k_base, o200k — not the full tokenizer family)
 
-**Benchmark-Gap-Flag:** Nicht erforderlich. Architektur-Problem.
+**Benchmark-gap flag:** Not required. Architecture problem.
 
 ## If NO-GO — BACKLOG entry
 
-Archiviert 2026-04-21. Full review: `docs/perf-review/xenova-transformers.md`.
+Archived 2026-04-21. Full review: `docs/perf-review/xenova-transformers.md`.

--- a/scripts/new-package.sh
+++ b/scripts/new-package.sh
@@ -3,6 +3,15 @@ set -euo pipefail
 
 NAME=${1:?"Usage: ./scripts/new-package.sh <package-name>"}
 
+# Validate the package name up front. We feed `$NAME` into `sed` and many
+# build-tool inputs that don't escape arbitrary characters; restrict to
+# lowercase alphanumerics + dash to match npm/cargo conventions and to
+# avoid the historical CVE shape (`/`, `&`, `\` in a `sed` replacement).
+if [[ ! "$NAME" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+  echo "Error: package name must match [a-z0-9][a-z0-9_-]* (got: $NAME)" >&2
+  exit 1
+fi
+
 if [ -d "crates/$NAME" ]; then
   echo "Error: crates/$NAME already exists"
   exit 1
@@ -15,7 +24,8 @@ while IFS= read -r -d '' f; do
   mv "$f" "${f%.tmpl}"
 done < <(find "crates/$NAME" -type f -name "*.tmpl" -print0)
 
-# Replace template variables in every non-binary file
+# Replace template variables in every non-binary file. The validation
+# above ensures `$NAME` contains no sed metacharacters (`/`, `&`, `\`).
 while IFS= read -r -d '' f; do
   sed -i "s/{{NAME}}/$NAME/g" "$f"
 done < <(find "crates/$NAME" -type f \( -name "*.toml" -o -name "*.json" -o -name "*.rs" -o -name "*.ts" -o -name "*.md" \) -print0)

--- a/scripts/new-package.sh
+++ b/scripts/new-package.sh
@@ -5,8 +5,10 @@ NAME=${1:?"Usage: ./scripts/new-package.sh <package-name>"}
 
 # Validate the package name up front. We feed `$NAME` into `sed` and many
 # build-tool inputs that don't escape arbitrary characters; restrict to
-# lowercase alphanumerics + dash to match npm/cargo conventions and to
-# avoid the historical CVE shape (`/`, `&`, `\` in a `sed` replacement).
+# lowercase alphanumerics, dash and underscore to match npm/cargo
+# conventions (and the existing `_template`, `_search-core` crate names)
+# and to avoid the historical CVE shape (`/`, `&`, `\` in a `sed`
+# replacement).
 if [[ ! "$NAME" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
   echo "Error: package name must match [a-z0-9][a-z0-9_-]* (got: $NAME)" >&2
   exit 1

--- a/scripts/sync-registry.mjs
+++ b/scripts/sync-registry.mjs
@@ -122,6 +122,37 @@ function updateReleaseYaml(yaml, crates) {
   return `${before}\n${items}\n${indent}${after}`
 }
 
+/**
+ * Verify each crate's `npm/<target>/package.json` carries the same
+ * version string as its parent. After `napi pre-publish` injects
+ * `optionalDependencies: { "@amigo-labs/<name>-<target>": "<parent>" }`,
+ * any stub at a stale version no longer exists on the registry and
+ * `npm install` falls into the postinstall error path. Returns an array
+ * of mismatch descriptors; an empty array means all stubs are aligned.
+ */
+function checkNpmStubVersions(crates) {
+  const mismatches = []
+  for (const { dir, pkg } of crates) {
+    const npmDir = join(cratesDir, dir, 'npm')
+    if (!existsSync(npmDir)) continue
+    for (const target of readdirSync(npmDir, { withFileTypes: true })) {
+      if (!target.isDirectory()) continue
+      const stubPath = join(npmDir, target.name, 'package.json')
+      if (!existsSync(stubPath)) continue
+      const stub = loadJson(stubPath)
+      if (stub.version !== pkg.version) {
+        mismatches.push({
+          crate: dir,
+          target: target.name,
+          parent: pkg.version,
+          stub: stub.version,
+        })
+      }
+    }
+  }
+  return mismatches
+}
+
 function updateReadme(readme, tableBlock) {
   const startIdx = readme.indexOf(README_START)
   const endIdx = readme.indexOf(README_END)
@@ -155,16 +186,35 @@ function main() {
   const readmeChanged = nextReadme !== readme
   const releaseChanged = nextReleaseYaml !== releaseYaml
 
+  const stubMismatches = checkNpmStubVersions(crates)
+
   if (check) {
-    if (pkgChanged || readmeChanged || releaseChanged) {
+    let stale = pkgChanged || readmeChanged || releaseChanged
+    if (stale) {
       console.error('sync-registry: outputs are stale. Run `node scripts/sync-registry.mjs` and commit the result.')
       if (pkgChanged) console.error('  - docs/packages.json')
       if (readmeChanged) console.error('  - README.md')
       if (releaseChanged) console.error('  - .github/workflows/release.yml')
-      process.exit(1)
     }
-    console.log(`sync-registry: up to date (${crates.length} crates).`)
+    if (stubMismatches.length) {
+      stale = true
+      console.error(
+        `sync-registry: ${stubMismatches.length} npm platform stub version(s) drifted from their parent crate.`,
+      )
+      console.error('  After `napi pre-publish`, stubs must match the parent so optionalDependencies resolve.')
+      for (const m of stubMismatches) {
+        console.error(`  - crates/${m.crate}/npm/${m.target}/package.json: ${m.stub} (parent ${m.parent})`)
+      }
+    }
+    if (stale) process.exit(1)
+    console.log(`sync-registry: up to date (${crates.length} crates, all stubs aligned).`)
     return
+  }
+
+  if (stubMismatches.length) {
+    console.warn(
+      `sync-registry: ${stubMismatches.length} npm platform stub version(s) do not match their parent crate; run --check in CI to fail on drift.`,
+    )
   }
 
   if (pkgChanged) writeFileSync(packagesJsonPath, nextPkgStr)


### PR DESCRIPTION
## Summary

Verifies every finding in `docs/code-review-2026-04-25.md` against the current
`HEAD` and lands fixes for the ones that were still present, plus one new
P2 my own audit turned up.

Six focused commits, one cluster per commit:

1. **`093a003` — P0 #1, #2, #5 (memory safety / DoS):**
   - `inflate`: `InflateOptions.maxOutputSize` (default 256 MiB) caps `decompress_bulk`'s `grow_uninit` and wraps the gzip path in `Take(max+1)`. Closes the gzip-bomb DoS in `inflate`, `inflateRaw` and `ungzip`.
   - `zip`: caps `Vec::with_capacity(f.size())` at `MAX_PREALLOC_PER_ENTRY` (256 MiB) and switches `ZipEntryInfo.size` / `.compressedSize` from `u32` (with `.min(u32::MAX)` truncation) to `BigInt` so zip64 entries no longer corrupt silently.
   - `minisearch` / `bm25`: every `.lock().unwrap()` is now `.lock().unwrap_or_else(|e| e.into_inner())` — a panic in any critical section no longer poisons the mutex and bricks the index.

2. **`3561364` — P0 #3, P1 #6 (release blockers):**
   - Bumps the 12 stale `npm/<target>/package.json` files for sanitize-html and xxhash from 0.1.0 to 0.2.0.
   - `scripts/sync-registry.mjs --check` now compares each stub against its parent and fails non-zero on drift, with a human-readable mismatch list.
   - Extracts a focused `__conformance__/parity.spec.ts` for each of `deepmerge`, `encoding`, `file-type`, `inflate`, `jwt`, `nanoid` and `zip`, and changes every `test:conformance` script from `vitest run __conformance__/fuzz.spec.ts` to `vitest run __conformance__`. The cross-verification assertions used to be silently skipped during the conformance run.

3. **`9de033f` — P0 #4 (English-only rule, partial):**
   Translates 15 of the 36 German perf-review docs to English while preserving every data table and code block verbatim. The remaining 21 are tracked in the commit body and need a follow-up. Verify with `grep -lP '[äöüÄÖÜß]' docs/perf-review/*.md`.

4. **`7b76f66` — P1 #7, #9, #10 (CI hygiene):**
   - New `audit-rust` job in `ci.yml` runs `cargo audit --deny warnings`. Vulnerable transitive crates now fail CI.
   - `NODE_VERSION` hoisted to a workflow-level `env:` block in both `ci.yml` and `release.yml`; every `setup-node` step now references `${{ env.NODE_VERSION }}`.
   - Pins all four `actions/upload-artifact` and `actions/download-artifact` references to `@v4` (release.yml was on `@v7`/`@v8`).

5. **`4af99c3` — P1 #8, #11, #12 (correctness + types):**
   - `sanitize-html`: `SanitizeOptions.maxDepth` (default 256) and `SanitizeOptions.maxInputBytes` (default 5 MiB). The fast-path frame stack refuses to grow past `maxDepth` (extra tags unwrap, content is kept). The strict path also honours `maxInputBytes`. Three regression tests added; existing 225 conformance tests still pass.
   - `crates/jose` switches `main`/`types` to a manual `wrapper.{js,d.ts}` so the public surface uses `Jwk = Record<string, unknown>` instead of `any`. (jwt and deepmerge already had wrapper.d.ts files; their auto-generated `index.d.ts` is internal per their package.json.)
   - `CONTRIBUTING.md`: Node ≥ 20 → Node ≥ 22 to match `package.json:engines.node` and `README.md`.
   - Also fixes the misleading `// remove(idx)` comment in `v2.rs:186` that contradicted the actual `drain(idx + 1..)` (P2 #14).

6. **`e130e6f` — P2 cleanups:**
   - `text-splitters`: the four internal `split_*` helpers return `Result` instead of unwrapping `ChunkConfig::with_overlap`.
   - **NEW finding from this round's audit:** `crates/diff/src/lib.rs` `build_offsets` now uses `checked_add` and `try_into()` on hunk lengths, so a >4 GiB hunk surfaces a napi error instead of wrapping `old_pos`/`new_pos` and emitting nonsense u32 offsets.
   - `scripts/new-package.sh`: validates `$NAME` against `[a-z0-9][a-z0-9_-]*` before feeding it to `sed`.
   - `.github/dependabot.yml`: cargo + npm + github-actions, weekly Monday, minor/patch grouped.
   - `docs/follow-ups.md` stale heading link fixed.
   - `docs/app.js` one-line comment above the README `innerHTML` assignment.

False positives I rejected after direct verification (so they're not in any commit): `turndown` `name_l[1..].parse()` (the match arm filters to h1–h6, so the slice is never empty), `sentences` UTF-8 trim (`is_ascii_whitespace` only matches single-byte codepoints, so `s`/`e` never land mid-codepoint), `jwt` `u32 as i64` (always lossless), and `svgo` negative RGB (deterministic, non-spec input that we normalize).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p amigo-{inflate,zip,minisearch,bm25,sanitize-html,jwt,jose,deepmerge,diff,text-splitters}` — all green
- [x] `pnpm test` per crate for every modified package — all green
- [x] `pnpm test:conformance` for the 7 crates that gained `parity.spec.ts` — all 3 spec files run
- [x] `node scripts/sync-registry.mjs --check` passes with parity stubs aligned, fails non-zero when artificially drifted
- [x] sanitize-html new regression tests cover deep nesting, oversize input, user-overridable `maxInputBytes`
- [x] inflate vitest covers `maxOutputSize` rejection on a 1 MiB-of-zeros gzip bomb under a 256 KiB limit

## Follow-ups

- Translate the remaining 21 German perf-review files (cheerio, diff, file-type, franc, hnswlib-node, inflate, jwt, langchain__textsplitters, minisearch, nanoid, natural, pdf-parse, remark, sanitize-html, sbd, semver, slugify, turndown, wink-bm25-text-search, xxhash, zip).
- P2 items that were intentionally deferred: #19 modern `exports` field rollout (touches 30 package.json files), #20 `dtolnay/rust-toolchain` SHA pin, #22 `vitest pool: 'forks'` audit (no concrete repro yet).

---
_Generated by [Claude Code](https://claude.ai/code/session_015jPLqwXKpENFAGgZkcCkXk)_