### PR TITLE
fix(release-please): bump npm platform stubs + tabify package detail

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -450,8 +450,6 @@ function buildSlabHTML(p) {
     </div>
     <p class="slab-desc" id="slabDesc"></p>
 
-    <div class="slab-trend" id="slabTrend"></div>
-
     <div class="slab-install">
       <span class="prefix" aria-hidden="true">$</span>
       <span class="cmd" id="slabCmd"></span><span class="caret" aria-hidden="true"></span>
@@ -466,29 +464,32 @@ function buildSlabHTML(p) {
       ${p.postMortemUrl ? `<a href="${p.postMortemUrl}" target="_blank" rel="noopener noreferrer">post-mortem <span aria-hidden="true">&nearr;</span>${newTabSr}</a>` : ''}
     </div>
 
-    <div class="slab-grid">
-      <div class="slab-col">
-        <div class="slab-col-head">Benchmarks (ops/s)</div>
+    <div class="slab-tabs" id="slabTabs">
+      <div class="slab-tablist" role="tablist" aria-label="Package details">
+        <button class="slab-tab" role="tab" id="tab-bench" aria-controls="panel-bench" aria-selected="true" tabindex="0">Benchmarks</button>
+        <button class="slab-tab" role="tab" id="tab-foot" aria-controls="panel-foot" aria-selected="false" tabindex="-1">Footprint</button>
+        <button class="slab-tab" role="tab" id="tab-readme" aria-controls="panel-readme" aria-selected="false" tabindex="-1">README</button>
+      </div>
+      <section class="slab-tabpanel" id="panel-bench" role="tabpanel" aria-labelledby="tab-bench">
+        <div class="slab-trend" id="slabTrend"></div>
         <div class="chart-legend" aria-hidden="true">
           <span><span class="swatch amigo"></span>amigo-labs</span>
           <span><span class="swatch competitor"></span>competitor</span>
         </div>
         <div id="slabBench"></div>
-      </div>
-      <div class="slab-col">
-        <div class="slab-col-head">Install footprint</div>
+      </section>
+      <section class="slab-tabpanel" id="panel-foot" role="tabpanel" aria-labelledby="tab-foot" hidden>
         <div class="chart-legend" aria-hidden="true">
           <span><span class="swatch amigo"></span>amigo-labs</span>
           <span><span class="swatch competitor"></span>competitor</span>
         </div>
         <div id="slabSizes"></div>
-      </div>
+      </section>
+      <section class="slab-tabpanel" id="panel-readme" role="tabpanel" aria-labelledby="tab-readme" hidden>
+        <div class="readme-tab-hint">rendered by @amigo-labs/commonmark</div>
+        <div class="readme-body" id="slabReadme"></div>
+      </section>
     </div>
-
-    <details class="slab-readme" id="slabReadmeHost">
-      <summary>README <span class="readme-hint">rendered by @amigo-labs/commonmark</span></summary>
-      <div class="readme-body" id="slabReadme"></div>
-    </details>
 
     ${p.perfReviewUrl ? `
     <details class="slab-readme" id="slabPerfReviewHost">
@@ -522,8 +523,55 @@ function animateSlab(p) {
   renderBench(p);
   renderSizes(p);
   renderTrend(p);
-  wireReadme(p);
+  initTabs(p);
   wirePerfReview(p);
+}
+
+function initTabs(pkg) {
+  const tablist = document.querySelector('#slabTabs .slab-tablist');
+  if (!tablist) return;
+  const tabs = Array.from(tablist.querySelectorAll('[role="tab"]'));
+  const panels = tabs.map(t => document.getElementById(t.getAttribute('aria-controls')));
+  let readmeLoaded = false;
+
+  // Cache pre-warm — if README is already cached for this pkg, render it
+  // immediately so first activation doesn't re-fetch.
+  const readmeHost = $('#slabReadme');
+  if (readmeHost && _readmeCache[pkg.name]) {
+    readmeHost.innerHTML = _readmeCache[pkg.name];
+    readmeLoaded = true;
+  }
+
+  function activate(i, focus) {
+    tabs.forEach((t, j) => {
+      const on = i === j;
+      t.setAttribute('aria-selected', on ? 'true' : 'false');
+      t.tabIndex = on ? 0 : -1;
+      panels[j].hidden = !on;
+    });
+    if (focus) tabs[i].focus();
+    if (tabs[i].id === 'tab-readme' && !readmeLoaded) {
+      readmeLoaded = true;
+      loadMarkdown({
+        host: readmeHost,
+        cache: _readmeCache,
+        key: pkg.name,
+        fetchPath: `readmes/${pkg.name}.html`,
+        label: 'README',
+      });
+    }
+  }
+
+  tabs.forEach((t, i) => {
+    t.addEventListener('click', () => activate(i, false));
+    t.addEventListener('keydown', e => {
+      const n = tabs.length;
+      if (e.key === 'ArrowRight') { activate((i + 1) % n, true); e.preventDefault(); }
+      else if (e.key === 'ArrowLeft') { activate((i - 1 + n) % n, true); e.preventDefault(); }
+      else if (e.key === 'Home') { activate(0, true); e.preventDefault(); }
+      else if (e.key === 'End') { activate(n - 1, true); e.preventDefault(); }
+    });
+  });
 }
 
 // Per-package perf history lives in docs/history/<name>.jsonl, one entry
@@ -677,42 +725,36 @@ async function copyToClipboard(text, btn, installRow) {
 const _readmeCache = {};
 const _perfReviewCache = {};
 
+async function loadMarkdown({ host, cache, key, fetchPath, label }) {
+  if (!host) return;
+  if (cache[key]) {
+    host.innerHTML = cache[key];
+    return;
+  }
+  host.innerHTML = `<div class="readme-skeleton" aria-label="Loading ${label}"><div class="line"></div><div class="line"></div><div class="line"></div></div>`;
+  try {
+    const res = await fetch(fetchPath);
+    if (!res.ok) throw new Error(res.statusText);
+    // The fetched HTML is locally rendered from project-owned markdown
+    // via our own commonmark crate during the docs build — same-origin,
+    // no user-controlled content. Do NOT route untrusted markup through
+    // this assignment without sanitising it first.
+    const html = await res.text();
+    cache[key] = html;
+    host.innerHTML = html;
+  } catch {
+    host.innerHTML = `<div class="readme-error">Could not load ${label}.</div>`;
+  }
+}
+
 function wireMarkdownDetails({ details, host, cache, key, fetchPath, label }) {
   if (!details || !host) return;
   if (cache[key]) {
     host.innerHTML = cache[key];
   }
-  details.addEventListener('toggle', async () => {
+  details.addEventListener('toggle', () => {
     if (!details.open) return;
-    if (cache[key]) {
-      host.innerHTML = cache[key];
-      return;
-    }
-    host.innerHTML = `<div class="readme-skeleton" aria-label="Loading ${label}"><div class="line"></div><div class="line"></div><div class="line"></div></div>`;
-    try {
-      const res = await fetch(fetchPath);
-      if (!res.ok) throw new Error(res.statusText);
-      // The fetched HTML is locally rendered from project-owned markdown
-      // via our own commonmark crate during the docs build — same-origin,
-      // no user-controlled content. Do NOT route untrusted markup through
-      // this assignment without sanitising it first.
-      const html = await res.text();
-      cache[key] = html;
-      host.innerHTML = html;
-    } catch {
-      host.innerHTML = `<div class="readme-error">Could not load ${label}.</div>`;
-    }
-  });
-}
-
-function wireReadme(pkg) {
-  wireMarkdownDetails({
-    details: $('#slabReadmeHost'),
-    host: $('#slabReadme'),
-    cache: _readmeCache,
-    key: pkg.name,
-    fetchPath: `readmes/${pkg.name}.html`,
-    label: 'README',
+    loadMarkdown({ host, cache, key, fetchPath, label });
   });
 }
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -365,11 +365,9 @@ a:hover { color: var(--text-primary); }
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 10px 14px;
-  margin: 0 0 16px;
-  background: var(--bg-sunken);
-  border: 1px solid var(--border);
-  border-radius: 10px;
+  padding: 0 0 12px;
+  margin: 0 0 12px;
+  border-bottom: 1px dashed var(--border);
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.7rem;
   color: var(--text-tertiary);
@@ -472,6 +470,48 @@ a:hover { color: var(--text-primary); }
 .slab-col-sub {
   font-size: 0.8rem; color: var(--text-tertiary);
   margin: 8px 0 6px; font-weight: 300;
+}
+
+.slab-tabs {
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-bottom: 24px;
+  overflow: hidden;
+}
+.slab-tablist {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.slab-tab {
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: var(--text-tertiary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 14px 18px;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+.slab-tab:hover { color: var(--text-secondary); background: rgba(255, 255, 255, 0.02); }
+.slab-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.slab-tab[aria-selected="true"] {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.slab-tabpanel { padding: 18px; min-width: 0; }
+.slab-tabpanel[hidden] { display: none; }
+.readme-tab-hint {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 12px;
 }
 
 .bar-row {
@@ -781,6 +821,10 @@ a:hover { color: var(--text-primary); }
 
   .slab-grid { grid-template-columns: 1fr; gap: 16px; margin-bottom: 20px; min-width: 0; max-width: 100%; }
   .slab-col { padding: 14px; min-width: 0; overflow: hidden; }
+
+  .slab-tabs { margin-bottom: 20px; }
+  .slab-tab { flex: 1 1 auto; padding: 12px 10px; font-size: 0.62rem; letter-spacing: 0.08em; }
+  .slab-tabpanel { padding: 14px; }
 
   .bar-row { font-size: 0.7rem; gap: 6px; min-width: 0; max-width: 100%; }
   .bar-row .label { min-width: 0; }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,48 +10,411 @@
   "pull-request-header": "Automated release proposed by release-please. Merging this PR creates per-crate tags and triggers the npm publish workflow.",
   "bootstrap-sha": "e8478c226c1c9bc5731d890e937625495f0e3e19",
   "changelog-sections": [
-    { "type": "feat",     "section": "Features" },
-    { "type": "fix",      "section": "Bug Fixes" },
-    { "type": "perf",     "section": "Performance Improvements" },
-    { "type": "revert",   "section": "Reverts" },
-    { "type": "docs",     "section": "Documentation" },
-    { "type": "refactor", "section": "Code Refactoring",        "hidden": true },
-    { "type": "test",     "section": "Tests",                   "hidden": true },
-    { "type": "build",    "section": "Build System",            "hidden": true },
-    { "type": "ci",       "section": "Continuous Integration",  "hidden": true },
-    { "type": "chore",    "section": "Miscellaneous",           "hidden": true }
+    {"type":"feat","section":"Features"},
+    {"type":"fix","section":"Bug Fixes"},
+    {"type":"perf","section":"Performance Improvements"},
+    {"type":"revert","section":"Reverts"},
+    {"type":"docs","section":"Documentation"},
+    {"type":"refactor","section":"Code Refactoring","hidden":true},
+    {"type":"test","section":"Tests","hidden":true},
+    {"type":"build","section":"Build System","hidden":true},
+    {"type":"ci","section":"Continuous Integration","hidden":true},
+    {"type":"chore","section":"Miscellaneous","hidden":true}
   ],
   "packages": {
-    "crates/argon2":          { "package-name": "@amigo-labs/argon2",          "component": "argon2",          "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/bcrypt":          { "package-name": "@amigo-labs/bcrypt",          "component": "bcrypt",          "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/bm25":            { "package-name": "@amigo-labs/bm25",            "component": "bm25",            "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/commonmark":      { "package-name": "@amigo-labs/commonmark",      "component": "commonmark",      "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/csv":             { "package-name": "@amigo-labs/csv",             "component": "csv",             "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/deepmerge":       { "package-name": "@amigo-labs/deepmerge",       "component": "deepmerge",       "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/diff":            { "package-name": "@amigo-labs/diff",            "component": "diff",            "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/encoding":        { "package-name": "@amigo-labs/encoding",        "component": "encoding",        "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/file-type":       { "package-name": "@amigo-labs/file-type",       "component": "file-type",       "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/force-layout":    { "package-name": "@amigo-labs/force-layout",    "component": "force-layout",    "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/graph-layout":    { "package-name": "@amigo-labs/graph-layout",    "component": "graph-layout",    "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/inflate":         { "package-name": "@amigo-labs/inflate",         "component": "inflate",         "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/jose":            { "package-name": "@amigo-labs/jose",            "component": "jose",            "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/jwt":             { "package-name": "@amigo-labs/jwt",             "component": "jwt",             "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/language-detect": { "package-name": "@amigo-labs/language-detect", "component": "language-detect", "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/minisearch":      { "package-name": "@amigo-labs/minisearch",      "component": "minisearch",      "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/nanoid":          { "package-name": "@amigo-labs/nanoid",          "component": "nanoid" },
-    "crates/pdf":             { "package-name": "@amigo-labs/pdf",             "component": "pdf",             "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/pdf-parse":       { "package-name": "@amigo-labs/pdf-parse",       "component": "pdf-parse",       "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/sanitize-html":   { "package-name": "@amigo-labs/sanitize-html",   "component": "sanitize-html",   "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/sentences":       { "package-name": "@amigo-labs/sentences",       "component": "sentences",       "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/slugify":         { "package-name": "@amigo-labs/slugify",         "component": "slugify",         "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/stemmer":         { "package-name": "@amigo-labs/stemmer",         "component": "stemmer",         "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/svgo":            { "package-name": "@amigo-labs/svgo",            "component": "svgo",            "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/text-splitters":  { "package-name": "@amigo-labs/text-splitters",  "component": "text-splitters",  "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/tiktoken":        { "package-name": "@amigo-labs/tiktoken",        "component": "tiktoken",        "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/turndown":        { "package-name": "@amigo-labs/turndown",        "component": "turndown",        "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/typst":           { "package-name": "@amigo-labs/typst",           "component": "typst",           "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/xlsx":            { "package-name": "@amigo-labs/xlsx",            "component": "xlsx",            "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/xxhash":          { "package-name": "@amigo-labs/xxhash",          "component": "xxhash",          "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] },
-    "crates/zip":             { "package-name": "@amigo-labs/zip",             "component": "zip",             "extra-files": [{ "type": "toml", "path": "Cargo.toml", "jsonpath": "$.package.version" }] }
+    "crates/argon2": {
+      "package-name": "@amigo-labs/argon2",
+      "component": "argon2",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/bcrypt": {
+      "package-name": "@amigo-labs/bcrypt",
+      "component": "bcrypt",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/bm25": {
+      "package-name": "@amigo-labs/bm25",
+      "component": "bm25",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/commonmark": {
+      "package-name": "@amigo-labs/commonmark",
+      "component": "commonmark",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/csv": {
+      "package-name": "@amigo-labs/csv",
+      "component": "csv",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/deepmerge": {
+      "package-name": "@amigo-labs/deepmerge",
+      "component": "deepmerge",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/diff": {
+      "package-name": "@amigo-labs/diff",
+      "component": "diff",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/encoding": {
+      "package-name": "@amigo-labs/encoding",
+      "component": "encoding",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/file-type": {
+      "package-name": "@amigo-labs/file-type",
+      "component": "file-type",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/force-layout": {
+      "package-name": "@amigo-labs/force-layout",
+      "component": "force-layout",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/graph-layout": {
+      "package-name": "@amigo-labs/graph-layout",
+      "component": "graph-layout",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/inflate": {
+      "package-name": "@amigo-labs/inflate",
+      "component": "inflate",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/jose": {
+      "package-name": "@amigo-labs/jose",
+      "component": "jose",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/jwt": {
+      "package-name": "@amigo-labs/jwt",
+      "component": "jwt",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/language-detect": {
+      "package-name": "@amigo-labs/language-detect",
+      "component": "language-detect",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/minisearch": {
+      "package-name": "@amigo-labs/minisearch",
+      "component": "minisearch",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/nanoid": {
+      "package-name": "@amigo-labs/nanoid",
+      "component": "nanoid"
+    },
+    "crates/pdf": {
+      "package-name": "@amigo-labs/pdf",
+      "component": "pdf",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/pdf-parse": {
+      "package-name": "@amigo-labs/pdf-parse",
+      "component": "pdf-parse",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/sanitize-html": {
+      "package-name": "@amigo-labs/sanitize-html",
+      "component": "sanitize-html",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/sentences": {
+      "package-name": "@amigo-labs/sentences",
+      "component": "sentences",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/slugify": {
+      "package-name": "@amigo-labs/slugify",
+      "component": "slugify",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/stemmer": {
+      "package-name": "@amigo-labs/stemmer",
+      "component": "stemmer",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/svgo": {
+      "package-name": "@amigo-labs/svgo",
+      "component": "svgo",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/text-splitters": {
+      "package-name": "@amigo-labs/text-splitters",
+      "component": "text-splitters",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/tiktoken": {
+      "package-name": "@amigo-labs/tiktoken",
+      "component": "tiktoken",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/turndown": {
+      "package-name": "@amigo-labs/turndown",
+      "component": "turndown",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/typst": {
+      "package-name": "@amigo-labs/typst",
+      "component": "typst",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/xlsx": {
+      "package-name": "@amigo-labs/xlsx",
+      "component": "xlsx",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/xxhash": {
+      "package-name": "@amigo-labs/xxhash",
+      "component": "xxhash",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    },
+    "crates/zip": {
+      "package-name": "@amigo-labs/zip",
+      "component": "zip",
+      "extra-files": [
+        {"type":"toml","path":"Cargo.toml","jsonpath":"$.package.version"},
+        {"type":"json","path":"npm/darwin-arm64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/darwin-x64/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-arm64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-gnu/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/linux-x64-musl/package.json","jsonpath":"$.version"},
+        {"type":"json","path":"npm/win32-x64-msvc/package.json","jsonpath":"$.version"}
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **Lint fix for PR #73.** `node scripts/sync-registry.mjs --check` fails on the release-please PR because the six `crates/<name>/npm/<target>/package.json` platform stubs stay at the previous version (`0.1.0` / `0.2.0`) when release-please bumps the parent. This adds the stubs to each crate's `extra-files` in `release-please-config.json` so future release PRs bump them in lockstep. nanoid stays exempt (no Cargo.toml, no npm/ stubs).
- **Tabify package detail.** The Benchmarks card, Install Footprint card and README expander on the docs site collapse into a single tab card (Benchmarks / Footprint / README). README lazy-loads on first activation, reusing the existing `_readmeCache`. Keyboard nav: ArrowLeft/Right cycle, Home/End jump. Perf-review `<details>` stays below the tabs unchanged.
- **Trend bar move.** `slab-trend` is no longer a top-of-slab strip — it lives inside the Benchmarks tab panel, above the bench bars.

## Notes for the reviewer

PR #73 itself will only turn green after release-please regenerates the PR using the new config (push an empty commit to `main` or trigger the release workflow once this lands). Verified locally:

- `node scripts/sync-registry.mjs --check` → `up to date (31 crates, all stubs aligned).`
- Replayed in a worktree against `origin/release-please--branches--main`: with the 180 stub `version` fields bumped to match parents (which release-please will do automatically next time), the check passes.
- `npx oxlint --ignore-pattern 'crates/sanitize-html/__conformance__/upstream/**' .` → 0 warnings, 0 errors.
- `node --check docs/app.js` parses clean.

## Test plan

- [ ] Trigger release-please (after merge) and confirm the regenerated PR includes bumps for every `crates/*/npm/*/package.json`.
- [ ] CI `lint` job on the regenerated release-please PR passes (`sync-registry --check`).
- [ ] Open the docs site, navigate to a package: default tab is Benchmarks with the trend bar above the bars; ArrowLeft/Right cycle through tabs; README lazy-loads with skeleton on first activation; cached on subsequent visits.
- [ ] Mobile width (≤ 720 px): tabs wrap rather than overflow.
- [ ] Perf-review `<details>` below the tabs still toggles and lazy-loads (e.g. on `argon2`).

https://claude.ai/code/session_01K131FQH1fxrJWAaWxQd1f4

---
_Generated by [Claude Code](https://claude.ai/code/session_01K131FQH1fxrJWAaWxQd1f4)_