### PR TITLE
docs: full UI/UX pass on the showcase site

### DIFF
--- a/crates/argon2/package.json
+++ b/crates/argon2/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "Argon2",
+    "category": "crypto",
     "description": "Argon2id password hashing with sync + async API.",
     "tableDescription": "Argon2id password hashing (sync + async)",
     "replaces": "argon2/hash-wasm",

--- a/crates/bcrypt/package.json
+++ b/crates/bcrypt/package.json
@@ -56,6 +56,7 @@
   },
   "amigo": {
     "title": "Bcrypt",
+    "category": "crypto",
     "description": "Bcrypt password hashing with sync + async API. Argon2 sibling.",
     "tableDescription": "Bcrypt password hashing (sync + async)",
     "replaces": "bcrypt/bcryptjs",

--- a/crates/bm25/package.json
+++ b/crates/bm25/package.json
@@ -58,6 +58,7 @@
   },
   "amigo": {
     "title": "BM25",
+    "category": "search",
     "description": "BM25 full-text search. Stateful NAPI class — build index once, query many times.",
     "tableDescription": "BM25 full-text search",
     "replaces": "wink-bm25-text-search",

--- a/crates/commonmark/package.json
+++ b/crates/commonmark/package.json
@@ -59,6 +59,7 @@
   },
   "amigo": {
     "title": "CommonMark",
+    "category": "text",
     "description": "CommonMark + GFM renderer powered by pulldown-cmark.",
     "tableDescription": "CommonMark + GFM renderer via `pulldown-cmark`",
     "replaces": "marked/markdown-it",

--- a/crates/csv/package.json
+++ b/crates/csv/package.json
@@ -58,6 +58,7 @@
   },
   "amigo": {
     "title": "CSV",
+    "category": "document",
     "description": "CSV parsing and serialization via BurntSushi's csv crate.",
     "tableDescription": "CSV parsing/serialization via BurntSushi's `csv`",
     "replaces": "csv-parse/papaparse",

--- a/crates/deepmerge/package.json
+++ b/crates/deepmerge/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "Deepmerge",
+    "category": "util",
     "description": "Recursive object merge for JSON-safe values.",
     "tableDescription": "Recursive object merge",
     "replaces": "deepmerge",

--- a/crates/diff/package.json
+++ b/crates/diff/package.json
@@ -56,6 +56,7 @@
   },
   "amigo": {
     "title": "Diff",
+    "category": "util",
     "description": "Myers/Patience diff via `similar`. Drop-in-shape with an offset-packed hot-path for char-level and large-input cases.",
     "tableDescription": "Text diff via `similar`, offset-packed hot-path",
     "replaces": "diff",

--- a/crates/encoding/package.json
+++ b/crates/encoding/package.json
@@ -59,6 +59,7 @@
   },
   "amigo": {
     "title": "Encoding",
+    "category": "text",
     "description": "Character encoding conversion powered by Mozilla's encoding_rs.",
     "tableDescription": "Character encoding via `encoding_rs`",
     "replaces": "iconv-lite",

--- a/crates/file-type/package.json
+++ b/crates/file-type/package.json
@@ -56,6 +56,7 @@
   },
   "amigo": {
     "title": "File Type",
+    "category": "util",
     "description": "Magic-byte file-type detection via the Rust infer crate.",
     "tableDescription": "Magic-byte file detection via `infer`",
     "replaces": "file-type",

--- a/crates/force-layout/package.json
+++ b/crates/force-layout/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "Force Layout",
+    "category": "graph",
     "description": "Force-directed graph simulation. Batch-mode d3-force replacement for SSR / precompute workloads.",
     "tableDescription": "Force-directed graph layout (batch)",
     "replaces": "d3-force",

--- a/crates/graph-layout/package.json
+++ b/crates/graph-layout/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "Graph Layout",
+    "category": "graph",
     "description": "Hierarchical (Sugiyama-style) DAG layout. Single-call spec → positions + edge routing.",
     "tableDescription": "Hierarchical DAG layout, spec in, positions out",
     "replaces": "dagre",

--- a/crates/inflate/package.json
+++ b/crates/inflate/package.json
@@ -58,6 +58,7 @@
   },
   "amigo": {
     "title": "Inflate",
+    "category": "archive",
     "description": "zlib deflate/inflate/gzip powered by flate2 + zlib-rs.",
     "tableDescription": "zlib deflate/inflate/gzip via `flate2` (zlib-rs)",
     "replaces": "pako",

--- a/crates/jose/package.json
+++ b/crates/jose/package.json
@@ -62,6 +62,7 @@
   },
   "amigo": {
     "title": "JOSE",
+    "category": "crypto",
     "description": "Ed25519 JWK generation and RFC 7638 thumbprints. JWE roadmap.",
     "tableDescription": "Ed25519 JWK + RFC 7638 thumbprints",
     "replaces": "jose (subset)",

--- a/crates/jwt/package.json
+++ b/crates/jwt/package.json
@@ -59,6 +59,7 @@
   },
   "amigo": {
     "title": "JWT",
+    "category": "crypto",
     "description": "JWT sign, verify, and decode via the jsonwebtoken Rust crate.",
     "tableDescription": "JWT sign/verify via `jsonwebtoken` crate",
     "replaces": "jsonwebtoken",

--- a/crates/language-detect/package.json
+++ b/crates/language-detect/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "Language Detect",
+    "category": "text",
     "description": "Language detection powered by whatlang. Paragraph-size Green, short-string Red by design.",
     "tableDescription": "Language detection via `whatlang`",
     "replaces": "franc",

--- a/crates/minisearch/package.json
+++ b/crates/minisearch/package.json
@@ -56,6 +56,7 @@
   },
   "amigo": {
     "title": "Minisearch",
+    "category": "search",
     "description": "Tiny in-memory full-text search with prefix autocomplete. Shares Rust search-core with @amigo-labs/bm25.",
     "tableDescription": "In-memory full-text search + autocomplete",
     "replaces": "minisearch",

--- a/crates/nanoid/package.json
+++ b/crates/nanoid/package.json
@@ -39,6 +39,7 @@
   },
   "amigo": {
     "title": "NanoID",
+    "category": "crypto",
     "description": "Fast crypto-safe URL-friendly ID generator with pool-amortised entropy. Pure JS — the NAPI FFI boundary was bigger than the entire ID-generation path.",
     "tableDescription": "Crypto-safe URL-safe IDs via `nanoid` crate",
     "replaces": "nanoid",

--- a/crates/pdf-parse/package.json
+++ b/crates/pdf-parse/package.json
@@ -55,6 +55,7 @@
   },
   "amigo": {
     "title": "PDF Parse",
+    "category": "document",
     "description": "PDF text + metadata extraction via pdf-extract/lopdf. No pdf.js, no browser pipeline.",
     "tableDescription": "PDF text + metadata extraction",
     "replaces": "pdf-parse",

--- a/crates/pdf/package.json
+++ b/crates/pdf/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "PDF",
+    "category": "document",
     "description": "PDF generation — one FFI call per document. Labels / tickets / simple reports.",
     "tableDescription": "PDF generation, spec-in / Buffer-out",
     "replaces": "pdfkit",

--- a/crates/sanitize-html/package.json
+++ b/crates/sanitize-html/package.json
@@ -73,6 +73,7 @@
   },
   "amigo": {
     "title": "Sanitize HTML",
+    "category": "text",
     "description": "HTML sanitization via Mozilla's ammonia engine.",
     "tableDescription": "HTML sanitization via Mozilla's `ammonia`",
     "replaces": "sanitize-html",

--- a/crates/sentences/package.json
+++ b/crates/sentences/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "Sentences",
+    "category": "text",
     "description": "Multi-language sentence boundary detection. String or offset-packed output for hot paths.",
     "tableDescription": "Sentence splitter, multi-language + offset hot-path",
     "replaces": "sbd",

--- a/crates/slugify/package.json
+++ b/crates/slugify/package.json
@@ -54,6 +54,7 @@
   },
   "amigo": {
     "title": "Slugify",
+    "category": "text",
     "description": "Unicode-aware slugification. Wraps deunicode + unicode-normalization.",
     "tableDescription": "Unicode-aware slugification via `deunicode`",
     "replaces": "slugify",

--- a/crates/stemmer/package.json
+++ b/crates/stemmer/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "Stemmer",
+    "category": "text",
     "description": "Porter/Snowball stemming via rust-stemmers. Batch-only API — single-word calls are intentionally not exposed.",
     "tableDescription": "Porter/Snowball stemmer (batch-only) via `rust-stemmers`",
     "replaces": "natural (stemmer subset)",

--- a/crates/svgo/package.json
+++ b/crates/svgo/package.json
@@ -56,6 +56,7 @@
   },
   "amigo": {
     "title": "Svgo",
+    "category": "document",
     "description": "SVG optimizer via quick-xml. Ships the 8 highest-impact `preset-default` plugins.",
     "tableDescription": "SVG optimizer, 8 preset-default plugins",
     "replaces": "svgo",

--- a/crates/text-splitters/package.json
+++ b/crates/text-splitters/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "Text Splitters",
+    "category": "text",
     "description": "RAG text splitters (recursive-character + markdown-aware), with native tiktoken length.",
     "tableDescription": "RAG splitters, tiktoken-aware",
     "replaces": "@langchain/textsplitters",

--- a/crates/tiktoken/package.json
+++ b/crates/tiktoken/package.json
@@ -60,6 +60,7 @@
   },
   "amigo": {
     "title": "Tiktoken",
+    "category": "text",
     "description": "OpenAI BPE tokenizer powered by tiktoken-rs. Drop-in for tiktoken (WASM) and js-tiktoken.",
     "tableDescription": "OpenAI BPE tokenizer (cl100k, o200k) via `tiktoken-rs`",
     "replaces": "tiktoken/js-tiktoken",

--- a/crates/turndown/package.json
+++ b/crates/turndown/package.json
@@ -59,6 +59,7 @@
   },
   "amigo": {
     "title": "Turndown",
+    "category": "text",
     "description": "HTML → Markdown via html5ever. Ships CommonMark + GFM tables/strikethrough.",
     "tableDescription": "HTML → Markdown, CommonMark + GFM",
     "replaces": "turndown",

--- a/crates/typst/package.json
+++ b/crates/typst/package.json
@@ -55,6 +55,7 @@
   },
   "amigo": {
     "title": "Typst",
+    "category": "document",
     "description": "Typst document compiler — source in, PDF out. Bundled Libertinus fonts; offline-only packages.",
     "tableDescription": "Typst compiler, source → PDF",
     "replaces": "typst-js",

--- a/crates/xlsx/package.json
+++ b/crates/xlsx/package.json
@@ -58,6 +58,7 @@
   },
   "amigo": {
     "title": "XLSX",
+    "category": "document",
     "description": "XLSX read + write. Buffer in → rows out, rows in → Buffer out. Single-FFI-crossing.",
     "tableDescription": "XLSX read + write",
     "replaces": "xlsx",

--- a/crates/xxhash/package.json
+++ b/crates/xxhash/package.json
@@ -57,6 +57,7 @@
   },
   "amigo": {
     "title": "XXHash",
+    "category": "crypto",
     "description": "XXH32, XXH64, and XXH3 with batch + streaming support.",
     "tableDescription": "XXH32/64/XXH3 hashing with batch + streaming API",
     "replaces": "xxhash-wasm/xxhashjs",

--- a/crates/zip/package.json
+++ b/crates/zip/package.json
@@ -59,6 +59,7 @@
   },
   "amigo": {
     "title": "ZIP",
+    "category": "archive",
     "description": "ZIP archive read/write via the zip Rust crate.",
     "tableDescription": "ZIP read/write via `zip` crate",
     "replaces": "yauzl/adm-zip/jszip",

--- a/docs/app.js
+++ b/docs/app.js
@@ -159,6 +159,7 @@ async function boot() {
   renderCategoryChips();
   renderPicker();
   updatePickerCount();
+  wirePicker();
   wireSortChips();
   wireFilter();
   cycleHeroTagline();
@@ -263,39 +264,43 @@ function renderPicker() {
       </li>
     `;
   }).join('');
+  updatePickerPadding();
+}
 
-  // mobile still needs horizontal center-snap padding; desktop is a flat top-aligned list
-  const updatePadding = () => {
-    const isMobile = window.innerWidth <= 900;
-    if (isMobile) {
-      picker.style.paddingTop = '';
-      picker.style.paddingBottom = '';
-      picker.style.paddingLeft = '50%';
-      picker.style.paddingRight = '50%';
-    } else {
-      picker.style.paddingLeft = '';
-      picker.style.paddingRight = '';
-      picker.style.paddingTop = '';
-      picker.style.paddingBottom = '';
-    }
-  };
-  updatePadding();
-  window.addEventListener('resize', () => {
-    updatePadding();
-    // mobile's horizontal picker needs to re-center on the active item when the
-    // layout flips across the 900px breakpoint; desktop's flat list is a no-op
-    snapTo(state.activeIdx, false);
+// Mobile needs horizontal center-snap padding; desktop is a flat top-aligned list.
+function updatePickerPadding() {
+  const picker = $('#picker');
+  if (!picker) return;
+  const isMobile = window.innerWidth <= 900;
+  if (isMobile) {
+    picker.style.paddingTop = '';
+    picker.style.paddingBottom = '';
+    picker.style.paddingLeft = '50%';
+    picker.style.paddingRight = '50%';
+  } else {
+    picker.style.paddingLeft = '';
+    picker.style.paddingRight = '';
+    picker.style.paddingTop = '';
+    picker.style.paddingBottom = '';
+  }
+}
+
+// One-time wiring on the persistent #picker element. Event delegation for
+// clicks means renderPicker() can rebuild the list freely without piling up
+// handlers on each render. The window-level resize listener used to live
+// inside renderPicker(), where every sort/filter change attached a duplicate.
+function wirePicker() {
+  const picker = $('#picker');
+  if (!picker) return;
+
+  picker.addEventListener('click', e => {
+    const li = e.target.closest('li[data-idx]');
+    if (!li || !picker.contains(li)) return;
+    const idx = parseInt(li.dataset.idx, 10);
+    if (Number.isFinite(idx)) snapTo(idx, true);
   });
 
-  // click to select
-  picker.querySelectorAll('li').forEach(li => {
-    li.addEventListener('click', () => {
-      const idx = parseInt(li.dataset.idx, 10);
-      snapTo(idx, true);
-    });
-  });
-
-  // scroll-based active detection only on mobile (horizontal wheel-picker)
+  // Scroll-based active detection only on mobile (horizontal wheel-picker).
   let scrollTimer = null;
   picker.addEventListener('scroll', () => {
     if (window.innerWidth > 900) return;
@@ -313,6 +318,14 @@ function renderPicker() {
       }
     });
   }, { passive: true });
+
+  window.addEventListener('resize', () => {
+    updatePickerPadding();
+    // Mobile's horizontal picker needs to re-center on the active item when
+    // the layout flips across the 900 px breakpoint; desktop's flat list is
+    // a no-op.
+    snapTo(state.activeIdx, false);
+  });
 }
 
 function nearestCenterIdx() {
@@ -521,33 +534,39 @@ function animateSlab(p) {
 // per commit. Each entry has a list of suites, where ratio = amigo/competitor
 // (null when there's no comparable competitor). We aggregate per-commit by
 // geomean of the available ratios and plot the sequence as an inline sparkline.
+//
+// Cache the *in-flight Promise*, not just its resolved value, so that a
+// second caller (e.g. user clicks pkg A → switches to pkg B → switches back
+// to A before A's fetch lands) shares the same network request.
 const _historyCache = {};
-async function loadHistory(name) {
-  if (_historyCache[name] !== undefined) return _historyCache[name];
-  try {
-    const res = await fetch(`history/${name}.jsonl`);
-    if (!res.ok) throw new Error(res.statusText);
-    const txt = await res.text();
-    const lines = txt.split('\n').map(l => l.trim()).filter(Boolean);
-    const entries = [];
-    for (const line of lines) {
-      try {
-        const e = JSON.parse(line);
-        const ratios = (e.suites || [])
-          .map(s => typeof s.ratio === 'number' ? s.ratio : null)
-          .filter(r => r !== null && r > 0 && isFinite(r));
-        if (!ratios.length) continue;
-        const logSum = ratios.reduce((a, r) => a + Math.log(r), 0);
-        const geomean = Math.exp(logSum / ratios.length);
-        entries.push({ commit: e.commit, date: e.date, geomean });
-      } catch { /* skip malformed line */ }
+function loadHistory(name) {
+  if (_historyCache[name]) return _historyCache[name];
+  const promise = (async () => {
+    try {
+      const res = await fetch(`history/${name}.jsonl`);
+      if (!res.ok) throw new Error(res.statusText);
+      const txt = await res.text();
+      const lines = txt.split('\n').map(l => l.trim()).filter(Boolean);
+      const entries = [];
+      for (const line of lines) {
+        try {
+          const e = JSON.parse(line);
+          const ratios = (e.suites || [])
+            .map(s => typeof s.ratio === 'number' ? s.ratio : null)
+            .filter(r => r !== null && r > 0 && isFinite(r));
+          if (!ratios.length) continue;
+          const logSum = ratios.reduce((a, r) => a + Math.log(r), 0);
+          const geomean = Math.exp(logSum / ratios.length);
+          entries.push({ commit: e.commit, date: e.date, geomean });
+        } catch { /* skip malformed line */ }
+      }
+      return entries;
+    } catch {
+      return [];
     }
-    _historyCache[name] = entries;
-    return entries;
-  } catch {
-    _historyCache[name] = [];
-    return [];
-  }
+  })();
+  _historyCache[name] = promise;
+  return promise;
 }
 
 function buildSparkline(values, width = 96, height = 24) {

--- a/docs/app.js
+++ b/docs/app.js
@@ -262,6 +262,7 @@ function renderPicker() {
         updateActiveClass();
         renderSlab();
         updateHash();
+        updateMeta();
       }
     });
   }, { passive: true });
@@ -310,6 +311,7 @@ function snapTo(idx, smooth) {
   updateActiveClass();
   renderSlab();
   updateHash();
+  updateMeta();
 }
 
 function updateActiveClass() {
@@ -341,6 +343,25 @@ function focusActiveOptionIfInPicker() {
 function updateHash() {
   const p = state.sortedList[state.activeIdx];
   if (p) history.replaceState(null, '', '#' + p.name);
+}
+
+// Reflect the active package in the document title + description so that
+// tab labels, browser history entries, and link previews include it.
+function updateMeta() {
+  const p = state.sortedList[state.activeIdx];
+  if (!p) return;
+  document.title = `${p.name} · ${p.speedup} — amigo-native`;
+  const desc = document.querySelector('meta[name="description"]');
+  if (desc) {
+    desc.setAttribute('content',
+      `@amigo-labs/${p.name}: ${p.description} ${p.speedup}.`);
+  }
+  const ogTitle = document.querySelector('meta[property="og:title"]');
+  if (ogTitle) {
+    ogTitle.setAttribute('content', `@amigo-labs/${p.name} — ${p.speedup}`);
+  }
+  const ogDesc = document.querySelector('meta[property="og:description"]');
+  if (ogDesc) ogDesc.setAttribute('content', p.description);
 }
 
 // --- slab ---

--- a/docs/app.js
+++ b/docs/app.js
@@ -6,7 +6,9 @@ const state = {
   activeIdx: 0,
   activeName: null,
   sortMode: 'speedup', // 'speedup' | 'alpha' | 'size'
-  sortedList: [],
+  filter: '',           // user's text query (lowercased)
+  category: 'all',      // 'all' | category id
+  sortedList: [],       // packages after sort + filter
   typingTimers: [],
 };
 
@@ -44,7 +46,22 @@ function sizeAdvantage(pkgName, sizesData) {
 }
 
 function computeSortedList() {
-  const list = [...state.pkgs.packages];
+  let list = [...state.pkgs.packages];
+
+  // Filter by category first (mostly disjoint, fast).
+  if (state.category && state.category !== 'all') {
+    list = list.filter(p => p.category === state.category);
+  }
+  // Then by free-text query against name + description.
+  if (state.filter) {
+    const q = state.filter.toLowerCase();
+    list = list.filter(p =>
+      p.name.toLowerCase().includes(q) ||
+      (p.description || '').toLowerCase().includes(q) ||
+      (p.title || '').toLowerCase().includes(q)
+    );
+  }
+
   const mode = state.sortMode;
   if (mode === 'alpha') {
     list.sort((a, b) => a.name.localeCompare(b.name));
@@ -55,6 +72,14 @@ function computeSortedList() {
     list.sort((a, b) => sizeAdvantage(b.name, sizes) - sizeAdvantage(a.name, sizes));
   }
   state.sortedList = list;
+}
+
+function uniqueCategories() {
+  const seen = new Set();
+  for (const p of state.pkgs.packages) {
+    if (p.category) seen.add(p.category);
+  }
+  return [...seen].sort();
 }
 
 // --- helpers ---
@@ -122,8 +147,11 @@ async function boot() {
 
   renderBrand();
   renderMarquee();
+  renderCategoryChips();
   renderPicker();
+  updatePickerCount();
   wireSortChips();
+  wireFilter();
   cycleHeroTagline();
   wireKeyboard();
   wireWheel();
@@ -630,6 +658,75 @@ function renderSizes(pkg) {
 }
 
 // --- keyboard ---
+function renderCategoryChips() {
+  const host = $('#categoryChips');
+  if (!host) return;
+  const cats = uniqueCategories();
+  const items = [{ id: 'all', label: 'all' }, ...cats.map(c => ({ id: c, label: c }))];
+  host.innerHTML = items.map(c => `
+    <button class="chip" type="button" data-category="${c.id}"
+      aria-pressed="${state.category === c.id ? 'true' : 'false'}">${c.label}</button>
+  `).join('');
+  host.querySelectorAll('.chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      state.category = chip.dataset.category;
+      host.querySelectorAll('.chip').forEach(c => {
+        c.setAttribute('aria-pressed', c.dataset.category === state.category ? 'true' : 'false');
+      });
+      onFilterOrCategoryChange();
+    });
+  });
+}
+
+function updatePickerCount() {
+  const el = $('#pickerCount');
+  if (!el) return;
+  const total = state.pkgs.packages.length;
+  const shown = state.sortedList.length;
+  el.textContent = shown === total ? `(${total})` : `(${shown}/${total})`;
+}
+
+// Re-run filter+sort, refresh the picker, and either jump to the active item
+// (if still visible) or land on the first match. Empty state shows when the
+// query has zero hits.
+function onFilterOrCategoryChange() {
+  const keepName = state.activeName;
+  computeSortedList();
+  renderPicker();
+  updatePickerCount();
+  const empty = $('#pickerEmpty');
+  if (empty) empty.hidden = state.sortedList.length > 0;
+  if (!state.sortedList.length) return;
+  const newIdx = state.sortedList.findIndex(p => p.name === keepName);
+  state.activeIdx = newIdx >= 0 ? newIdx : 0;
+  state.activeName = state.sortedList[state.activeIdx].name;
+  requestAnimationFrame(() => snapTo(state.activeIdx, false));
+}
+
+function wireFilter() {
+  const input = $('#pkgFilter');
+  if (!input) return;
+  input.addEventListener('input', () => {
+    state.filter = input.value.trim();
+    onFilterOrCategoryChange();
+  });
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Escape') {
+      if (input.value) {
+        input.value = '';
+        state.filter = '';
+        onFilterOrCategoryChange();
+      } else {
+        input.blur();
+      }
+    } else if (e.key === 'Enter') {
+      // Jump to first match and put focus back on the picker for arrow nav.
+      const picker = $('#picker');
+      if (state.sortedList.length && picker) picker.focus();
+    }
+  });
+}
+
 function wireSortChips() {
   document.querySelectorAll('.sort-chips .chip').forEach(chip => {
     chip.addEventListener('click', () => {
@@ -642,6 +739,8 @@ function wireSortChips() {
       const keepName = state.activeName;
       computeSortedList();
       renderPicker();
+      updatePickerCount();
+      if (!state.sortedList.length) return;
       const newIdx = Math.max(0, state.sortedList.findIndex(p => p.name === keepName));
       requestAnimationFrame(() => snapTo(newIdx, true));
     });
@@ -656,8 +755,20 @@ function wireKeyboard() {
   };
 
   document.addEventListener('keydown', e => {
-    if (!state.sortedList.length) return;
     if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+    // "/" focuses the filter input from anywhere outside an editable. We do
+    // this before the interactive-target / empty-list checks so the shortcut
+    // works even when the picker is empty.
+    if (e.key === '/' && !isInteractiveTarget(e.target)) {
+      const input = document.getElementById('pkgFilter');
+      if (input) {
+        input.focus();
+        input.select();
+        e.preventDefault();
+      }
+      return;
+    }
+    if (!state.sortedList.length) return;
     if (isInteractiveTarget(e.target)) return;
 
     const n = state.sortedList.length;

--- a/docs/app.js
+++ b/docs/app.js
@@ -131,6 +131,9 @@ async function boot() {
   // initial active from hash (name-based so it survives sort changes)
   const hash = (location.hash || '').replace('#', '');
   const hashIdx = state.sortedList.findIndex(p => p.name === hash);
+  if (hash && hashIdx < 0) {
+    console.warn(`[amigo-native] no package matches #${hash} — falling back to first.`);
+  }
   state.activeIdx = hashIdx >= 0 ? hashIdx : 0;
   state.activeName = state.sortedList[state.activeIdx].name;
 
@@ -365,6 +368,9 @@ function updateMeta() {
 }
 
 // --- slab ---
+// Holding ↓/↑ rapidly cascades the 120 ms fade per render and feels janky.
+// Coalesce: only the latest pending render lands; intermediates are dropped.
+let renderSlabPending = null;
 function renderSlab() {
   const p = state.sortedList[state.activeIdx];
   if (!p) return;
@@ -372,15 +378,22 @@ function renderSlab() {
   clearTimers();
 
   // Announce the new package to assistive tech via the persistent live region.
-  // Updating its text content (vs. re-rendering it) is what makes SRs read it.
   const announce = $('#slabAnnounce');
   if (announce) announce.textContent = `${p.name} — ${p.speedup}`;
 
+  if (renderSlabPending !== null) {
+    clearTimeout(renderSlabPending);
+    renderSlabPending = null;
+  }
+
   slab.classList.add('fading');
-  setTimeout(() => {
-    slab.innerHTML = buildSlabHTML(p);
+  renderSlabPending = setTimeout(() => {
+    renderSlabPending = null;
+    const cur = state.sortedList[state.activeIdx];
+    if (!cur) return;
+    slab.innerHTML = buildSlabHTML(cur);
     slab.classList.remove('fading');
-    animateSlab(p);
+    animateSlab(cur);
   }, reducedMotion() ? 0 : 120);
 }
 
@@ -434,21 +447,62 @@ function buildSlabHTML(p) {
 function animateSlab(p) {
   const cmdText = 'npm install @amigo-labs/' + p.name;
 
-  typeInto($('#slabSpeedup'), p.speedup, 18);
-  typeInto($('#slabDesc'), p.description, 8);
+  // Speedup and description are functional content — show instantly so the
+  // user can read them. The slab fade-in already provides motion. Only the
+  // install command keeps the typewriter (it's the on-brand shell prompt).
+  $('#slabSpeedup').textContent = p.speedup;
+  $('#slabDesc').textContent = p.description;
   typeInto($('#slabCmd'), cmdText, 20);
 
-  $('#slabCopy').addEventListener('click', () => {
-    navigator.clipboard.writeText(cmdText);
-    const btn = $('#slabCopy');
-    const prev = btn.textContent;
-    btn.textContent = 'Copied';
-    setTimeout(() => { btn.textContent = prev; }, 1500);
+  const installRow = document.querySelector('.slab-install');
+  const copyBtn = $('#slabCopy');
+  const triggerCopy = () => copyToClipboard(cmdText, copyBtn, installRow);
+  copyBtn.addEventListener('click', triggerCopy);
+  // Tapping anywhere on the install row also copies — so users don't have
+  // to aim at the small button on touch devices.
+  installRow.addEventListener('click', e => {
+    if (e.target.closest('.copy-btn')) return; // button click already handled
+    triggerCopy();
   });
 
   renderBench(p);
   renderSizes(p);
   wireReadme(p);
+}
+
+// Try the modern clipboard API; fall back to the legacy execCommand path
+// for non-secure contexts (file://, embedded). On full failure surface a
+// visible error state so the user knows to copy manually.
+async function copyToClipboard(text, btn, installRow) {
+  let ok = false;
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      ok = true;
+    } else {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.setAttribute('readonly', '');
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+  } catch {
+    ok = false;
+  }
+  if (!btn) return;
+  const prev = btn.textContent;
+  btn.textContent = ok ? '✓ Copied' : 'Copy failed';
+  btn.classList.add(ok ? 'is-ok' : 'is-err');
+  if (installRow && ok) installRow.classList.add('flash');
+  setTimeout(() => {
+    btn.textContent = prev;
+    btn.classList.remove('is-ok', 'is-err');
+    if (installRow) installRow.classList.remove('flash');
+  }, 1500);
 }
 
 function wireReadme(pkg) {
@@ -626,7 +680,9 @@ function wireKeyboard() {
   });
 }
 
-// --- wheel: let mouse-wheel anywhere on the page drive the picker ---
+// Wheel-driven picker navigation, scoped to the picker column. Wheels
+// elsewhere on the page are left alone so users from "normal" sites don't
+// feel hijacked. The picker's own native scroll-snap still works.
 function wireWheel() {
   let accum = 0;
   let lastTime = 0;
@@ -634,22 +690,18 @@ function wireWheel() {
   const THRESHOLD = 40;
   const COOLDOWN_MS = 220;
 
-  window.addEventListener('wheel', e => {
+  const pickerWrap = document.querySelector('.picker-wrap');
+  if (!pickerWrap) return;
+
+  pickerWrap.addEventListener('wheel', e => {
     if (window.innerWidth <= 900) return; // mobile uses its own swipes
     if (!state.sortedList.length) return;
 
     const picker = document.getElementById('picker');
-    const slab = document.getElementById('slab');
 
-    // allow native scroll inside the slab while it still has room
-    if (slab && slab.contains(e.target)) {
-      const canScrollDown = slab.scrollTop + slab.clientHeight < slab.scrollHeight - 1;
-      const canScrollUp = slab.scrollTop > 0;
-      if (e.deltaY > 0 && canScrollDown) return;
-      if (e.deltaY < 0 && canScrollUp) return;
-    }
-
-    // let the picker handle its own wheel natively (scroll-snap)
+    // The picker's own scroll-snap handles wheels that land directly on it.
+    // Wheels on the surrounding column (label, sort chips) drive the picker
+    // programmatically.
     if (picker && picker.contains(e.target)) return;
 
     e.preventDefault();

--- a/docs/app.js
+++ b/docs/app.js
@@ -434,6 +434,8 @@ function buildSlabHTML(p) {
     </div>
     <p class="slab-desc" id="slabDesc"></p>
 
+    <div class="slab-trend" id="slabTrend"></div>
+
     <div class="slab-install">
       <span class="prefix" aria-hidden="true">$</span>
       <span class="cmd" id="slabCmd"></span><span class="caret" aria-hidden="true"></span>
@@ -495,7 +497,98 @@ function animateSlab(p) {
 
   renderBench(p);
   renderSizes(p);
+  renderTrend(p);
   wireReadme(p);
+}
+
+// Per-package perf history lives in docs/history/<name>.jsonl, one entry
+// per commit. Each entry has a list of suites, where ratio = amigo/competitor
+// (null when there's no comparable competitor). We aggregate per-commit by
+// geomean of the available ratios and plot the sequence as an inline sparkline.
+const _historyCache = {};
+async function loadHistory(name) {
+  if (_historyCache[name] !== undefined) return _historyCache[name];
+  try {
+    const res = await fetch(`history/${name}.jsonl`);
+    if (!res.ok) throw new Error(res.statusText);
+    const txt = await res.text();
+    const lines = txt.split('\n').map(l => l.trim()).filter(Boolean);
+    const entries = [];
+    for (const line of lines) {
+      try {
+        const e = JSON.parse(line);
+        const ratios = (e.suites || [])
+          .map(s => typeof s.ratio === 'number' ? s.ratio : null)
+          .filter(r => r !== null && r > 0 && isFinite(r));
+        if (!ratios.length) continue;
+        const logSum = ratios.reduce((a, r) => a + Math.log(r), 0);
+        const geomean = Math.exp(logSum / ratios.length);
+        entries.push({ commit: e.commit, date: e.date, geomean });
+      } catch { /* skip malformed line */ }
+    }
+    _historyCache[name] = entries;
+    return entries;
+  } catch {
+    _historyCache[name] = [];
+    return [];
+  }
+}
+
+function buildSparkline(values, width = 96, height = 24) {
+  if (!values.length) return '';
+  const min = Math.min(...values, 1);
+  const max = Math.max(...values, 1);
+  const span = max - min || 1;
+  const padY = 3;
+  const usableH = height - padY * 2;
+  const stepX = values.length > 1 ? width / (values.length - 1) : 0;
+  const points = values.map((v, i) => {
+    const x = stepX * i;
+    const y = padY + (1 - (v - min) / span) * usableH;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  }).join(' ');
+  const last = values[values.length - 1];
+  const lastX = stepX * (values.length - 1);
+  const lastY = padY + (1 - (last - min) / span) * usableH;
+  return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="trend sparkline">
+    <polyline points="${points}" fill="none" stroke="var(--accent)" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>
+    <circle cx="${lastX.toFixed(1)}" cy="${lastY.toFixed(1)}" r="2" fill="var(--accent)"/>
+  </svg>`;
+}
+
+async function renderTrend(pkg) {
+  const host = $('#slabTrend');
+  if (!host) return;
+  host.classList.add('empty');
+  host.innerHTML = '<span class="label">trend</span><span>loading…</span>';
+
+  const entries = await loadHistory(pkg.name);
+  // The slab might have re-rendered while we were fetching; bail if so.
+  if ($('#slabTrend') !== host) return;
+
+  if (!entries.length) {
+    host.innerHTML = '<span class="label">trend</span><span>no history yet</span>';
+    return;
+  }
+
+  host.classList.remove('empty');
+  const values = entries.map(e => e.geomean);
+  const first = values[0];
+  const last = values[values.length - 1];
+  const pct = first > 0 ? ((last - first) / first) * 100 : 0;
+  let arrow = '→', cls = 'flat';
+  if (pct > 5) { arrow = '↑'; cls = 'up'; }
+  else if (pct < -5) { arrow = '↓'; cls = 'down'; }
+  const sign = pct >= 0 ? '+' : '';
+  const sparkline = buildSparkline(values);
+  const latest = `<span class="latest">${last.toFixed(2)}×</span>`;
+
+  host.innerHTML = `
+    <span class="label">trend · ${entries.length} runs</span>
+    ${sparkline}
+    <span>geomean ${latest}</span>
+    <span class="delta ${cls}" aria-label="trend ${cls}">${arrow} ${sign}${pct.toFixed(1)}%</span>
+  `;
 }
 
 // Try the modern clipboard API; fall back to the legacy execCommand path

--- a/docs/app.js
+++ b/docs/app.js
@@ -122,7 +122,6 @@ async function boot() {
 
   renderBrand();
   renderMarquee();
-  renderFooter();
   renderPicker();
   wireSortChips();
   cycleHeroTagline();
@@ -162,8 +161,6 @@ function renderMarquee() {
     .map(i => `<div class="marquee-item">${i.k}<span>${i.v}</span></div>`).join('');
   $('#marqueeTrack').innerHTML = html;
 }
-
-function renderFooter() { /* merged into renderBrand */ }
 
 // --- hero tagline typewriter ---
 function cycleHeroTagline() {
@@ -214,9 +211,9 @@ function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
 function renderPicker() {
   const picker = $('#picker');
   picker.innerHTML = state.sortedList.map((p, i) => `
-    <li id="pkg-opt-${p.name}" role="option" data-idx="${i}" data-name="${p.name}" aria-selected="false">
+    <li id="pkg-opt-${p.name}" role="option" data-idx="${i}" data-name="${p.name}" aria-selected="false" tabindex="-1">
       <span>${p.name}</span>
-      <span class="arrow">&larr;</span>
+      <span class="arrow" aria-hidden="true">&larr;</span>
     </li>
   `).join('');
 
@@ -328,6 +325,19 @@ function updateActiveClass() {
   picker.setAttribute('aria-activedescendant', activeId);
 }
 
+// When the user is arrow-navigating from inside the listbox, keep the visible
+// focus ring on the active option. We don't steal focus when arrows fire from
+// elsewhere in the page (e.g. global hotkeys with body focused).
+function focusActiveOptionIfInPicker() {
+  const picker = $('#picker');
+  if (!picker) return;
+  const active = document.activeElement;
+  const isInPicker = active === picker || (active instanceof Node && picker.contains(active));
+  if (!isInPicker) return;
+  const li = picker.querySelectorAll('li')[state.activeIdx];
+  if (li) li.focus({ preventScroll: true });
+}
+
 function updateHash() {
   const p = state.sortedList[state.activeIdx];
   if (p) history.replaceState(null, '', '#' + p.name);
@@ -340,6 +350,11 @@ function renderSlab() {
   const slab = $('#slab');
   clearTimers();
 
+  // Announce the new package to assistive tech via the persistent live region.
+  // Updating its text content (vs. re-rendering it) is what makes SRs read it.
+  const announce = $('#slabAnnounce');
+  if (announce) announce.textContent = `${p.name} — ${p.speedup}`;
+
   slab.classList.add('fading');
   setTimeout(() => {
     slab.innerHTML = buildSlabHTML(p);
@@ -349,6 +364,7 @@ function renderSlab() {
 }
 
 function buildSlabHTML(p) {
+  const newTabSr = '<span class="visually-hidden"> (opens in new tab)</span>';
   return `
     <div class="slab-head">
       <div class="slab-name"><span class="scope">@amigo-labs/</span><span id="slabName">${p.name}</span></div>
@@ -357,24 +373,32 @@ function buildSlabHTML(p) {
     <p class="slab-desc" id="slabDesc"></p>
 
     <div class="slab-install">
-      <span class="prefix">$</span>
+      <span class="prefix" aria-hidden="true">$</span>
       <span class="cmd" id="slabCmd"></span><span class="caret" aria-hidden="true"></span>
-      <button class="copy-btn" type="button" id="slabCopy">Copy</button>
+      <button class="copy-btn" type="button" id="slabCopy" aria-label="Copy install command">Copy</button>
     </div>
 
     <div class="slab-links">
-      <a href="${p.npmUrl}" target="_blank" rel="noopener">npm &nearr;</a>
-      <a href="${p.sourceUrl}" target="_blank" rel="noopener">source &nearr;</a>
-      <a href="${p.readmeUrl}" target="_blank" rel="noopener">readme &nearr;</a>
+      <a href="${p.npmUrl}" target="_blank" rel="noopener noreferrer">npm <span aria-hidden="true">&nearr;</span>${newTabSr}</a>
+      <a href="${p.sourceUrl}" target="_blank" rel="noopener noreferrer">source <span aria-hidden="true">&nearr;</span>${newTabSr}</a>
+      <a href="${p.readmeUrl}" target="_blank" rel="noopener noreferrer">readme <span aria-hidden="true">&nearr;</span>${newTabSr}</a>
     </div>
 
     <div class="slab-grid">
       <div class="slab-col">
         <div class="slab-col-head">Benchmarks (ops/s)</div>
+        <div class="chart-legend" aria-hidden="true">
+          <span><span class="swatch amigo"></span>amigo-labs</span>
+          <span><span class="swatch competitor"></span>competitor</span>
+        </div>
         <div id="slabBench"></div>
       </div>
       <div class="slab-col">
         <div class="slab-col-head">Install footprint</div>
+        <div class="chart-legend" aria-hidden="true">
+          <span><span class="swatch amigo"></span>amigo-labs</span>
+          <span><span class="swatch competitor"></span>competitor</span>
+        </div>
         <div id="slabSizes"></div>
       </div>
     </div>
@@ -413,7 +437,7 @@ function wireReadme(pkg) {
   let loaded = false;
   details.addEventListener('toggle', async () => {
     if (!details.open || loaded) return;
-    host.innerHTML = '<div class="readme-loading">Loading…</div>';
+    host.innerHTML = '<div class="readme-skeleton" aria-label="Loading README"><div class="line"></div><div class="line"></div><div class="line"></div></div>';
     try {
       const res = await fetch(`readmes/${pkg.name}.html`);
       if (!res.ok) throw new Error(res.statusText);
@@ -432,12 +456,12 @@ function wireReadme(pkg) {
 function renderBench(pkg) {
   const host = $('#slabBench');
   if (!state.data?.benchmarks?.suites) {
-    host.innerHTML = '<div style="color:var(--text-tertiary);font-size:.75rem">No benchmark data available.</div>';
+    host.innerHTML = '<div class="empty-state">No benchmark data available.</div>';
     return;
   }
   const suites = state.data.benchmarks.suites.filter(s => suiteCrate(s) === pkg.name);
   if (!suites.length) {
-    host.innerHTML = '<div style="color:var(--text-tertiary);font-size:.75rem">No benchmarks for this package yet.</div>';
+    host.innerHTML = '<div class="empty-state">No benchmarks for this package yet.</div>';
     return;
   }
   let html = '';
@@ -459,9 +483,10 @@ function renderBench(pkg) {
         const second = sorted.find(e => !e.name.includes('@amigo'));
         if (second) ratio = `<span class="ratio">${(entry.hz / second.hz).toFixed(1)}&times;</span>`;
       }
+      const tag = isAmigo ? '<span class="amigo-tag" aria-hidden="true">amigo</span>' : '';
       html += `
         <div class="bar-row">
-          <span class="label${labelCls}">${entry.name}</span>
+          <span class="label${labelCls}">${tag}${entry.name}</span>
           <span class="val" data-hz="${entry.hz}">0</span>${ratio}
           <div class="track"><div class="fill ${fillCls}" data-pct="${pct}" style="width:0%"></div></div>
         </div>`;
@@ -485,7 +510,7 @@ function renderSizes(pkg) {
   const host = $('#slabSizes');
   const sizes = state.data?.sizes?.[pkg.name];
   if (!sizes) {
-    host.innerHTML = '<div style="color:var(--text-tertiary);font-size:.75rem">No size data.</div>';
+    host.innerHTML = '<div class="empty-state">No size data.</div>';
     return;
   }
   const amigoKey = '@amigo-labs/' + pkg.name;
@@ -508,9 +533,10 @@ function renderSizes(pkg) {
         ratio = `<span class="ratio">${(largestCompetitor / size).toFixed(1)}&times;</span>`;
       }
     }
+    const tag = isAmigo ? '<span class="amigo-tag" aria-hidden="true">amigo</span>' : '';
     html += `
       <div class="bar-row">
-        <span class="label${labelCls}">${name}</span>
+        <span class="label${labelCls}">${tag}${name}</span>
         <span class="val" data-bytes="${size}">0</span>${ratio}
         <div class="track"><div class="fill ${fillCls}" data-pct="${pct}" style="width:0%"></div></div>
       </div>`;
@@ -536,7 +562,7 @@ function wireSortChips() {
       if (mode === state.sortMode) return;
       state.sortMode = mode;
       document.querySelectorAll('.sort-chips .chip').forEach(c => {
-        c.setAttribute('aria-selected', c.dataset.sort === mode ? 'true' : 'false');
+        c.setAttribute('aria-pressed', c.dataset.sort === mode ? 'true' : 'false');
       });
       const keepName = state.activeName;
       computeSortedList();
@@ -562,17 +588,19 @@ function wireKeyboard() {
     const n = state.sortedList.length;
     if (e.key === 'ArrowDown' || e.key === 'ArrowRight' || e.key === 'j') {
       snapTo((state.activeIdx + 1) % n, true);
+      focusActiveOptionIfInPicker();
       e.preventDefault();
     } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft' || e.key === 'k') {
       snapTo((state.activeIdx - 1 + n) % n, true);
+      focusActiveOptionIfInPicker();
       e.preventDefault();
     } else if (e.key === 'c') {
       const btn = document.getElementById('slabCopy');
       if (btn) btn.click();
     } else if (e.key === 'Home') {
-      snapTo(0, true); e.preventDefault();
+      snapTo(0, true); focusActiveOptionIfInPicker(); e.preventDefault();
     } else if (e.key === 'End') {
-      snapTo(n - 1, true); e.preventDefault();
+      snapTo(n - 1, true); focusActiveOptionIfInPicker(); e.preventDefault();
     }
   });
 }

--- a/docs/app.js
+++ b/docs/app.js
@@ -117,6 +117,15 @@ function countUp(el, from, to, duration = 400, formatter = v => v) {
   }
   requestAnimationFrame(tick);
 }
+function formatSpeedupShort(n) {
+  // Compact form for picker rows: 1.4×, 11×, 31×. Drop the decimal once
+  // the value is comfortably above 10× — at that scale the .1 rounding is
+  // visual noise.
+  if (!isFinite(n) || n <= 0) return '';
+  if (n >= 10) return Math.round(n) + '×';
+  return n.toFixed(1).replace(/\.0$/, '') + '×';
+}
+
 function formatOps(hz) {
   if (hz >= 1e6) return (hz / 1e6).toFixed(2) + 'M';
   if (hz >= 1e3) return (hz / 1e3).toFixed(1) + 'K';
@@ -241,12 +250,19 @@ function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
 // --- picker ---
 function renderPicker() {
   const picker = $('#picker');
-  picker.innerHTML = state.sortedList.map((p, i) => `
-    <li id="pkg-opt-${p.name}" role="option" data-idx="${i}" data-name="${p.name}" aria-selected="false" tabindex="-1">
-      <span>${p.name}</span>
-      <span class="arrow" aria-hidden="true">&larr;</span>
-    </li>
-  `).join('');
+  picker.innerHTML = state.sortedList.map((p, i) => {
+    const speed = parseMaxSpeedup(p.speedup);
+    const speedTag = speed > 0
+      ? `<span class="row-speed" aria-hidden="true">${formatSpeedupShort(speed)}</span>`
+      : '';
+    return `
+      <li id="pkg-opt-${p.name}" role="option" data-idx="${i}" data-name="${p.name}" aria-selected="false" tabindex="-1">
+        <span class="row-name">${p.name}</span>
+        ${speedTag}
+        <span class="arrow" aria-hidden="true">←</span>
+      </li>
+    `;
+  }).join('');
 
   // mobile still needs horizontal center-snap padding; desktop is a flat top-aligned list
   const updatePadding = () => {

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0A0B0D"/>
+  <path d="M14 44 L26 18 L38 44 M19 36 L33 36" fill="none" stroke="#E8E6E2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="48" cy="44" r="5" fill="#FF6B2B"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -72,14 +72,20 @@
   <main class="dashboard">
     <div class="picker-wrap">
       <div class="picker-head">
-        <div class="picker-label" id="pickerLabel">Packages</div>
+        <div class="picker-label" id="pickerLabel">Packages <span class="picker-count" id="pickerCount" aria-hidden="true"></span></div>
         <div class="sort-chips" role="group" aria-label="Sort packages">
           <button class="chip" type="button" data-sort="speedup" aria-pressed="true">Speedup</button>
           <button class="chip" type="button" data-sort="alpha" aria-pressed="false">A&ndash;Z</button>
           <button class="chip" type="button" data-sort="size" aria-pressed="false">Size</button>
         </div>
       </div>
+      <div class="picker-search">
+        <input type="search" id="pkgFilter" placeholder="filter packages…" autocomplete="off" spellcheck="false" aria-label="Filter packages by name or description">
+        <span class="picker-search-hint" aria-hidden="true"><kbd>/</kbd></span>
+      </div>
+      <div class="category-chips" role="group" aria-label="Filter by category" id="categoryChips"></div>
       <ul class="picker" id="picker" role="listbox" aria-labelledby="pickerLabel" tabindex="0" aria-activedescendant=""></ul>
+      <div class="picker-empty empty-state" id="pickerEmpty" hidden>No packages match.</div>
     </div>
     <section class="slab" id="slab"></section>
     <div id="slabAnnounce" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,8 +11,10 @@
 </head>
 <body>
 
-<div class="bg-grid"></div>
-<div class="ambient-aura"></div>
+<a class="skip-link" href="#picker">Skip to packages</a>
+
+<div class="bg-grid" aria-hidden="true"></div>
+<div class="ambient-aura" aria-hidden="true"></div>
 
 <div class="app">
 
@@ -20,7 +22,7 @@
     <img src="logo.png" alt="" class="hero-logo">
     <div class="hero-text">
       <h1 id="brandName">amigo-<span>native</span></h1>
-      <div class="hero-tagline"><span class="prefix">&gt;</span><span id="heroTagline"></span><span class="caret"></span></div>
+      <div class="hero-tagline"><span class="prefix" aria-hidden="true">&gt;</span><span id="heroTagline"></span><span class="caret" aria-hidden="true"></span></div>
     </div>
     <a href="https://github.com/amigo-labs/amigo-native" class="hero-repo" id="heroRepo" target="_blank" rel="noopener">
       <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -28,21 +30,22 @@
     </a>
   </header>
 
-  <div class="marquee"><div class="marquee-track" id="marqueeTrack"></div></div>
+  <div class="marquee" aria-hidden="true"><div class="marquee-track" id="marqueeTrack"></div></div>
 
   <main class="dashboard">
     <div class="picker-wrap">
       <div class="picker-head">
-        <div class="picker-label">Packages</div>
-        <div class="sort-chips" role="tablist" aria-label="Sort packages">
-          <button class="chip" role="tab" data-sort="speedup" aria-selected="true">Speedup</button>
-          <button class="chip" role="tab" data-sort="alpha" aria-selected="false">A&ndash;Z</button>
-          <button class="chip" role="tab" data-sort="size" aria-selected="false">Size</button>
+        <div class="picker-label" id="pickerLabel">Packages</div>
+        <div class="sort-chips" role="group" aria-label="Sort packages">
+          <button class="chip" type="button" data-sort="speedup" aria-pressed="true">Speedup</button>
+          <button class="chip" type="button" data-sort="alpha" aria-pressed="false">A&ndash;Z</button>
+          <button class="chip" type="button" data-sort="size" aria-pressed="false">Size</button>
         </div>
       </div>
-      <ul class="picker" id="picker" role="listbox" aria-label="Select a package" tabindex="0" aria-activedescendant=""></ul>
+      <ul class="picker" id="picker" role="listbox" aria-labelledby="pickerLabel" tabindex="0" aria-activedescendant=""></ul>
     </div>
-    <section class="slab" id="slab" aria-live="polite"></section>
+    <section class="slab" id="slab"></section>
+    <div id="slabAnnounce" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
   </main>
 
   <footer class="footer">

--- a/docs/index.html
+++ b/docs/index.html
@@ -92,7 +92,15 @@
   </main>
 
   <footer class="footer">
-    <div><a href="https://github.com/amigo-labs/amigo-native" id="footerRepo" target="_blank" rel="noopener">amigo-labs/amigo-native</a> &middot; <span id="footerLicense">MIT License</span></div>
+    <div class="footer-links">
+      <a href="https://github.com/amigo-labs/amigo-native" id="footerRepo" target="_blank" rel="noopener noreferrer">amigo-labs/amigo-native</a>
+      <span class="sep" aria-hidden="true">·</span>
+      <span id="footerLicense">MIT License</span>
+      <span class="sep" aria-hidden="true">·</span>
+      <a href="https://github.com/amigo-labs/amigo-native/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">contributing</a>
+      <span class="sep" aria-hidden="true">·</span>
+      <a href="https://github.com/amigo-labs/amigo-native/blob/main/BACKLOG.md" target="_blank" rel="noopener noreferrer">backlog</a>
+    </div>
     <div id="footerMeta"></div>
   </footer>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -92,7 +92,12 @@
 
 </div>
 
-<div class="kbd-hint"><kbd>&uarr;</kbd><kbd>&darr;</kbd> switch &middot; <kbd>c</kbd> copy</div>
+<div class="kbd-hint" aria-label="Keyboard shortcuts">
+  <kbd>&uarr;</kbd><kbd>&darr;</kbd> switch &middot;
+  <kbd>Home</kbd>/<kbd>End</kbd> jump &middot;
+  <kbd>c</kbd> copy &middot;
+  <kbd>/</kbd> filter
+</div>
 
 <script src="app.js" defer></script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,44 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="dark">
+<meta name="theme-color" content="#FF6B2B">
 <title>amigo-native | Rust-powered Node.js packages</title>
+<meta name="description" content="Rust-powered drop-in replacements for popular Node.js packages. Compiled to native addons via NAPI-RS, prebuilt for every major platform, zero transitive dependencies.">
+
+<link rel="canonical" href="https://amigo-labs.github.io/amigo-native/">
+<link rel="icon" type="image/svg+xml" href="favicon.svg">
+<link rel="alternate icon" type="image/png" href="logo.png">
+<link rel="apple-touch-icon" href="logo.png">
+
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="amigo-native">
+<meta property="og:title" content="amigo-native — Rust-powered Node.js packages">
+<meta property="og:description" content="Drop-in replacements for popular Node.js packages, compiled to native via NAPI-RS. Prebuilt for every major platform. Zero transitive dependencies.">
+<meta property="og:url" content="https://amigo-labs.github.io/amigo-native/">
+<meta property="og:image" content="https://amigo-labs.github.io/amigo-native/logo.png">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="amigo-native — Rust-powered Node.js packages">
+<meta name="twitter:description" content="Drop-in replacements for popular Node.js packages, compiled to native via NAPI-RS. Zero transitive dependencies.">
+<meta name="twitter:image" content="https://amigo-labs.github.io/amigo-native/logo.png">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "name": "amigo-native",
+  "description": "Rust-powered drop-in replacements for popular Node.js packages.",
+  "codeRepository": "https://github.com/amigo-labs/amigo-native",
+  "programmingLanguage": ["Rust", "JavaScript", "TypeScript"],
+  "license": "https://opensource.org/licenses/MIT",
+  "author": {
+    "@type": "Organization",
+    "name": "amigo-labs",
+    "url": "https://github.com/amigo-labs"
+  }
+}
+</script>
+
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
@@ -57,6 +94,6 @@
 
 <div class="kbd-hint"><kbd>&uarr;</kbd><kbd>&darr;</kbd> switch &middot; <kbd>c</kbd> copy</div>
 
-<script src="app.js"></script>
+<script src="app.js" defer></script>
 </body>
 </html>

--- a/docs/packages.json
+++ b/docs/packages.json
@@ -56,6 +56,7 @@
     {
       "name": "argon2",
       "title": "Argon2",
+      "category": "crypto",
       "description": "Argon2id password hashing with sync + async API.",
       "speedup": "1.35× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/argon2",
@@ -65,6 +66,7 @@
     {
       "name": "bcrypt",
       "title": "Bcrypt",
+      "category": "crypto",
       "description": "Bcrypt password hashing with sync + async API. Argon2 sibling.",
       "speedup": "up to 1.07× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/bcrypt",
@@ -74,6 +76,7 @@
     {
       "name": "bm25",
       "title": "BM25",
+      "category": "search",
       "description": "BM25 full-text search. Stateful NAPI class — build index once, query many times.",
       "speedup": "14× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/bm25",
@@ -83,6 +86,7 @@
     {
       "name": "commonmark",
       "title": "CommonMark",
+      "category": "text",
       "description": "CommonMark + GFM renderer powered by pulldown-cmark.",
       "speedup": "6.7× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/commonmark",
@@ -92,6 +96,7 @@
     {
       "name": "csv",
       "title": "CSV",
+      "category": "document",
       "description": "CSV parsing and serialization via BurntSushi's csv crate.",
       "speedup": "1.49–1.98× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/csv",
@@ -101,6 +106,7 @@
     {
       "name": "deepmerge",
       "title": "Deepmerge",
+      "category": "util",
       "description": "Recursive object merge for JSON-safe values.",
       "speedup": "3–6.2× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/deepmerge",
@@ -110,6 +116,7 @@
     {
       "name": "diff",
       "title": "Diff",
+      "category": "util",
       "description": "Myers/Patience diff via `similar`. Drop-in-shape with an offset-packed hot-path for char-level and large-input cases.",
       "speedup": "11–23× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/diff",
@@ -119,6 +126,7 @@
     {
       "name": "encoding",
       "title": "Encoding",
+      "category": "text",
       "description": "Character encoding conversion powered by Mozilla's encoding_rs.",
       "speedup": "up to 33× faster / 1.59× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/encoding",
@@ -128,6 +136,7 @@
     {
       "name": "file-type",
       "title": "File Type",
+      "category": "util",
       "description": "Magic-byte file-type detection via the Rust infer crate.",
       "speedup": "28× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/file-type",
@@ -137,6 +146,7 @@
     {
       "name": "force-layout",
       "title": "Force Layout",
+      "category": "graph",
       "description": "Force-directed graph simulation. Batch-mode d3-force replacement for SSR / precompute workloads.",
       "speedup": "3.5–6.6× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/force-layout",
@@ -146,6 +156,7 @@
     {
       "name": "graph-layout",
       "title": "Graph Layout",
+      "category": "graph",
       "description": "Hierarchical (Sugiyama-style) DAG layout. Single-call spec → positions + edge routing.",
       "speedup": "31–66× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/graph-layout",
@@ -155,6 +166,7 @@
     {
       "name": "inflate",
       "title": "Inflate",
+      "category": "archive",
       "description": "zlib deflate/inflate/gzip powered by flate2 + zlib-rs.",
       "speedup": "up to 11× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/inflate",
@@ -164,6 +176,7 @@
     {
       "name": "jose",
       "title": "JOSE",
+      "category": "crypto",
       "description": "Ed25519 JWK generation and RFC 7638 thumbprints. JWE roadmap.",
       "speedup": "1.53–4.1× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/jose",
@@ -173,6 +186,7 @@
     {
       "name": "jwt",
       "title": "JWT",
+      "category": "crypto",
       "description": "JWT sign, verify, and decode via the jsonwebtoken Rust crate.",
       "speedup": "up to 7.9× faster / 3.5× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/jwt",
@@ -182,6 +196,7 @@
     {
       "name": "language-detect",
       "title": "Language Detect",
+      "category": "text",
       "description": "Language detection powered by whatlang. Paragraph-size Green, short-string Red by design.",
       "speedup": "3–16× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/language-detect",
@@ -191,6 +206,7 @@
     {
       "name": "minisearch",
       "title": "Minisearch",
+      "category": "search",
       "description": "Tiny in-memory full-text search with prefix autocomplete. Shares Rust search-core with @amigo-labs/bm25.",
       "speedup": "1.23–51× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/minisearch",
@@ -200,6 +216,7 @@
     {
       "name": "nanoid",
       "title": "NanoID",
+      "category": "crypto",
       "description": "Fast crypto-safe URL-friendly ID generator with pool-amortised entropy. Pure JS — the NAPI FFI boundary was bigger than the entire ID-generation path.",
       "speedup": "up to 1.11× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/nanoid",
@@ -209,6 +226,7 @@
     {
       "name": "pdf",
       "title": "PDF",
+      "category": "document",
       "description": "PDF generation — one FFI call per document. Labels / tickets / simple reports.",
       "speedup": "TBD",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/pdf",
@@ -218,6 +236,7 @@
     {
       "name": "pdf-parse",
       "title": "PDF Parse",
+      "category": "document",
       "description": "PDF text + metadata extraction via pdf-extract/lopdf. No pdf.js, no browser pipeline.",
       "speedup": "up to 2.5× faster / 2.2× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/pdf-parse",
@@ -227,6 +246,7 @@
     {
       "name": "sanitize-html",
       "title": "Sanitize HTML",
+      "category": "text",
       "description": "HTML sanitization via Mozilla's ammonia engine.",
       "speedup": "1.7–4.1× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/sanitize-html",
@@ -236,6 +256,7 @@
     {
       "name": "sentences",
       "title": "Sentences",
+      "category": "text",
       "description": "Multi-language sentence boundary detection. String or offset-packed output for hot paths.",
       "speedup": "TBD",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/sentences",
@@ -245,6 +266,7 @@
     {
       "name": "slugify",
       "title": "Slugify",
+      "category": "text",
       "description": "Unicode-aware slugification. Wraps deunicode + unicode-normalization.",
       "speedup": "2.4–5.3× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/slugify",
@@ -254,6 +276,7 @@
     {
       "name": "stemmer",
       "title": "Stemmer",
+      "category": "text",
       "description": "Porter/Snowball stemming via rust-stemmers. Batch-only API — single-word calls are intentionally not exposed.",
       "speedup": "7.1–8.3× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/stemmer",
@@ -263,6 +286,7 @@
     {
       "name": "svgo",
       "title": "Svgo",
+      "category": "document",
       "description": "SVG optimizer via quick-xml. Ships the 8 highest-impact `preset-default` plugins.",
       "speedup": "15–27× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/svgo",
@@ -272,6 +296,7 @@
     {
       "name": "text-splitters",
       "title": "Text Splitters",
+      "category": "text",
       "description": "RAG text splitters (recursive-character + markdown-aware), with native tiktoken length.",
       "speedup": "up to 2.5× faster / 4.6× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/text-splitters",
@@ -281,6 +306,7 @@
     {
       "name": "tiktoken",
       "title": "Tiktoken",
+      "category": "text",
       "description": "OpenAI BPE tokenizer powered by tiktoken-rs. Drop-in for tiktoken (WASM) and js-tiktoken.",
       "speedup": "3.2–3.8× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/tiktoken",
@@ -290,6 +316,7 @@
     {
       "name": "turndown",
       "title": "Turndown",
+      "category": "text",
       "description": "HTML → Markdown via html5ever. Ships CommonMark + GFM tables/strikethrough.",
       "speedup": "9.7–16× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/turndown",
@@ -299,6 +326,7 @@
     {
       "name": "typst",
       "title": "Typst",
+      "category": "document",
       "description": "Typst document compiler — source in, PDF out. Bundled Libertinus fonts; offline-only packages.",
       "speedup": "TBD",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/typst",
@@ -308,6 +336,7 @@
     {
       "name": "xlsx",
       "title": "XLSX",
+      "category": "document",
       "description": "XLSX read + write. Buffer in → rows out, rows in → Buffer out. Single-FFI-crossing.",
       "speedup": "2.3–3× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/xlsx",
@@ -317,6 +346,7 @@
     {
       "name": "xxhash",
       "title": "XXHash",
+      "category": "crypto",
       "description": "XXH32, XXH64, and XXH3 with batch + streaming support.",
       "speedup": "up to 2.7× faster / 2.9× slower",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/xxhash",
@@ -326,6 +356,7 @@
     {
       "name": "zip",
       "title": "ZIP",
+      "category": "archive",
       "description": "ZIP archive read/write via the zip Rust crate.",
       "speedup": "1.85–8.8× faster",
       "npmUrl": "https://www.npmjs.com/package/@amigo-labs/zip",

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -6,7 +6,7 @@
   --border-hover: #3B444E;
   --text-primary: #E8E6E2;
   --text-secondary: #8B8D91;
-  --text-tertiary: #4A4D52;
+  --text-tertiary: #6B6E73;
   --accent: #FF6B2B;
   --accent-hot: #FF8A3D;
   --accent-glow: rgba(255, 107, 43, 0.25);
@@ -28,6 +28,46 @@ body {
 ::selection { background: var(--accent); color: var(--bg); }
 a { color: var(--text-secondary); text-decoration: none; transition: color 0.2s; }
 a:hover { color: var(--text-primary); }
+
+/* Visible focus for keyboard users. Pointer focus stays unstyled via :focus-visible. */
+:focus { outline: none; }
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+.picker:focus-visible { outline-offset: 4px; }
+.picker li:focus-visible { outline-offset: -2px; }
+
+/* Visually hidden — keeps content for screen readers, hides for sighted users. */
+.visually-hidden {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
+}
+
+/* Skip link — first tab stop, jumps past decorative chrome. */
+.skip-link {
+  position: absolute;
+  top: -100px; left: 8px;
+  z-index: 1000;
+  padding: 8px 14px;
+  background: var(--accent); color: var(--bg);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem; font-weight: 600;
+  border-radius: 6px;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  transition: top 0.15s ease;
+}
+.skip-link:focus,
+.skip-link:focus-visible {
+  top: 8px;
+  outline: 2px solid var(--text-primary);
+  outline-offset: 2px;
+  color: var(--bg);
+}
 
 .bg-grid {
   position: fixed; inset: 0; z-index: -2; pointer-events: none;
@@ -160,7 +200,7 @@ a:hover { color: var(--text-primary); }
   text-transform: uppercase;
 }
 .chip:hover { color: var(--text-secondary); border-color: var(--border-hover); }
-.chip[aria-selected="true"] {
+.chip[aria-pressed="true"] {
   color: var(--accent);
   border-color: var(--accent);
   background: var(--accent-dim);
@@ -319,6 +359,47 @@ a:hover { color: var(--text-primary); }
 .bar-row .fill.competitor { background: var(--text-tertiary); }
 .bar-row .val { color: var(--text-primary); text-align: right; white-space: nowrap; }
 .bar-row .ratio { color: var(--ok); font-size: 0.7rem; margin-left: 6px; }
+.bar-row .label .amigo-tag {
+  display: inline-block;
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  background: var(--accent-dim);
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-right: 6px;
+  vertical-align: 1px;
+  text-transform: uppercase;
+}
+
+.chart-legend {
+  display: flex;
+  gap: 14px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+.chart-legend .swatch {
+  display: inline-block;
+  width: 10px; height: 4px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.chart-legend .swatch.amigo { background: var(--accent); }
+.chart-legend .swatch.competitor { background: var(--text-tertiary); }
+
+/* Reusable empty-state for missing benches / sizes / filter no-match. */
+.empty-state {
+  color: var(--text-tertiary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  padding: 8px 0;
+}
 
 .slab-links {
   display: flex; gap: 18px;
@@ -422,6 +503,33 @@ a:hover { color: var(--text-primary); }
 }
 .readme-error { color: var(--accent); }
 
+/* Loading skeleton — three shimmer lines while fetching the README. */
+.readme-skeleton {
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.readme-skeleton .line {
+  height: 10px;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    rgba(232,230,226,0.04) 0%,
+    rgba(232,230,226,0.10) 50%,
+    rgba(232,230,226,0.04) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+.readme-skeleton .line:nth-child(1) { width: 90%; }
+.readme-skeleton .line:nth-child(2) { width: 75%; }
+.readme-skeleton .line:nth-child(3) { width: 60%; }
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
 .footer {
   display: flex; justify-content: space-between;
   gap: 16px; flex-wrap: wrap;
@@ -495,6 +603,7 @@ a:hover { color: var(--text-primary); }
     padding: 8px 14px; font-size: 0.85rem;
   }
   .picker li.active { font-size: 0.95rem; border-bottom-color: var(--accent); }
+  .picker li .arrow { display: none; }
 
   .slab { padding: 18px; overflow-x: hidden; overflow-y: visible; border-radius: 12px; min-width: 0; max-width: 100%; }
   .slab-head { gap: 10px; flex-wrap: wrap; max-width: 100%; }
@@ -534,4 +643,18 @@ a:hover { color: var(--text-primary); }
     transition-duration: 0.01ms !important;
   }
   .bar-row .fill { transition: none; }
+  .readme-skeleton .line {
+    animation: none;
+    background: rgba(232,230,226,0.07);
+  }
+}
+
+@media (prefers-contrast: more) {
+  :root {
+    --text-tertiary: #B0B3B8;
+    --text-secondary: #D4D6DA;
+    --border: var(--border-hover);
+  }
+  .ambient-aura, .bg-grid { display: none; }
+  .bar-row .fill.competitor { background: var(--text-secondary); }
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -116,7 +116,10 @@ a:hover { color: var(--text-primary); }
   font-weight: 500; letter-spacing: -0.04em;
   line-height: 1; text-transform: lowercase;
 }
-.hero h1 span { color: var(--accent); }
+.hero h1 span {
+  color: var(--accent);
+  text-shadow: 0 0 24px var(--accent-glow);
+}
 .hero-tagline {
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.8rem; color: var(--text-secondary);
@@ -275,12 +278,24 @@ a:hover { color: var(--text-primary); }
 .picker::-webkit-scrollbar { display: none; }
 .picker li {
   padding: 10px 14px; cursor: pointer;
-  display: flex; align-items: center; justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  column-gap: 10px;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.95rem; color: var(--text-tertiary);
   transition: color 0.15s ease, border-color 0.15s ease;
   border-left: 2px solid transparent;
   user-select: none;
+}
+.picker li .row-name {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.picker li .row-speed {
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0;
+  flex-shrink: 0;
 }
 .picker li:hover { color: var(--text-secondary); }
 .picker li.active {
@@ -288,6 +303,7 @@ a:hover { color: var(--text-primary); }
   border-left-color: var(--accent);
   text-shadow: 0 0 24px var(--accent-glow);
 }
+.picker li.active .row-speed { color: var(--accent); opacity: 0.85; }
 .picker li .arrow { opacity: 0; transition: opacity 0.2s; color: var(--accent); }
 .picker li.active .arrow { opacity: 1; }
 
@@ -660,6 +676,7 @@ a:hover { color: var(--text-primary); }
   display: flex; justify-content: space-between;
   gap: 16px; flex-wrap: wrap;
   padding: 12px 0;
+  padding-bottom: max(12px, env(safe-area-inset-bottom));
   border-top: 1px solid var(--border);
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.7rem; color: var(--text-tertiary);
@@ -667,9 +684,21 @@ a:hover { color: var(--text-primary); }
 }
 .footer a { color: var(--text-tertiary); }
 .footer a:hover { color: var(--accent); }
+.footer .footer-links {
+  display: inline-flex;
+  gap: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.footer .sep {
+  color: var(--text-tertiary);
+  opacity: 0.6;
+}
 
 .kbd-hint {
-  position: fixed; bottom: 16px; right: 16px;
+  position: fixed;
+  bottom: max(16px, env(safe-area-inset-bottom));
+  right: max(16px, env(safe-area-inset-right));
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.65rem; color: var(--text-tertiary);
   letter-spacing: 0.08em; opacity: 0.6;
@@ -677,6 +706,7 @@ a:hover { color: var(--text-primary); }
   background: rgba(19,22,26,0.7);
   border: 1px solid var(--border); border-radius: 6px;
   backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+  pointer-events: none;
 }
 .kbd-hint kbd {
   color: var(--text-secondary);
@@ -718,8 +748,8 @@ a:hover { color: var(--text-primary); }
     overflow-x: auto; overflow-y: hidden;
     scroll-snap-type: x mandatory;
     height: auto; gap: 8px; padding: 4px 0;
-    mask-image: linear-gradient(to right, transparent 0, black 10%, black 90%, transparent 100%);
-    -webkit-mask-image: linear-gradient(to right, transparent 0, black 10%, black 90%, transparent 100%);
+    mask-image: linear-gradient(to right, transparent 0, black 5%, black 95%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to right, transparent 0, black 5%, black 95%, transparent 100%);
   }
   .picker li {
     scroll-snap-align: center;
@@ -729,7 +759,8 @@ a:hover { color: var(--text-primary); }
     padding: 8px 14px; font-size: 0.85rem;
   }
   .picker li.active { font-size: 0.95rem; border-bottom-color: var(--accent); }
-  .picker li .arrow { display: none; }
+  .picker li .arrow,
+  .picker li .row-speed { display: none; }
 
   .slab { padding: 18px; overflow-x: hidden; overflow-y: visible; border-radius: 12px; min-width: 0; max-width: 100%; }
   .slab-head { gap: 10px; flex-wrap: wrap; max-width: 100%; }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -152,6 +152,10 @@ a:hover { color: var(--text-primary); }
   animation: marquee 30s linear infinite;
   white-space: nowrap;
 }
+.marquee:hover .marquee-track,
+.marquee:focus-within .marquee-track {
+  animation-play-state: paused;
+}
 .marquee-item {
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.7rem; color: var(--text-tertiary);
@@ -292,6 +296,13 @@ a:hover { color: var(--text-primary); }
   margin-bottom: 28px;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.9rem; flex-wrap: wrap;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.slab-install:hover { border-color: var(--border-hover); }
+.slab-install.flash {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent), 0 0 24px var(--accent-dim);
 }
 .slab-install .prefix { color: var(--text-tertiary); }
 .slab-install .cmd { color: var(--text-primary); flex: 1; min-width: 0; }
@@ -311,6 +322,20 @@ a:hover { color: var(--text-primary); }
 }
 .slab-install .copy-btn:hover { background: var(--accent-hot); }
 .slab-install .copy-btn:active { transform: scale(0.95); }
+.slab-install .copy-btn.is-ok {
+  background: var(--ok);
+  animation: copy-pulse 0.4s ease;
+}
+.slab-install .copy-btn.is-err {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+@keyframes copy-pulse {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
 
 .slab-grid {
   display: grid; grid-template-columns: 1fr 1fr;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -188,6 +188,63 @@ a:hover { color: var(--text-primary); }
   font-size: 0.65rem; color: var(--text-tertiary);
   text-transform: uppercase; letter-spacing: 0.1em;
 }
+.picker-count {
+  color: var(--text-tertiary);
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+.picker-search {
+  position: relative;
+  margin-bottom: 8px;
+}
+.picker-search input {
+  width: 100%;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  padding: 7px 30px 7px 10px;
+  transition: border-color 0.15s ease;
+}
+.picker-search input::placeholder { color: var(--text-tertiary); }
+.picker-search input:hover { border-color: var(--border-hover); }
+.picker-search input:focus { outline: none; border-color: var(--accent); }
+.picker-search input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px; height: 12px;
+  background-color: var(--text-tertiary);
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M4 4l8 8M12 4l-8 8' stroke='black' stroke-width='2' fill='none' stroke-linecap='round'/></svg>") no-repeat center;
+          mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M4 4l8 8M12 4l-8 8' stroke='black' stroke-width='2' fill='none' stroke-linecap='round'/></svg>") no-repeat center;
+  cursor: pointer;
+}
+.picker-search-hint {
+  position: absolute;
+  right: 10px; top: 50%; transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 0.6rem;
+}
+.picker-search input:not(:placeholder-shown) ~ .picker-search-hint,
+.picker-search input:focus ~ .picker-search-hint { display: none; }
+
+.category-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+.category-chips .chip {
+  font-size: 0.6rem;
+  padding: 3px 7px;
+}
+.picker-empty {
+  text-align: center;
+  padding: 20px 0;
+}
 .sort-chips {
   display: flex; gap: 4px;
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -29,8 +29,11 @@ body {
 a { color: var(--text-secondary); text-decoration: none; transition: color 0.2s; }
 a:hover { color: var(--text-primary); }
 
-/* Visible focus for keyboard users. Pointer focus stays unstyled via :focus-visible. */
-:focus { outline: none; }
+/* Visible focus for keyboard users. Pointer focus stays unstyled, but only
+ * suppress the browser default *when the engine actually supports
+ * :focus-visible* — older engines would otherwise lose all focus indication.
+ */
+:focus:not(:focus-visible) { outline: none; }
 :focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -345,6 +345,50 @@ a:hover { color: var(--text-primary); }
   margin: 16px 0 24px; max-width: 640px;
 }
 
+.slab-trend {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px;
+  margin: 0 0 16px;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.05em;
+  flex-wrap: wrap;
+}
+.slab-trend .label {
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  letter-spacing: 0.1em;
+  font-size: 0.6rem;
+}
+.slab-trend svg {
+  display: block;
+  flex: 0 0 auto;
+}
+.slab-trend .delta {
+  margin-left: auto;
+  font-size: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.slab-trend .delta.up { color: var(--ok); }
+.slab-trend .delta.down { color: var(--accent); }
+.slab-trend .delta.flat { color: var(--text-secondary); }
+.slab-trend .latest {
+  color: var(--text-primary);
+}
+.slab-trend.empty {
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  justify-content: flex-start;
+}
+
 .slab-install {
   display: flex; align-items: center; gap: 12px;
   padding: 14px 18px;

--- a/scripts/sync-registry.mjs
+++ b/scripts/sync-registry.mjs
@@ -56,9 +56,15 @@ function buildPackagesJson(crates, existing) {
   const packages = crates.map(({ dir, amigo }) => {
     const prev = existingByName.get(dir)
     const speedup = prev?.speedup ?? amigo.speedup ?? 'TBD'
+    // Categories drive the docs site's category-chip filter. Source of
+    // truth is the crate's amigo.category — if it's missing we fall back
+    // to whatever was in docs/packages.json so a partial roll-out doesn't
+    // erase data, and finally to "util".
+    const category = amigo.category ?? prev?.category ?? 'util'
     return {
       name: dir,
       title: amigo.title,
+      category,
       description: amigo.description,
       speedup,
       npmUrl: `https://www.npmjs.com/package/@amigo-labs/${dir}`,


### PR DESCRIPTION
## Summary

Six-commit UX pass over `docs/` (the showcase SPA at index.html / styles.css / app.js / packages.json). Each commit is independently reviewable.

1. **a11y baseline** — `:focus-visible` rings, contrast bump on `--text-tertiary` to clear WCAG AA, skip-to-content link, sort chips moved off the misused `role="tab"` pattern onto `aria-pressed` buttons, decorative bits properly `aria-hidden`, picker options become a proper roving-tabindex listbox, the live region narrowed to a persistent `#slabAnnounce` so SRs hear "<name> — <speedup>" instead of the entire slab on every nav, screen-reader hint for "(opens in new tab)" links, "amigo" badge + chart legend so charts don't rely on colour alone, README shimmer skeleton replacing plain "Loading…", `prefers-contrast: more` support.
2. **SEO + link sharing** — inline SVG favicon, canonical, `theme-color`, `color-scheme`, `description`, full Open Graph + Twitter card set, `SoftwareSourceCode` JSON-LD, `defer` on the script, `updateMeta()` reflects the active package in `document.title` and the description meta on every nav.
3. **interaction polish** — speedup + description render instantly (typewriter dropped on functional content; only the on-brand shell prompt keeps it), wheel-driven picker nav scoped to `.picker-wrap` so the rest of the page no longer feels hijacked, marquee pauses on hover/focus, copy feedback now flashes the install row + pulses the button + shows "✓ Copied" so the keyboard shortcut user sees something happen, clipboard fallback via `execCommand` for non-secure contexts, the whole install row is clickable, `renderSlab` coalesces rapid renders so holding ↑/↓ doesn't cascade fades, bad `#hash` logs a console warning instead of silently falling back, `kbd-hint` updated to actually list the shortcuts.
4. **search + categories** — live search input above the picker filtering against name/title/description; category chips ("crypto / text / search / document / archive / graph / util"); `/` focuses search from anywhere, Esc clears, Enter punts focus back to the picker; `pickerCount` shows `(31)` or `(4/31)`; "no matches" empty state.
5. **trend sparklines** — every slab now shows an inline 96×24 SVG sparkline of the geomean amigo-vs-competitor ratio across the per-package history JSONL, with the latest value and a +/- delta vs the first run. Lazy-fetched, cached, race-safe. Surfaces data the repo already had but the UI never showed.
6. **visual polish** — picker rows show a compact speedup suffix (1.4×, 11×, 31×) on desktop, accent-coloured on the active row; the brand "native" half of the wordmark gains the same accent glow the logo already had; footer adds links to CONTRIBUTING + BACKLOG; `safe-area-inset` for footer + kbd-hint so notched mobiles don't swallow them; mobile carousel mask softened from 10% to 5%.

The plan that drove this lives at `/root/.claude/plans/stell-dir-vor-du-jaunty-moonbeam.md`. Sections G2–G6 (per-package routes, compare mode, overview dashboard, post-mortem visibility) and the larger structural changes (D4 overflow rework, B2 skeleton boot, B3 data split) were intentionally **not** included here — they want separate review.

## Test plan

- [ ] `python3 -m http.server -d docs 8080` and open the page; confirm all 31 packages load and switch via arrows / wheel / click
- [ ] Tab from the top — every focusable element has a visible orange ring; first Tab reveals the skip link; the picker focus moves with arrow keys
- [ ] `/` focuses search; type `arg` → only `argon2` matches; Esc clears; Enter returns focus to the picker
- [ ] Click each category chip — picker filters; "all" restores; counter updates accordingly
- [ ] Click Copy or hit `c` — install row flashes accent and the button pulses with "✓ Copied"; works in https and http contexts
- [ ] Hover the marquee — animation pauses; mouse off — resumes
- [ ] Switch packages quickly — title and meta description in the head update; sparkline re-fetches without orphaned renders
- [ ] Resize below 900px — search + categories still usable, picker becomes the carousel, kbd-hint hidden, footer wraps cleanly
- [ ] Run Lighthouse / axe — 0 critical a11y issues, contrast all green
- [ ] Paste the page URL into a chat / link unfurler — preview shows logo + brand + description
- [ ] `prefers-reduced-motion`: typewriters and shimmers stop; `prefers-contrast: more`: ambient effects gone, borders solid

https://claude.ai/code/session_01VYL6BWCSLVsjhjgvKowts3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYL6BWCSLVsjhjgvKowts3)_