### PR TITLE
ci: speed up build job with thin-LTO + mold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         # the workspace target/ so dependency compilation is shared
         # across runs.
         env:
-          CARGO_PROFILE_RELEASE_LTO: "false"
+          CARGO_PROFILE_RELEASE_LTO: "thin"
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
           RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: napi-build
+      - uses: rui314/setup-mold@v1
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -141,17 +142,24 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build crates
-        # `--workspace-concurrency=4` matches the GitHub-hosted Ubuntu
-        # runner's 4 vCPUs. Each crate is an independent `cdylib` with
-        # `lto = true` + `codegen-units = 1` (release profile), so the
-        # bottleneck is per-crate LTO rather than shared dependency
-        # compilation — parallelizing 4 crates at a time uses the box
-        # close to fully without thrashing cargo's `target/` lock.
+        # CI overrides the workspace `[profile.release]` (lto = true,
+        # codegen-units = 1) with thin-LTO + 16 codegen-units via env
+        # vars. Per-crate codegen is the dominant cost and goes from
+        # single-threaded to parallel; mold replaces ld for a faster
+        # link step. release.yml is unaffected — its builds inherit
+        # Cargo.toml's full-LTO profile and ship to npm unchanged.
+        # The benchmark job re-builds with full-LTO so its numbers
+        # remain representative of the published binaries.
         #
-        # When only a subset of crates changed (and no workspace-wide
-        # files were touched) we filter to those crates only — the
-        # `Swatinem/rust-cache` step still warms the workspace target/
-        # so dependency compilation is shared across runs.
+        # `--workspace-concurrency=4` matches the GitHub-hosted Ubuntu
+        # runner's 4 vCPUs. When only a subset of crates changed we
+        # filter to those — the `Swatinem/rust-cache` step still warms
+        # the workspace target/ so dependency compilation is shared
+        # across runs.
+        env:
+          CARGO_PROFILE_RELEASE_LTO: "false"
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+          RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
         run: |
           set -euo pipefail
           if [ "${{ needs.detect-changes.outputs.rebuildall }}" = "1" ]; then
@@ -266,17 +274,37 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
+      - uses: dtolnay/rust-toolchain@stable
+      # Distinct cache key from the `build` job: this job builds with
+      # the full-LTO release profile so benchmark numbers reflect the
+      # binaries published to npm. Sharing the `napi-build` key would
+      # poison the fast-PR cache with full-LTO artifacts.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: napi-build-fulllto
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Download NAPI binaries
-        uses: actions/download-artifact@v8
-        with:
-          name: napi-binaries
-          path: crates/
+      - name: Build crates (full-LTO release profile)
+        # Mirrors the gating in `Run benchmarks and generate report`:
+        # if neither a full-bench commit nor any changed crates, skip
+        # the build (the next step exits 0 on the same condition).
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.detect-changes.outputs.fullbench }}" = "1" ]; then
+            pnpm -r --workspace-concurrency=4 run build
+          elif [ -n "${{ needs.detect-changes.outputs.crates }}" ]; then
+            filters=""
+            for c in $(echo "${{ needs.detect-changes.outputs.crates }}" | tr ',' ' '); do
+              filters="$filters --filter @amigo-labs/$c"
+            done
+            pnpm $filters --workspace-concurrency=4 run build
+          else
+            echo "No crates changed and not a full-bench commit; skipping build."
+          fi
       - name: Run benchmarks and generate report
         run: |
           if [ "${{ needs.detect-changes.outputs.fullbench }}" = "1" ]; then


### PR DESCRIPTION
## Summary

The `build` job in `ci.yml` is the slowest critical-path step on most PRs. The bottleneck is documented in the job itself (`ci.yml:144-149`): per-crate `lto = true` + `codegen-units = 1` (defined in `Cargo.toml:10-14`) is single-threaded and dominates wall-clock — caching, change-detection, and crate-level concurrency are already in place.

This PR overrides the release profile **for the CI build job only** via env vars:

```yaml
env:
  CARGO_PROFILE_RELEASE_LTO: "false"
  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
  RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
```

- Per-crate codegen goes from single-threaded to parallel (≈3-5× faster on cdylibs of this size).
- `mold` replaces `ld` for the link step (now a meaningful fraction once codegen is parallelized).
- Expected wall-clock reduction on the `build` job: ~40-60% on full-rebuild PRs.

`release.yml` is **untouched** — published npm binaries continue to be full-LTO + `codegen-units = 1`.

To keep benchmark numbers representative of what's actually shipped, the `benchmark` job (main-push only) is changed to build its own full-LTO binaries instead of consuming the build artifact. It uses a distinct rust-cache key (`napi-build-fulllto`) so it doesn't poison the fast PR cache.

### Why env vars instead of a `[profile.ci]` entry

Env-var override avoids touching `Cargo.toml`, the 33 per-crate `package.json` files, and the crate template. Scope is limited to one CI step.

### Out of scope

- `sccache`: marginal benefit on top of `Swatinem/rust-cache` unless `Cargo.lock` churns frequently. Revisit if measurement shows it.
- Matrix fan-out: per-runner setup overhead (~60-90s) exceeds per-crate compile time on Free-Tier 4-vCPU runners once thin-LTO lands.
- Larger paid runners: not available for this repo.

## Test plan

- [ ] CI green on this PR (lint, audit-rust, test-rust, **build**, test-node, test-conformance).
- [ ] Compare `build`-job duration to a recent `main` run with similar crate coverage; expect ≥ 30% wall-clock reduction.
- [ ] Verify mold is actually used: `mold` appears in the link command output of the `Build crates` step, or `mold --version` echoes successfully.
- [ ] Conformance still passes — the thin-LTO binaries are tested by the same suite that gates production today; any failure here would indicate a real semantic difference (highly unlikely).
- [ ] After merge, watch the next `main`-push `benchmark` job: it should fetch the toolchain, restore `napi-build-fulllto` cache, build, and produce numbers in line with historical magnitudes (no 10-30% regression that would suggest the rebuild used the thin-LTO profile by accident).
- [ ] `git diff main -- .github/workflows/release.yml` is empty.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPuNMCLDboN7CVM5vFvx8d)_