### PR TITLE
chore(deps): update zip requirement from 2 to 8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ lto = true
 strip = "symbols"
 codegen-units = 1
 panic = "abort"
+

--- a/crates/zip/Cargo.toml
+++ b/crates/zip/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-zip = { version = "2", default-features = false, features = ["deflate", "deflate-flate2"] }
+zip = { version = "8", default-features = false, features = ["deflate", "deflate-flate2"] }
 
 [build-dependencies]
 napi-build = "2"


### PR DESCRIPTION
## Summary

Fixes Dependabot PR #64, which intended to bump the `zip` crate from v2 to v8 but contained a copy-paste bug:

- It left `version = "2"` unchanged.
- It renamed the feature `deflate-flate2` → `deflate-flate8`, which does not exist (the feature name refers to the underlying `flate2` Rust backend, not the major version of `zip`).

This PR applies the intended bump correctly: `version = "8"` with the original `deflate-flate2` feature.

## Test plan

- [x] `cargo build -p amigo-zip` succeeds against zip 8.6.0
- [x] `cargo test -p amigo-zip` passes
- [x] `cargo clippy -p amigo-zip --all-targets -- -D warnings` is clean
- [ ] CI green (build / lint / test-rust / audit-rust / test-conformance)
- [ ] JS test suite (`vitest run __test__` and `__conformance__`) passes once napi binding is rebuilt in CI

Closes #64.


---
_Generated by [Claude Code](https://claude.ai/code/session_011LcsmpHttpaqgpum9xavSG)_