### PR TITLE
chore(deps-dev): bump fast-check from 3.23.2 to 4.7.0 (rebased)

### DIFF
--- a/crates/_template/__conformance__/fuzz.spec.ts.tmpl
+++ b/crates/_template/__conformance__/fuzz.spec.ts.tmpl
@@ -7,7 +7,7 @@ const runs = Number(process.env.FUZZ_RUNS ?? 200)
 describe('{{NAME}} — fuzz (totality + safety)', () => {
   it.todo('never throws on arbitrary unicode input', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (_input) => {
+      fc.property(fc.string({ unit: 'binary' }), (_input) => {
         // something(_input)
       }),
       { numRuns: runs },
@@ -16,7 +16,7 @@ describe('{{NAME}} — fuzz (totality + safety)', () => {
 
   it.todo('output is always valid UTF-8 (Buffer round-trip)', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (_input) => {
+      fc.property(fc.string({ unit: 'binary' }), (_input) => {
         // const out = something(_input)
         // expect(Buffer.from(out, 'utf8').toString('utf8')).toBe(out)
       }),

--- a/crates/argon2/package.json
+++ b/crates/argon2/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
     "argon2": "^0.44.0",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "hash-wasm": "^4.11.0",
     "vitest": "^4.1.5"
   },

--- a/crates/bcrypt/package.json
+++ b/crates/bcrypt/package.json
@@ -34,7 +34,7 @@
     "@napi-rs/cli": "^3.6.2",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.3",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5"
   },
   "license": "MIT",

--- a/crates/bm25/package.json
+++ b/crates/bm25/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "okapibm25": "^1.2.2",
     "vitest": "^4.1.5",
     "wink-bm25-text-search": "^3.1.0",

--- a/crates/commonmark/__conformance__/fuzz.spec.ts
+++ b/crates/commonmark/__conformance__/fuzz.spec.ts
@@ -7,7 +7,7 @@ const runs = Number(process.env.FUZZ_RUNS ?? 200)
 describe('fuzz — totality and safety', () => {
   it('never throws on arbitrary unicode input', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         render(input)
       }),
       { numRuns: runs },
@@ -16,7 +16,7 @@ describe('fuzz — totality and safety', () => {
 
   it('never emits a <script> tag under default (unsafeHtml: false)', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const out = render(input)
         expect(out).not.toMatch(/<script/i)
       }),
@@ -27,10 +27,11 @@ describe('fuzz — totality and safety', () => {
   it('never emits an active tag (<iframe|object|embed) under default', () => {
     // Markdown input can contain `<iframe src=...>` — safe mode must drop such tags.
     // We test by generating HTML-like tokens and asserting no opening tags leak through.
-    const tagInput = fc.stringOf(
-      fc.constantFrom('<', '>', 'iframe', 'object', 'embed', 'script', ' ', 'src=', '"x"', '\n', 'hi'),
-      { minLength: 1, maxLength: 80 },
-    )
+    const tagInput = fc.string({
+      unit: fc.constantFrom('<', '>', 'iframe', 'object', 'embed', 'script', ' ', 'src=', '"x"', '\n', 'hi'),
+      minLength: 1,
+      maxLength: 80,
+    })
     fc.assert(
       fc.property(tagInput, (input) => {
         const out = render(input)
@@ -43,7 +44,7 @@ describe('fuzz — totality and safety', () => {
 
   it('output is always valid UTF-8 (Buffer round-trip)', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const out = render(input)
         const round = Buffer.from(out, 'utf8').toString('utf8')
         expect(round).toBe(out)
@@ -55,7 +56,7 @@ describe('fuzz — totality and safety', () => {
   it('idempotent for pure-paragraph text (render twice through a paragraph wrapper)', () => {
     fc.assert(
       fc.property(
-        fc.stringOf(fc.constantFrom('a', 'b', 'c', ' '), { minLength: 1, maxLength: 40 }),
+        fc.string({ unit: fc.constantFrom('a', 'b', 'c', ' '), minLength: 1, maxLength: 40 }),
         (input) => {
           const trimmed = input.trim()
           if (!trimmed) return

--- a/crates/commonmark/package.json
+++ b/crates/commonmark/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
     "commonmark-spec": "^0.31.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "markdown-it": "^14.1.0",
     "marked": "^15.0.0",
     "vitest": "^4.1.5"

--- a/crates/csv/package.json
+++ b/crates/csv/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
     "csv-parse": "^5.6.0",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "papaparse": "^5.4.1",
     "vitest": "^4.1.5"
   },

--- a/crates/deepmerge/package.json
+++ b/crates/deepmerge/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
     "deepmerge": "^4.3.1",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5"
   },
   "license": "MIT",

--- a/crates/diff/__conformance__/fuzz.spec.ts
+++ b/crates/diff/__conformance__/fuzz.spec.ts
@@ -7,7 +7,7 @@ const runs = Number(process.env.FUZZ_RUNS ?? 200)
 describe('diff — fuzz (totality + reconstruction)', () => {
   it('diffLines is total for arbitrary unicode', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), fc.fullUnicodeString(), (a, b) => {
+      fc.property(fc.string({ unit: 'binary' }), fc.string({ unit: 'binary' }), (a, b) => {
         const h = diffLines(a, b)
         expect(Array.isArray(h)).toBe(true)
       }),

--- a/crates/diff/package.json
+++ b/crates/diff/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
     "diff": "^9.0.0",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5"
   },
   "license": "MIT",

--- a/crates/encoding/package.json
+++ b/crates/encoding/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "iconv-lite": "^0.7.2",
     "vitest": "^4.1.5"
   },

--- a/crates/file-type/package.json
+++ b/crates/file-type/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "file-type": "^19.6.0",
     "vitest": "^4.1.5"
   },

--- a/crates/force-layout/package.json
+++ b/crates/force-layout/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
     "d3-force": "^3.0.0",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5"
   },
   "license": "MIT",

--- a/crates/graph-layout/package.json
+++ b/crates/graph-layout/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@dagrejs/dagre": "^1.1.4",
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5"
   },
   "license": "MIT",

--- a/crates/inflate/package.json
+++ b/crates/inflate/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "pako": "^2.1.0",
     "vitest": "^4.1.5"
   },

--- a/crates/jose/package.json
+++ b/crates/jose/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "jose": "^5.9.0",
     "vitest": "^4.1.5"
   },

--- a/crates/jwt/package.json
+++ b/crates/jwt/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
     "@types/jsonwebtoken": "^9.0.7",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "jsonwebtoken": "^9.0.2",
     "vitest": "^4.1.5"
   },

--- a/crates/language-detect/__conformance__/fuzz.spec.ts
+++ b/crates/language-detect/__conformance__/fuzz.spec.ts
@@ -7,7 +7,7 @@ const runs = Number(process.env.FUZZ_RUNS ?? 200)
 describe('language-detect — fuzz (totality + safety)', () => {
   it('detect never throws on arbitrary unicode', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const out = detect(input)
         expect(typeof out).toBe('string')
         // ISO-639-3 codes are always 3 lowercase letters; "und" is our
@@ -20,7 +20,7 @@ describe('language-detect — fuzz (totality + safety)', () => {
 
   it('detectAll never throws and returns a well-formed array', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const out = detectAll(input)
         expect(Array.isArray(out)).toBe(true)
         for (const m of out) {
@@ -35,7 +35,7 @@ describe('language-detect — fuzz (totality + safety)', () => {
 
   it('detectMany returns an array of the same length as input', () => {
     fc.assert(
-      fc.property(fc.array(fc.fullUnicodeString(), { maxLength: 20 }), (inputs) => {
+      fc.property(fc.array(fc.string({ unit: 'binary' }), { maxLength: 20 }), (inputs) => {
         const out = detectMany(inputs)
         expect(out).toHaveLength(inputs.length)
       }),
@@ -45,7 +45,7 @@ describe('language-detect — fuzz (totality + safety)', () => {
 
   it('languageExists is total — returns boolean for arbitrary input', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString({ maxLength: 20 }), (input) => {
+      fc.property(fc.string({ unit: 'binary', maxLength: 20 }), (input) => {
         expect(typeof languageExists(input)).toBe('boolean')
       }),
       { numRuns: runs },

--- a/crates/language-detect/package.json
+++ b/crates/language-detect/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "franc": "^6.2.0",
     "vitest": "^4.1.5"
   },

--- a/crates/minisearch/package.json
+++ b/crates/minisearch/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "minisearch": "^7.1.0",
     "vitest": "^4.1.5"
   },

--- a/crates/nanoid/__conformance__/fuzz.spec.ts
+++ b/crates/nanoid/__conformance__/fuzz.spec.ts
@@ -22,7 +22,7 @@ describe('nanoid fuzzing', () => {
   it('custom alphabet is respected', () => {
     fc.assert(
       fc.property(
-        fc.stringOf(fc.constantFrom(...'abcdef0123456789'), { minLength: 2, maxLength: 16 }),
+        fc.string({ unit: fc.constantFrom(...'abcdef0123456789'), minLength: 2, maxLength: 16 }),
         fc.integer({ min: 1, max: 32 }),
         (alphabet, size) => {
           const unique = [...new Set(alphabet)].join('')

--- a/crates/nanoid/package.json
+++ b/crates/nanoid/package.json
@@ -24,7 +24,7 @@
     "test:upstream": "vitest run __conformance__/upstream.spec.ts"
   },
   "devDependencies": {
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "nanoid": "^5.1.11",
     "vitest": "^4.1.5"
   },

--- a/crates/pdf-parse/package.json
+++ b/crates/pdf-parse/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "pdf-parse": "^2.4.5",
     "vitest": "^4.1.5"
   },

--- a/crates/pdf/package.json
+++ b/crates/pdf/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "pdfkit": "^0.18.0",
     "vitest": "^4.1.5"
   },

--- a/crates/sanitize-html/package.json
+++ b/crates/sanitize-html/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "isomorphic-dompurify": "^3.12.0",
     "sanitize-html": "^2.17.3",
     "vitest": "^4.1.5"

--- a/crates/sentences/package.json
+++ b/crates/sentences/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "sbd": "^1.0.19",
     "vitest": "^4.1.5"
   },

--- a/crates/slugify/__conformance__/fuzz.spec.ts
+++ b/crates/slugify/__conformance__/fuzz.spec.ts
@@ -9,7 +9,7 @@ import { slugify as nativeSlugify } from '../index.js';
 describe('slugify fuzzing — invariants', () => {
   it('output is always lowercase', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const result = nativeSlugify(input);
         return result === result.toLowerCase();
       }),
@@ -19,7 +19,7 @@ describe('slugify fuzzing — invariants', () => {
 
   it('output never contains double separators', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const result = nativeSlugify(input);
         return !result.includes('--');
       }),
@@ -29,7 +29,7 @@ describe('slugify fuzzing — invariants', () => {
 
   it('output has no leading or trailing separators', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const result = nativeSlugify(input);
         return !result.startsWith('-') && !result.endsWith('-');
       }),
@@ -39,7 +39,7 @@ describe('slugify fuzzing — invariants', () => {
 
   it('output contains only [a-z0-9-]', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const result = nativeSlugify(input);
         return /^[a-z0-9-]*$/.test(result);
       }),
@@ -49,7 +49,7 @@ describe('slugify fuzzing — invariants', () => {
 
   it('idempotent: slugify(slugify(x)) === slugify(x)', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const once = nativeSlugify(input);
         const twice = nativeSlugify(once);
         return once === twice;

--- a/crates/slugify/package.json
+++ b/crates/slugify/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "slugify": "^1.6.6",
     "vitest": "^4.1.5"
   },

--- a/crates/stemmer/__conformance__/fuzz.spec.ts
+++ b/crates/stemmer/__conformance__/fuzz.spec.ts
@@ -9,7 +9,7 @@ describe('stemmer — fuzz (totality + safety)', () => {
 
   it('stemMany is total (never throws on arbitrary unicode strings)', () => {
     fc.assert(
-      fc.property(fc.array(fc.fullUnicodeString(), { maxLength: 20 }), (input) => {
+      fc.property(fc.array(fc.string({ unit: 'binary' }), { maxLength: 20 }), (input) => {
         const out = s.stemMany(input)
         expect(out).toHaveLength(input.length)
       }),
@@ -19,7 +19,7 @@ describe('stemmer — fuzz (totality + safety)', () => {
 
   it('tokenizeAndStem is total', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         const out = s.tokenizeAndStem(input)
         expect(Array.isArray(out)).toBe(true)
       }),

--- a/crates/stemmer/package.json
+++ b/crates/stemmer/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "natural": "^8.0.0",
     "vitest": "^4.1.5"
   },

--- a/crates/svgo/package.json
+++ b/crates/svgo/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "svgo": "^4.0.1",
     "vitest": "^4.1.5"
   },

--- a/crates/text-splitters/package.json
+++ b/crates/text-splitters/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@langchain/textsplitters": "^0.1.0",
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5"
   },
   "license": "MIT",

--- a/crates/tiktoken/__conformance__/fuzz.spec.ts
+++ b/crates/tiktoken/__conformance__/fuzz.spec.ts
@@ -10,7 +10,7 @@ describe('tiktoken — fuzz (totality + safety)', () => {
 
   it('never throws on arbitrary unicode input (cl100k_base)', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         cl100k.encode(input)
       }),
       { numRuns: runs, seed: 42 },
@@ -19,7 +19,7 @@ describe('tiktoken — fuzz (totality + safety)', () => {
 
   it('encode → decode is lossless for arbitrary unicode (cl100k_base)', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         expect(cl100k.decode(cl100k.encode(input))).toBe(input)
       }),
       { numRuns: runs, seed: 42 },
@@ -28,7 +28,7 @@ describe('tiktoken — fuzz (totality + safety)', () => {
 
   it('encode → decode is lossless for arbitrary unicode (o200k_base)', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         expect(o200k.decode(o200k.encode(input))).toBe(input)
       }),
       { numRuns: runs, seed: 42 },
@@ -37,7 +37,7 @@ describe('tiktoken — fuzz (totality + safety)', () => {
 
   it('countTokens is consistent with encodeOrdinary.length', () => {
     fc.assert(
-      fc.property(fc.fullUnicodeString(), (input) => {
+      fc.property(fc.string({ unit: 'binary' }), (input) => {
         expect(cl100k.countTokens(input)).toBe(cl100k.encodeOrdinary(input).length)
       }),
       { numRuns: runs, seed: 42 },
@@ -47,7 +47,7 @@ describe('tiktoken — fuzz (totality + safety)', () => {
   it('isWithinTokenLimit is consistent with countTokens', () => {
     fc.assert(
       fc.property(
-        fc.fullUnicodeString(),
+        fc.string({ unit: 'binary' }),
         fc.integer({ min: 0, max: 10_000 }),
         (input, limit) => {
           const count = cl100k.countTokens(input)
@@ -60,7 +60,7 @@ describe('tiktoken — fuzz (totality + safety)', () => {
 
   it('encodeMany matches per-call encodeOrdinary', () => {
     fc.assert(
-      fc.property(fc.array(fc.fullUnicodeString(), { maxLength: 20 }), (inputs) => {
+      fc.property(fc.array(fc.string({ unit: 'binary' }), { maxLength: 20 }), (inputs) => {
         const batch = cl100k.encodeMany(inputs)
         expect(batch).toHaveLength(inputs.length)
         for (let i = 0; i < inputs.length; i++) {

--- a/crates/tiktoken/package.json
+++ b/crates/tiktoken/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5"
   },
   "license": "MIT",

--- a/crates/turndown/package.json
+++ b/crates/turndown/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "jsdom": "^29.1.1",
     "turndown": "^7.2.0",
     "turndown-plugin-gfm": "^1.0.2",

--- a/crates/typst/package.json
+++ b/crates/typst/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5"
   },
   "license": "MIT",

--- a/crates/xlsx/package.json
+++ b/crates/xlsx/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
     "exceljs": "^4.4.0",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5",
     "xlsx": "^0.18.5"
   },

--- a/crates/xxhash/package.json
+++ b/crates/xxhash/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5",
     "xxhash-wasm": "^1.1.0",
     "xxhashjs": "^0.2.2"

--- a/crates/zip/package.json
+++ b/crates/zip/package.json
@@ -44,7 +44,7 @@
     "@types/adm-zip": "^0.5.7",
     "@types/yauzl": "^2.10.3",
     "adm-zip": "^0.5.16",
-    "fast-check": "^3.23.0",
+    "fast-check": "^4.7.0",
     "vitest": "^4.1.5",
     "yauzl": "^3.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: ^0.44.0
         version: 0.44.0
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       hash-wasm:
         specifier: ^4.11.0
         version: 4.12.0
@@ -150,8 +150,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -162,8 +162,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       okapibm25:
         specifier: ^1.2.2
         version: 1.4.1
@@ -186,8 +186,8 @@ importers:
         specifier: ^0.31.2
         version: 0.31.2
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       markdown-it:
         specifier: ^14.1.0
         version: 14.1.1
@@ -207,8 +207,8 @@ importers:
         specifier: ^5.6.0
         version: 5.6.0
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       papaparse:
         specifier: ^5.4.1
         version: 5.5.3
@@ -225,8 +225,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -240,8 +240,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -252,8 +252,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       iconv-lite:
         specifier: ^0.7.2
         version: 0.7.2
@@ -267,8 +267,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       file-type:
         specifier: ^19.6.0
         version: 19.6.0
@@ -285,8 +285,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -300,8 +300,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -312,8 +312,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       pako:
         specifier: ^2.1.0
         version: 2.1.0
@@ -327,8 +327,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       jose:
         specifier: ^5.9.0
         version: 5.10.0
@@ -345,8 +345,8 @@ importers:
         specifier: ^9.0.7
         version: 9.0.10
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -360,8 +360,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       franc:
         specifier: ^6.2.0
         version: 6.2.0
@@ -375,8 +375,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       minisearch:
         specifier: ^7.1.0
         version: 7.2.0
@@ -387,8 +387,8 @@ importers:
   crates/nanoid:
     devDependencies:
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11
@@ -402,8 +402,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       pdfkit:
         specifier: ^0.18.0
         version: 0.18.0
@@ -417,8 +417,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       pdf-parse:
         specifier: ^2.4.5
         version: 2.4.5
@@ -436,8 +436,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       isomorphic-dompurify:
         specifier: ^3.12.0
         version: 3.12.0(@noble/hashes@1.8.0)
@@ -454,8 +454,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       sbd:
         specifier: ^1.0.19
         version: 1.0.19
@@ -469,8 +469,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       slugify:
         specifier: ^1.6.6
         version: 1.6.9
@@ -484,8 +484,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       natural:
         specifier: ^8.0.0
         version: 8.1.1
@@ -499,8 +499,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       svgo:
         specifier: ^4.0.1
         version: 4.0.1
@@ -517,8 +517,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -529,8 +529,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -541,8 +541,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@1.8.0)
@@ -562,8 +562,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -577,8 +577,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -592,8 +592,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(node-addon-api@8.7.0)
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -619,8 +619,8 @@ importers:
         specifier: ^0.5.16
         version: 0.5.17
       fast-check:
-        specifier: ^3.23.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@25.6.0))
@@ -2687,9 +2687,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  fast-check@3.23.2:
-    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
-    engines: {node: '>=8.0.0'}
+  fast-check@4.7.0:
+    resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
+    engines: {node: '>=12.17.0'}
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
@@ -3270,8 +3270,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  pure-rand@6.1.0:
-    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -5399,9 +5399,9 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  fast-check@3.23.2:
+  fast-check@4.7.0:
     dependencies:
-      pure-rand: 6.1.0
+      pure-rand: 8.4.0
 
   fast-content-type-parse@3.0.0: {}
 
@@ -5980,7 +5980,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  pure-rand@6.1.0: {}
+  pure-rand@8.4.0: {}
 
   readable-stream@2.3.8:
     dependencies:


### PR DESCRIPTION
Replaces #71. Re-applies the dependabot fast-check `3.23.2` → `4.7.0` bump on top of current `main`, resolving conflicts that arose from intervening dependency updates.

## Conflicts resolved

The dependabot branch was made before several other dep updates landed on `main`. For each conflicting `package.json`, kept `main`'s newer co-located version while applying the fast-check bump:

- `crates/nanoid` — kept `nanoid@^5.1.11` (was `^5.0.9` in PR #71)
- `crates/sanitize-html` — kept `isomorphic-dompurify@^3.12.0` (was `^3.11.0`)
- `crates/svgo` — kept `svgo@^4.0.1` (was `^3.3.0`)
- `crates/turndown` — kept `jsdom@^29.1.1` (was `^29.1.0`)

`pnpm-lock.yaml` auto-merged cleanly; verified by re-running `pnpm install --lockfile-only` (no diff).

## Test plan

- [ ] CI passes on the rebased branch
- [ ] Conformance/property-based tests still run with fast-check 4.7.0 across all 31 crates

Closes #71.

https://claude.ai/code/session_01MsSZEjMJBBLVKk4QzTcXCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsSZEjMJBBLVKk4QzTcXCQ)_