### PR TITLE
fix(release-please): switch to per-package release PRs

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -117,6 +117,20 @@ is missing or the workflow is using `secrets.GITHUB_TOKEN` by accident. Push
 the tag manually with a PAT to recover the publish (`git push origin
 <crate>@<version>`), then fix the secret.
 
+**Release PR was merged but no tags were created.** Symptoms: the merged PR
+keeps the `autorelease: pending` label, the `release-please--branches--main`
+branch is not deleted, and no `<crate>@<version>` tags appear under
+`git ls-remote --tags origin`. Cause: the post-merge `release-please.yml`
+run could not parse the merged PR title against the per-package
+`pull-request-title-pattern` and aborted with `Bad pull request title`.
+This happens when grouped releases (`separate-pull-requests: false`) are
+combined with a literal `group-pull-request-title-pattern` — the single
+grouped title cannot simultaneously match every component's pattern.
+Recovery: run `node scripts/recover-release.mjs <merge-commit-sha>` with a
+PAT-authenticated remote to tag and push the missing releases. The script
+reads the manifest, derives each tag, skips tags already on origin, and
+pushes the rest, which fires `release.yml` once per tag.
+
 **A commit is missing from the Release PR.** Check the scope. Commits without
 a scope, or with a scope that doesn't match any directory under `crates/`, are
 not associated with any package and contribute nothing to a release.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,10 +4,8 @@
   "tag-separator": "@",
   "include-component-in-tag": true,
   "include-v-in-tag": false,
-  "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: release main",
-  "pull-request-title-pattern": "chore: release ${component} ${version}",
-  "pull-request-header": "Automated release proposed by release-please. Merging this PR creates per-crate tags and triggers the npm publish workflow.",
+  "separate-pull-requests": true,
+  "pull-request-header": "Automated release proposed by release-please. Merging this PR creates the per-crate tag and triggers the npm publish workflow.",
   "bootstrap-sha": "e8478c226c1c9bc5731d890e937625495f0e3e19",
   "changelog-sections": [
     {"type":"feat","section":"Features"},

--- a/scripts/recover-release.mjs
+++ b/scripts/recover-release.mjs
@@ -10,12 +10,17 @@
  * skips tags that already exist on origin, and creates the missing tags on the
  * commit passed as the first positional argument (default: HEAD).
  *
- * Tag pushes must use a token that can trigger downstream workflows — the default
- * GITHUB_TOKEN cannot. Run locally with a PAT configured for the remote, or set
- * `GIT_PUSH_REMOTE` to a remote URL that embeds the token.
+ * Tag pushes must use a token that can trigger downstream workflows — the
+ * default GITHUB_TOKEN cannot. Run locally against a remote whose URL embeds a
+ * PAT (e.g. `git remote set-url <name> https://<token>@github.com/<owner>/<repo>`)
+ * or that uses an SSH key authorised to push tags.
+ *
+ * The script is safely re-runnable: tags already present on the remote are
+ * skipped, and local tags pointing at the target commit are reused. A local
+ * tag pointing at a different commit is treated as a hard error.
  *
  * Usage:
- *   node scripts/recover-release.mjs [<commit-sha>] [--dry-run] [--remote <name>]
+ *   node scripts/recover-release.mjs [<commit-ish>] [--dry-run] [--remote <name>]
  *
  * Examples:
  *   node scripts/recover-release.mjs 14cf4ea --dry-run
@@ -26,15 +31,48 @@ import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
+const USAGE =
+  'usage: recover-release.mjs [<commit-ish>] [--dry-run] [--remote <name>]'
+
+function die(msg) {
+  console.error(`error: ${msg}`)
+  console.error(USAGE)
+  process.exit(2)
+}
+
+function parseArgs(argv) {
+  let dryRun = false
+  let remote = 'origin'
+  const positional = []
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--dry-run') {
+      dryRun = true
+    } else if (a === '--remote') {
+      const value = argv[i + 1]
+      if (!value || value.startsWith('--')) {
+        die(`--remote requires a value`)
+      }
+      remote = value
+      i++
+    } else if (a === '--help' || a === '-h') {
+      console.log(USAGE)
+      process.exit(0)
+    } else if (a.startsWith('--')) {
+      die(`unknown option: ${a}`)
+    } else {
+      positional.push(a)
+    }
+  }
+  if (positional.length > 1) {
+    die(`expected at most one commit-ish, got ${positional.length}: ${positional.join(' ')}`)
+  }
+  return { dryRun, remote, commit: positional[0] ?? 'HEAD' }
+}
+
+const { dryRun, remote, commit } = parseArgs(process.argv.slice(2))
+
 const root = process.cwd()
-
-const args = process.argv.slice(2)
-const dryRun = args.includes('--dry-run')
-const remoteIdx = args.indexOf('--remote')
-const remote = remoteIdx >= 0 ? args[remoteIdx + 1] : 'origin'
-const positional = args.filter((a, i) => !a.startsWith('--') && args[i - 1] !== '--remote')
-const commit = positional[0] ?? 'HEAD'
-
 const config = JSON.parse(readFileSync(join(root, 'release-please-config.json'), 'utf8'))
 const manifest = JSON.parse(readFileSync(join(root, '.release-please-manifest.json'), 'utf8'))
 
@@ -44,6 +82,17 @@ const includeV = config['include-v-in-tag'] !== false
 
 function git(...gitArgs) {
   return execFileSync('git', gitArgs, { encoding: 'utf8' }).trim()
+}
+
+function localTagSha(tag) {
+  try {
+    return execFileSync('git', ['rev-parse', '--verify', '--quiet', `refs/tags/${tag}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return null
+  }
 }
 
 const commitSha = git('rev-parse', commit)
@@ -90,10 +139,30 @@ if (todo.length === 0) {
   process.exit(0)
 }
 
+const conflicts = []
+for (const p of todo) {
+  const existing = localTagSha(p.tag)
+  if (existing && existing !== commitSha) {
+    conflicts.push({ tag: p.tag, existing })
+  }
+}
+if (conflicts.length > 0) {
+  console.error('\nlocal tags already exist at a different commit:')
+  for (const c of conflicts) {
+    console.error(`  ${c.tag} -> ${c.existing.slice(0, 7)} (expected ${commitSha.slice(0, 7)})`)
+  }
+  console.error('\nresolve manually (e.g. `git tag -d <tag>`) and rerun.')
+  process.exit(1)
+}
+
 console.log()
 for (const p of todo) {
-  git('tag', p.tag, commitSha)
-  console.log(`tagged ${p.tag} -> ${commitSha.slice(0, 7)}`)
+  if (localTagSha(p.tag) === commitSha) {
+    console.log(`reusing local tag ${p.tag} -> ${commitSha.slice(0, 7)}`)
+  } else {
+    git('tag', p.tag, commitSha)
+    console.log(`tagged ${p.tag} -> ${commitSha.slice(0, 7)}`)
+  }
 }
 
 const refspecs = todo.map((p) => `refs/tags/${p.tag}`)

--- a/scripts/recover-release.mjs
+++ b/scripts/recover-release.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+/**
+ * Recovers a release-please tag-push that was lost (e.g. because the post-merge
+ * release workflow aborted before tagging).
+ *
+ * Source of truth: `.release-please-manifest.json` and `release-please-config.json`.
+ * For each entry the script derives the tag name (using `tag-separator`,
+ * `include-component-in-tag`, `include-v-in-tag` and per-package `component`),
+ * skips tags that already exist on origin, and creates the missing tags on the
+ * commit passed as the first positional argument (default: HEAD).
+ *
+ * Tag pushes must use a token that can trigger downstream workflows — the default
+ * GITHUB_TOKEN cannot. Run locally with a PAT configured for the remote, or set
+ * `GIT_PUSH_REMOTE` to a remote URL that embeds the token.
+ *
+ * Usage:
+ *   node scripts/recover-release.mjs [<commit-sha>] [--dry-run] [--remote <name>]
+ *
+ * Examples:
+ *   node scripts/recover-release.mjs 14cf4ea --dry-run
+ *   node scripts/recover-release.mjs 14cf4ea
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+const args = process.argv.slice(2)
+const dryRun = args.includes('--dry-run')
+const remoteIdx = args.indexOf('--remote')
+const remote = remoteIdx >= 0 ? args[remoteIdx + 1] : 'origin'
+const positional = args.filter((a, i) => !a.startsWith('--') && args[i - 1] !== '--remote')
+const commit = positional[0] ?? 'HEAD'
+
+const config = JSON.parse(readFileSync(join(root, 'release-please-config.json'), 'utf8'))
+const manifest = JSON.parse(readFileSync(join(root, '.release-please-manifest.json'), 'utf8'))
+
+const separator = config['tag-separator'] ?? '-'
+const includeComponent = config['include-component-in-tag'] !== false
+const includeV = config['include-v-in-tag'] !== false
+
+function git(...gitArgs) {
+  return execFileSync('git', gitArgs, { encoding: 'utf8' }).trim()
+}
+
+const commitSha = git('rev-parse', commit)
+
+const remoteTagsRaw = git('ls-remote', '--tags', remote)
+const remoteTags = new Set(
+  remoteTagsRaw
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => line.split('\t')[1].replace(/^refs\/tags\//, '').replace(/\^\{\}$/, '')),
+)
+
+const plan = []
+for (const [path, version] of Object.entries(manifest)) {
+  const pkg = config.packages?.[path]
+  if (!pkg) {
+    console.warn(`skip ${path}: not in release-please-config.json packages`)
+    continue
+  }
+  const component = pkg.component ?? path.split('/').pop()
+  const versionPart = includeV ? `v${version}` : version
+  const tag = includeComponent ? `${component}${separator}${versionPart}` : versionPart
+  plan.push({ path, component, version, tag, exists: remoteTags.has(tag) })
+}
+
+const todo = plan.filter((p) => !p.exists)
+const skipped = plan.filter((p) => p.exists)
+
+console.log(`commit: ${commitSha}`)
+console.log(`remote: ${remote}`)
+console.log(`tags to create: ${todo.length}`)
+console.log(`tags already on remote (skipped): ${skipped.length}`)
+console.log()
+for (const p of todo) console.log(`  + ${p.tag}`)
+for (const p of skipped) console.log(`  = ${p.tag} (exists)`)
+
+if (dryRun) {
+  console.log('\n--dry-run: not pushing')
+  process.exit(0)
+}
+
+if (todo.length === 0) {
+  console.log('\nnothing to do')
+  process.exit(0)
+}
+
+console.log()
+for (const p of todo) {
+  git('tag', p.tag, commitSha)
+  console.log(`tagged ${p.tag} -> ${commitSha.slice(0, 7)}`)
+}
+
+const refspecs = todo.map((p) => `refs/tags/${p.tag}`)
+git('push', remote, ...refspecs)
+console.log(`\npushed ${todo.length} tags to ${remote}`)


### PR DESCRIPTION
## Summary

- Switches `release-please-config.json` to `separate-pull-requests: true` so every crate gets its own release PR with a title that matches the per-component title pattern. Removes the stale `group-pull-request-title-pattern` and `pull-request-title-pattern` overrides.
- Adds `scripts/recover-release.mjs` to backfill missing tags from the manifest when a post-merge release-please run drops the tagging step.
- Documents the failure mode in `docs/RELEASING.md`.

## Background

PR #73 was merged on 2026-05-07 but no `<crate>@<version>` tags appeared and `release.yml` never ran. The release-please workflow log showed:

```
✔ No latest release found for path: crates/argon2 ...
   but a previous version (0.1.1) was specified in the manifest.
...
✖ Bad pull request title: 'chore: release main'        (×31)
...
❯ Found pull request #73: 'chore: release main'
⚠ There are untagged, merged release PRs outstanding - aborting
```

`Strategy.buildRelease()` runs once per crate and parses `${component}` and `${version}` from the merged PR title. A grouped title (`chore: release main`) cannot simultaneously satisfy 31 component patterns, so every per-crate build fails and the run aborts before tagging.

Per-package PRs sidestep the matching problem entirely. release-please only opens a PR for crates that have releasable changes, so the typical post-merge wave is 2–5 PRs, not 31.

## Recovery for PR #73

Run locally with a PAT that can push tags (the workflow's GITHUB_TOKEN cannot, see `docs/RELEASING.md`):

```
node scripts/recover-release.mjs 14cf4ea --dry-run   # inspect the plan
node scripts/recover-release.mjs 14cf4ea             # tag and push
```

That fires `release.yml` once per tag and publishes the 31 packages already bumped on `main`.

## Test plan

- [ ] `node scripts/recover-release.mjs 14cf4ea --dry-run` lists 31 missing tags pointing at the merge commit
- [ ] After running without `--dry-run`, every `<crate>@<version>` tag is on origin and `release.yml` succeeds for each
- [ ] On the next conventional commit landed on `main`, release-please opens one PR per affected crate (not a single grouped PR)
- [ ] Merging one of those PRs creates the tag, triggers `release.yml`, and publishes the package to npm

https://claude.ai/code/session_01AFcaLxHJDmjs8vW1dR4Rb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFcaLxHJDmjs8vW1dR4Rb1)_