### PR TITLE
chore(ci): skip typst crate while typst-library 0.14.x is broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ env:
   # Mirrored by .claude/skills/audit-crates/scripts/audit.mjs (NODE_ONLY_CRATES)
   # and by .github/workflows/release.yml (the publish-job WASM build gate).
   NODE_ONLY_CRATES: 'argon2 jose jwt'
+  # Crates temporarily skipped in CI because of an unresolved upstream
+  # build break. Mirrors `[workspace] exclude` in Cargo.toml.
+  # Remove a crate from this list once it compiles again on stable rustc
+  # and unexclude it in Cargo.toml in the same commit.
+  #   typst — typst-library 0.14.x has an E0282 in foundations/str.rs:700
+  #           on stable rustc; fixed upstream but no crates.io release yet.
+  BROKEN_CRATES: 'typst'
 
 jobs:
   # ── change detection ────────────────────────────────────────────────────
@@ -190,6 +197,10 @@ jobs:
             if echo " $NODE_ONLY_CRATES " | grep -q " $crate "; then
               continue
             fi
+            if echo " $BROKEN_CRATES " | grep -q " $crate "; then
+              echo "::notice::Skipping wasm-test for $crate (in BROKEN_CRATES)"
+              continue
+            fi
             echo "::group::wasm-pack test $dir"
             (cd "$dir" && wasm-pack test --node)
             echo "::endgroup::"
@@ -256,6 +267,10 @@ jobs:
           for dir in $wasm_dirs; do
             crate=$(basename $(dirname "$dir"))
             if echo " $NODE_ONLY_CRATES " | grep -q " $crate "; then continue; fi
+            if echo " $BROKEN_CRATES " | grep -q " $crate "; then
+              echo "::notice::Skipping bundle-size for $crate (in BROKEN_CRATES)"
+              continue
+            fi
             echo "::group::bundle-size $crate"
             if ! (cd "$dir" && wasm-pack build --target bundler --release --out-dir pkg); then
               echo "::warning::wasm-pack build failed for $crate"
@@ -334,9 +349,14 @@ jobs:
           RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
         run: |
           set -euo pipefail
+          # Build the BROKEN_CRATES exclusion as pnpm `--filter '!@scope/x'`.
+          broken_filters=""
+          for b in $BROKEN_CRATES; do
+            broken_filters="$broken_filters --filter !@amigo-labs/$b"
+          done
           if [ "${{ needs.detect-changes.outputs.rebuildall }}" = "1" ]; then
             echo "::notice::Building all crates (rebuildall=1)"
-            pnpm -r --workspace-concurrency=4 run build
+            pnpm -r $broken_filters --workspace-concurrency=4 run build
           else
             echo "::notice::Building only: ${{ needs.detect-changes.outputs.crates }}"
             # commonmark is always built — `test-node` runs
@@ -345,6 +365,10 @@ jobs:
             # otherwise leave the artifact missing it.
             filters="--filter @amigo-labs/commonmark"
             for c in $(echo "${{ needs.detect-changes.outputs.crates }}" | tr ',' ' '); do
+              if echo " $BROKEN_CRATES " | grep -q " $c "; then
+                echo "::notice::Skipping build for $c (in BROKEN_CRATES)"
+                continue
+              fi
               filters="$filters --filter @amigo-labs/$c"
             done
             pnpm $filters --workspace-concurrency=4 run build
@@ -384,11 +408,19 @@ jobs:
       - name: Test crates
         run: |
           set -euo pipefail
+          broken_filters=""
+          for b in $BROKEN_CRATES; do
+            broken_filters="$broken_filters --filter !@amigo-labs/$b"
+          done
           if [ "${{ needs.detect-changes.outputs.rebuildall }}" = "1" ]; then
-            pnpm -r run test
+            pnpm -r $broken_filters run test
           else
             filters=""
             for c in $(echo "${{ needs.detect-changes.outputs.crates }}" | tr ',' ' '); do
+              if echo " $BROKEN_CRATES " | grep -q " $c "; then
+                echo "::notice::Skipping test for $c (in BROKEN_CRATES)"
+                continue
+              fi
               filters="$filters --filter @amigo-labs/$c"
             done
             pnpm $filters run test
@@ -422,10 +454,12 @@ jobs:
         # status so we still post the comment, then re-fail at the end.
         run: |
           set +e
+          # BROKEN_CRATES is space-separated; the script takes comma-separated.
+          exclude_csv=$(echo "$BROKEN_CRATES" | tr ' ' ',')
           if [ "${{ needs.detect-changes.outputs.rebuildall }}" = "1" ]; then
-            node scripts/conformance-summary.mjs
+            node scripts/conformance-summary.mjs --exclude "$exclude_csv"
           else
-            node scripts/conformance-summary.mjs --crates "${{ needs.detect-changes.outputs.crates }}"
+            node scripts/conformance-summary.mjs --crates "${{ needs.detect-changes.outputs.crates }}" --exclude "$exclude_csv"
           fi
           echo "exit=$?" >> "$GITHUB_OUTPUT"
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,11 @@ jobs:
         run: |
           set -euo pipefail
           # Build the BROKEN_CRATES exclusion as pnpm `--filter '!@scope/x'`.
-          broken_filters=""
+          # `!.` excludes the workspace root — pnpm normally skips it under
+          # `-r`, but as soon as any `--filter` is passed it gets pulled back
+          # in, and the root's `build` script (`pnpm -r run build`) would
+          # recurse without our filter and rebuild every excluded crate.
+          broken_filters="--filter !."
           for b in $BROKEN_CRATES; do
             broken_filters="$broken_filters --filter !@amigo-labs/$b"
           done
@@ -408,7 +412,10 @@ jobs:
       - name: Test crates
         run: |
           set -euo pipefail
-          broken_filters=""
+          # See the build job for why `!.` is required alongside the
+          # BROKEN_CRATES exclusions — the root's `test` script
+          # (`pnpm -r run test`) would otherwise recurse unfiltered.
+          broken_filters="--filter !."
           for b in $BROKEN_CRATES; do
             broken_filters="$broken_filters --filter !@amigo-labs/$b"
           done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 members = ["crates/*", "crates/*/wasm"]
-exclude = ["crates/_template"]
+# typst-{core,,/wasm} are excluded until a fix for the
+# `typst-library` E0282 type-inference bug
+# (foundations/str.rs:700 `self.as_ref().repr()`) is released upstream.
+# All released 0.14.x versions (0.14.0–0.14.2) trip the bug on current
+# stable rustc; upstream main has the `self.as_str()` fix but no new
+# crates.io release yet. CI mirrors this skip via `BROKEN_CRATES` in
+# .github/workflows/ci.yml.
+exclude = ["crates/_template", "crates/_typst-core", "crates/typst", "crates/typst/wasm"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/scripts/conformance-summary.mjs
+++ b/scripts/conformance-summary.mjs
@@ -8,7 +8,9 @@
  *   - conformance-summary.md   (PR comment / GITHUB_STEP_SUMMARY)
  *
  * Pass `--crates a,b,c` to restrict the run to a subset (used in CI
- * when only a subset of crates was rebuilt).
+ * when only a subset of crates was rebuilt). Pass `--exclude a,b,c`
+ * to skip specific crates regardless of the filter (used in CI to
+ * skip BROKEN_CRATES that don't currently build).
  */
 
 import { spawnSync } from 'node:child_process'
@@ -24,9 +26,16 @@ const cratesFilter =
     ? new Set(process.argv[cratesArgIdx + 1].split(',').map((s) => s.trim()).filter(Boolean))
     : null
 
+const excludeArgIdx = process.argv.indexOf('--exclude')
+const excludeSet =
+  excludeArgIdx !== -1 && process.argv[excludeArgIdx + 1]
+    ? new Set(process.argv[excludeArgIdx + 1].split(',').map((s) => s.trim()).filter(Boolean))
+    : new Set()
+
 const packages = []
 for (const entry of readdirSync(cratesDir)) {
   if (entry === '_template') continue
+  if (excludeSet.has(entry)) continue
   if (cratesFilter && !cratesFilter.has(entry)) continue
   const dir = join(cratesDir, entry, '__conformance__')
   if (!existsSync(dir) || !statSync(dir).isDirectory()) continue


### PR DESCRIPTION
## Why

PR #148 (a dependabot npm-minor bump) fails CI on `lint`, `test-rust`, `wasm-test`, and `build`. The PR diff is npm-only — none of the failures are about npm. Root cause is upstream:

- `typst-library` `0.14.0`, `0.14.1`, and `0.14.2` all hit `E0282: type annotations needed` at `src/foundations/str.rs:700` (`self.as_ref().repr()`) on current stable rustc (reproduced locally on rustc `1.94.1` *and* `1.93.1`).
- Upstream `typst/typst@main` has the fix (`self.as_str().repr()`) but no new crates.io release.
- Pointing `[patch.crates-io]` at upstream main pulls in unrelated API churn (`PagedDocument` path moved, `FileId::new` arity change, `VirtualPath::as_rooted_path` deprecated in favour of `get_with_slash`, `Datetime::today` trait signature change) which would require code changes in `crates/_typst-core/src/lib.rs`.
- `Cargo.lock` is gitignored so every CI run re-resolves; previous PR #146 only stayed green because `Swatinem/rust-cache` restored a pre-bug typst-library build.

## What

Temporarily quarantine the `typst` crate until upstream publishes a fixed `0.14.x`:

- `Cargo.toml`: add `crates/_typst-core`, `crates/typst`, `crates/typst/wasm` to `[workspace] exclude`. `cargo clippy --workspace` and `cargo test --workspace` no longer touch typst.
- `.github/workflows/ci.yml`: new `BROKEN_CRATES: 'typst'` env var (modelled on the existing `NODE_ONLY_CRATES` pattern), used to skip `typst` in:
  - `build` (`pnpm -r run build`) — both rebuildall and partial paths
  - `test-node` (`pnpm -r run test`) — both paths
  - `test-conformance` (passes `--exclude` to the summary script)
  - `wasm-test`
  - `bundle-size`
- `scripts/conformance-summary.mjs`: support a `--exclude a,b,c` flag, applied before the existing `--crates` filter.

The temporary state and re-introduction trigger are documented inline in both `Cargo.toml` and the new `BROKEN_CRATES` env block.

## Scope

This unblocks every PR that doesn't touch the `typst` crate (notably the open dependabot PR #148 and any future npm bumps). The `typst` crate itself does **not** build or test in this configuration — it gets re-enabled by removing the entries in `Cargo.toml`'s `exclude` and the env's `BROKEN_CRATES` value together with bumping the typst dep, in a single commit, once upstream releases a fix.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes locally
- [x] `cargo test --workspace --no-run` succeeds locally
- [x] `pnpm run lint` passes locally
- [x] `node scripts/sync-registry.mjs --check` passes
- [ ] CI on this PR is fully green
- [ ] After merge: rebase PR #148 and confirm its CI goes green

https://claude.ai/code/session_01Y2Dj6upSLqBbL8wRVawZZd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2Dj6upSLqBbL8wRVawZZd)_