### PR TITLE
chore(deps): bump htmlparser2 to 12.0.0, fix textarea entity decoding

### DIFF
--- a/crates/sanitize-html/compat.mjs
+++ b/crates/sanitize-html/compat.mjs
@@ -812,14 +812,15 @@ function tokenizerTransform(
         // keeping the wrapper.
         if (frame.suppressContent) return
         frame.rawText += text
-        // Text inside raw-text elements (script/style/textarea) is already
-        // delivered undecoded by htmlparser2 — escaping it here would
-        // double-encode entities like `&amp;`.
+        // Text inside raw-text elements (script/style) is delivered
+        // undecoded by htmlparser2 — escaping it here would double-encode
+        // entities like `&amp;`. As of htmlparser2 12.x, <textarea> is
+        // RCDATA: entities are decoded on the way in, so we must escape
+        // its text again on the way out.
         const isRawTextFrame =
           frame !== root &&
           (frame.emittedName === 'script' ||
             frame.emittedName === 'style' ||
-            frame.emittedName === 'textarea' ||
             frame.emittedName === 'pre')
         const ctxTag = frame === root ? '' : frame.emittedName
         const filtered = textFilter ? (textFilter(text, ctxTag) ?? text) : text

--- a/crates/sanitize-html/package.json
+++ b/crates/sanitize-html/package.json
@@ -43,7 +43,7 @@
     "bench": "vitest bench"
   },
   "dependencies": {
-    "htmlparser2": "^10.0.0"
+    "htmlparser2": "^12.0.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,8 +501,8 @@ importers:
   crates/sanitize-html:
     dependencies:
       htmlparser2:
-        specifier: ^10.0.0
-        version: 10.1.0
+        specifier: ^12.0.0
+        version: 12.0.0
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.6.2
@@ -2835,18 +2835,34 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
 
   dompurify@3.4.2:
     resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -3044,6 +3060,10 @@ packages:
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -5907,11 +5927,23 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   dompurify@3.4.2:
     optionalDependencies:
@@ -5922,6 +5954,12 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dotenv@17.4.2: {}
 
@@ -6167,6 +6205,13 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 7.0.1
+
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
 
   iconv-lite@0.7.2:
     dependencies:


### PR DESCRIPTION
## Summary

Supersedes #94. Bumps `htmlparser2` from `10.1.0` → `12.0.0` in `crates/sanitize-html` and fixes the two upstream-conformance regressions that the Dependabot PR triggered.

## Root cause

htmlparser2 12.x [aligns with the WHATWG spec](https://github.com/fb55/htmlparser2/releases/tag/v12.0.0) and now decodes entities inside `<textarea>` (RCDATA mode) the way it already did for `<title>`. Before 12.x, textarea text was delivered to `ontext()` undecoded.

`crates/sanitize-html/compat.mjs` (the JS-side `tokenizerTransform` shim that fronts the html5ever native sanitizer) was classifying `<textarea>` as a raw-text frame and pushing the decoded text into the intermediate buffer unescaped. With the bump, `<textarea>&lt;/textarea&gt;…</textarea>` became `<textarea></textarea>…</textarea>` in the intermediate string, which the native html5ever pass then terminated early — producing `<textarea></textarea>` with the content lost.

Fix: drop `textarea` from the raw-text frame list. Decoded text now flows through `escapeText` like any other element's text, restoring round-trip correctness. `<script>` and `<style>` remain raw-text (still genuinely raw in 12.x); `<pre>` is left alone (pre-existing, not exercised, out of scope for this bump).

## Test plan

- [x] `pnpm --filter @amigo-labs/sanitize-html test:conformance` → 225 / 1 skipped (was 223 / 2 failed / 1 skipped)
- [x] `pnpm --filter @amigo-labs/sanitize-html test` → 12 / 12
- [x] Both previously failing upstream tests now pass:
  - `should correctly maintain escaping when allowing a nonTextTags tag other than script or style`
  - `should not double-encode entities inside an allowed textarea element`
- [ ] CI: `test-node`, `test-conformance`, Workers preview build

https://claude.ai/code/session_01BtPUNGeBKVGSMVBmw3Fsem

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtPUNGeBKVGSMVBmw3Fsem)_