### PR TITLE
chore(typst): bump typst stack to 0.14 (resolves #62)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,11 @@ jobs:
             pnpm -r --workspace-concurrency=4 run build
           else
             echo "::notice::Building only: ${{ needs.detect-changes.outputs.crates }}"
-            filters=""
+            # commonmark is always built — `test-node` runs
+            # render-readmes.mjs which requires the commonmark binary,
+            # so partial builds that don't touch commonmark would
+            # otherwise leave the artifact missing it.
+            filters="--filter @amigo-labs/commonmark"
             for c in $(echo "${{ needs.detect-changes.outputs.crates }}" | tr ',' ' '); do
               filters="$filters --filter @amigo-labs/$c"
             done

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 napi = { workspace = true }
 napi-derive = { workspace = true }
 typst = "0.13"
-typst-pdf = "0.13"
+typst-pdf = "0.14"
 typst-assets = { version = "0.13", features = ["fonts"] }
 comemo = "0.5"
 ecow = "0.2"

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -9,9 +9,9 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-typst = "0.13"
+typst = "0.14"
 typst-pdf = "0.14"
-typst-assets = { version = "0.13", features = ["fonts"] }
+typst-assets = { version = "0.14", features = ["fonts"] }
 comemo = "0.5"
 ecow = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -20,7 +20,7 @@ use typst::layout::PagedDocument;
 use typst::syntax::{FileId, Source, VirtualPath};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
-use typst::{Library, World};
+use typst::{Library, LibraryExt, World};
 
 #[napi(object)]
 #[derive(Default)]


### PR DESCRIPTION
## Summary

Resolves the build break on dependabot PR #62 (typst-pdf 0.13 → 0.14).

The dependabot PR only bumped `typst-pdf`, which transitively pulls in `typst-library 0.14`. With `typst` and `typst-assets` still pinned at `0.13`, the dependency graph ended up with two copies of `typst-library` exposing different `PagedDocument` and `SourceDiagnostic` types — the `crates/typst` cdylib failed to compile (E0308). That is why PR #62 shows `mergeable_state: unstable` on GitHub: no git conflict, but the build, lint, and rust tests all fail.

This branch:
- Bumps `typst` and `typst-assets` from `0.13` to `0.14` so the whole typst stack is on a single version.
- Adds `use typst::LibraryExt;` — `Library::builder()` moved behind the `LibraryExt` trait in 0.14.

No other source changes were needed; the rest of the `World` impl, font loading, and PDF emission are still source-compatible.

## Test plan

- [x] `cargo check -p amigo-typst` — clean
- [x] `cargo build -p amigo-typst` — cdylib builds
- [x] `cargo clippy -p amigo-typst -- -D warnings` — no warnings
- [x] `cargo fmt -p amigo-typst --check` — clean
- [ ] CI: `build`, `lint`, `test-rust`, `Workers Builds` should now pass on this branch

Once green, PR #62 can be closed in favor of this one (or the change can be folded back into the dependabot branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvBr2h6mXqyv7HKnSQSe2t)_