### PR TITLE
fix(svgo): adopt quick-xml 0.40 with GeneralRef event support

### DIFF
--- a/crates/svgo/Cargo.toml
+++ b/crates/svgo/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-quick-xml = { version = "0.36", features = ["serialize"] }
+quick-xml = { version = "0.40", features = ["serialize"] }
 
 [build-dependencies]
 napi-build = "2"

--- a/crates/svgo/src/lib.rs
+++ b/crates/svgo/src/lib.rs
@@ -396,6 +396,7 @@ enum Node {
     Decl(Vec<u8>),
     PI(Vec<u8>),
     DocType(Vec<u8>),
+    GeneralRef(Vec<u8>),
 }
 
 fn parse(svg: &str, cfg: &Resolved) -> Vec<Node> {
@@ -456,6 +457,9 @@ fn parse_until_end(reader: &mut Reader<&[u8]>, close: Option<&[u8]>) -> Vec<Node
             }
             Event::DocType(d) => {
                 out.push(Node::DocType(d.as_ref().to_vec()));
+            }
+            Event::GeneralRef(r) => {
+                out.push(Node::GeneralRef(r.as_ref().to_vec()));
             }
         }
     }
@@ -602,6 +606,11 @@ fn serialize_node(w: &mut Writer<Cursor<Vec<u8>>>, n: &Node) {
         Node::DocType(bs) => {
             let s = std::str::from_utf8(bs).unwrap_or("");
             w.write_event(Event::DocType(BytesText::new(s))).ok();
+        }
+        Node::GeneralRef(bs) => {
+            let s = std::str::from_utf8(bs).unwrap_or("");
+            w.write_event(Event::GeneralRef(quick_xml::events::BytesRef::new(s)))
+                .ok();
         }
     }
 }


### PR DESCRIPTION
## Summary

Unblocks Dependabot PR #92 (`quick-xml 0.36 -> 0.40`) in `crates/svgo`.

quick-xml 0.40 split general entity references (`&name;`) into a new `Event::GeneralRef(BytesRef<'a>)` variant — previously, those bytes flowed through as part of `Event::Text`. The exhaustive match in `parse_until_end` failed to compile (`E0004: non-exhaustive patterns`).

Bump the dep and round-trip the new event:
- Add a `Node::GeneralRef(Vec<u8>)` variant storing the entity name bytes (the `transform` pass already has a wildcard arm that preserves it through).
- Reader: handle `Event::GeneralRef(r)` → `Node::GeneralRef(r.as_ref().to_vec())`.
- Writer: emit `Event::GeneralRef(BytesRef::new(name))`.

Supersedes #92 (which is just the version bump and would still fail to compile on its own).

## Changes

- `crates/svgo/Cargo.toml`: `quick-xml = "0.36"` → `"0.40"` (matches #92).
- `crates/svgo/src/lib.rs`: new `Node::GeneralRef` variant + reader/writer arms.

## Test plan

- [x] `cargo check -p amigo-svgo`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p amigo-svgo` (13/13 pass)
- [x] `pnpm --filter @amigo-labs/svgo build` + `test` (16/16 pass)
- [x] `pnpm --filter @amigo-labs/svgo test:conformance` (22/22 pass)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Meec44tgYU9JRtzAWzENji)_