### PR TITLE
Deep fixup: csv/xlsx boundary bugs, dual-target template, README + doc-drift cleanup

### DIFF
--- a/.claude/skills/audit-crates/SKILL.md
+++ b/.claude/skills/audit-crates/SKILL.md
@@ -89,8 +89,9 @@ A small, explicit allow-list of crates intentionally stays Node-only and
 
 The list is the single source of truth — duplicated as a constant in
 `audit.mjs` (`NODE_ONLY_CRATES`), `scripts/sync-registry.mjs`,
+`scripts/build-all-wasm.mjs`, `scripts/scaffold-wasm-bench.mjs`,
 `.github/workflows/ci.yml`, and `.github/workflows/release.yml`. To add
-or remove a crate from the group, edit all four spots together. See
+or remove a crate from the group, edit all six spots together. See
 `docs/specs/expansion-2026.md § Node.js server-only tier` for the policy.
 
 Globally:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,10 @@ jobs:
           fi
           for dir in $wasm_dirs; do
             crate=$(basename $(dirname "$dir"))
+            case "$crate" in _*)
+              # crates/_template/wasm is a scaffold (manifests are *.tmpl), not a crate
+              continue ;;
+            esac
             if echo " $NODE_ONLY_CRATES " | grep -q " $crate "; then
               continue
             fi
@@ -266,6 +270,8 @@ jobs:
           failed=0
           for dir in $wasm_dirs; do
             crate=$(basename $(dirname "$dir"))
+            # crates/_template/wasm is a scaffold (manifests are *.tmpl), not a crate
+            case "$crate" in _*) continue ;; esac
             if echo " $NODE_ONLY_CRATES " | grep -q " $crate "; then continue; fi
             if echo " $BROKEN_CRATES " | grep -q " $crate "; then
               echo "::notice::Skipping bundle-size for $crate (in BROKEN_CRATES)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,14 +129,16 @@ have a "WASM-target exclusion" section in their
 § Node.js server-only tier.
 
 The **single source of truth** for the group is the constant
-`NODE_ONLY_CRATES = {argon2, jose, jwt}`, duplicated in four places:
+`NODE_ONLY_CRATES = {argon2, jose, jwt}`, duplicated in six places:
 
 - `.claude/skills/audit-crates/scripts/audit.mjs`
 - `scripts/sync-registry.mjs`
+- `scripts/build-all-wasm.mjs`
+- `scripts/scaffold-wasm-bench.mjs`
 - `.github/workflows/ci.yml` (env var)
 - `.github/workflows/release.yml` (env var + `contains(fromJSON('…'))`)
 
-To add or remove a crate from the group, edit all four together and
+To add or remove a crate from the group, edit all six together and
 update the policy section in `expansion-2026.md`. The audit-crates
 skill verifies the invariants are upheld.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,9 +98,10 @@ there is a documented exclusion reason — see [`docs/specs/expansion-2026.md`](
 § Node.js server-only tier. Joining that tier requires either a
 performance perf-review entry (memory-hard / FFI-floor-dominated) or a
 threat-model rationale (private-key crypto). Add the crate's name to the
-`NODE_ONLY_CRATES` constant in all four spots
+`NODE_ONLY_CRATES` constant in all six spots
 (`.claude/skills/audit-crates/scripts/audit.mjs`,
-`scripts/sync-registry.mjs`, `.github/workflows/ci.yml`,
+`scripts/sync-registry.mjs`, `scripts/build-all-wasm.mjs`,
+`scripts/scaffold-wasm-bench.mjs`, `.github/workflows/ci.yml`,
 `.github/workflows/release.yml`) and to the policy table in
 `expansion-2026.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,34 +59,32 @@ reasoning.
 ./scripts/new-package.sh <name>
 ```
 
-Then:
+The scaffolder creates all three crates — the pure-Rust core at
+`crates/_<name>-core/`, the napi binding at `crates/<name>/`, and the
+WASM sub-crate at `crates/<name>/wasm/` — with the dual-target
+`package.json` fields (`browser`, conditional `exports`, the five
+`wasm/pkg/*` `files` entries, `build:wasm` / `build:all` / `test:wasm`,
+`amigo.targets: ["node", "browser"]`) already in place. Then:
 
-1. **Pure-Rust core** at `crates/_<name>-core/` (`publish = false`,
-   no napi / wasm-bindgen attributes — just the algorithm). This is
+1. Implement the algorithm in `crates/_<name>-core/src/lib.rs`
+   (`publish = false`, no napi / wasm-bindgen attributes). This is
    the single source of truth used by both bindings.
-2. Implement the napi surface in `crates/<name>/src/lib.rs` as a thin
+2. Fill in the napi surface in `crates/<name>/src/lib.rs` as a thin
    wrapper that translates `Buffer` / `BigInt` / option structs
    to/from the core types.
 3. Add the test suite at `crates/<name>/__test__/` and the upstream
    conformance corpus at `crates/<name>/__conformance__/`.
 4. Add benchmarks at `crates/<name>/__bench__/` that compare against the
    JS alternative you're replacing.
-5. **Add the WASM sub-crate** at `crates/<name>/wasm/` mirroring the
+5. Fill in the WASM sub-crate at `crates/<name>/wasm/`, mirroring the
    slugify pilot:
-   - `wasm/Cargo.toml` with `crate-type = ["cdylib", "rlib"]`,
-     `wasm-bindgen` / `serde-wasm-bindgen` from `[workspace.dependencies]`,
-     a path dep on `amigo-<name>-core`, and
-     `[package.metadata.wasm-pack.profile.release] wasm-opt = false`.
-   - `wasm/src/lib.rs` with `#[wasm_bindgen]` wrappers and
-     `js_name = "camelCase"` to mirror the napi surface.
-   - `wasm/tests/web.rs` with `wasm-bindgen-test` parity coverage.
-   - In `package.json`: add `browser`, conditional `exports`,
-     `build:wasm` / `build:all` / `test:wasm` scripts, the five
-     `wasm/pkg/*` entries in `files`, extend `prepublishOnly` to
-     `pnpm build:wasm && napi pre-publish ...`, and set
-     `amigo.targets: ["node", "browser"]`.
-   - In the README: an "Install for the browser" section pointing
-     at the same `import` (the bundler picks the WASM artifact).
+   - `wasm/src/lib.rs`: `#[wasm_bindgen]` wrappers with
+     `js_name = "camelCase"` to mirror the napi surface. Uncomment
+     `serde-wasm-bindgen` / `serde` in `wasm/Cargo.toml` if you need
+     option structs.
+   - `wasm/tests/web.rs`: `wasm-bindgen-test` parity coverage.
+   - In the README: flesh out the scaffolded "Install for the browser"
+     section (same `import`; the bundler picks the WASM artifact).
 6. Populate the `amigo` block in `crates/<name>/package.json` — then run
    `node scripts/sync-registry.mjs` to regenerate the root README table and
    `docs/packages.json` in one step. Don't edit those two files by hand.

--- a/PLAN.md
+++ b/PLAN.md
@@ -48,7 +48,7 @@ get built and tested (full 36-crate release build is out of scope).
       for an oversized row — use a row of 65,537 minimal cells.
       Verify: cargo test -p amigo-xlsx-core
 
-- [ ] T3: template/generator — scaffold core + wasm + dual-target package.json
+- [x] T3: template/generator — scaffold core + wasm + dual-target package.json
       Files: crates/_template/{core/Cargo.toml.tmpl, core/src/lib.rs,
              wasm/Cargo.toml.tmpl, wasm/src/lib.rs, wasm/tests/web.rs,
              README.md.tmpl} (new); crates/_template/{package.json.tmpl,

--- a/PLAN.md
+++ b/PLAN.md
@@ -24,7 +24,7 @@ get built and tested (full 36-crate release build is out of scope).
 
 ## Tasks
 
-- [ ] T1: csv — reject out-of-range delimiter/quote/escape/comment instead of silent u32→u8 truncation
+- [x] T1: csv — reject out-of-range delimiter/quote/escape/comment instead of silent u32→u8 truncation
       Files: crates/_csv-core/src/lib.rs:19-40 (+ tests), crates/csv/src/lib.rs, crates/csv/wasm/src/lib.rs (only if signatures shift)
       Change: `opts.delimiter as u8` etc. silently wraps (256 → NUL). Make the
       option translation fallible: validate each of delimiter/quote_char/

--- a/PLAN.md
+++ b/PLAN.md
@@ -115,10 +115,12 @@ get built and tested (full 36-crate release build is out of scope).
       "In flight" emptied (or this fixup session), expansion moved to
       "Recently shipped" (one summary row, not per-batch), "Next up" keeps
       only the still-open items — pack-verify CI step (absent from
-      workflows) and dashboard targets *filter* facet (TargetsPill display
-      exists, filter doesn't) — drops the README-subsection item (done in
+      workflows) — drops the README-subsection item (done in
       T4). Update header (date, branch), keep Q1/Q2 open questions table.
       Verify: re-read; no claim contradicts the repo state.
+      Correction (Copilot review): the dashboard targets filter DOES exist
+      (web/src/components/CategoryFilter.tsx, mounted on index.astro) — the
+      "Next up" entry claiming otherwise was removed again.
 
 - [x] T6: correct NODE_ONLY_CRATES "four places" undercount to six
       Files: CLAUDE.md:132, docs/specs/expansion-2026.md:427, CONTRIBUTING.md:103,
@@ -147,5 +149,4 @@ get built and tested (full 36-crate release build is out of scope).
   crates", 69116f5). Regenerating consistently needs a full `pnpm build` of
   all 36 packages — out of scope here; the churn was reverted.
 - pack-verify CI step (status.md backlog item — CI-only, can't validate locally)
-- dashboard "targets" filter facet in the web UI (feature, not drift)
 - full JS-side test run across all 36 packages (requires full release builds)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,136 @@
+# Deep Fixup Plan — 2026-06-10
+
+Session record for the analyze → plan → execute pass on branch
+`claude/deep-fixup-v7j8ey`. Tasks are executed top to bottom, one atomic
+commit per task (`T<nr>: <title>`).
+
+## Baseline (green bar)
+
+Measured before any change, all PASS:
+
+```bash
+cargo fmt --check
+cargo check --workspace          # ~57s
+cargo clippy --workspace -- -D warnings
+cargo test --workspace           # 50 suites
+```
+
+Full-session verification = the four commands above, plus the vitest suites
+of touched packages (csv, xlsx), `node scripts/render-readmes.mjs --check`,
+and `node scripts/sync-registry.mjs` idempotency after README changes.
+
+JS side: the container starts without `node_modules`; only touched packages
+get built and tested (full 36-crate release build is out of scope).
+
+## Tasks
+
+- [ ] T1: csv — reject out-of-range delimiter/quote/escape/comment instead of silent u32→u8 truncation
+      Files: crates/_csv-core/src/lib.rs:19-40 (+ tests), crates/csv/src/lib.rs, crates/csv/wasm/src/lib.rs (only if signatures shift)
+      Change: `opts.delimiter as u8` etc. silently wraps (256 → NUL). Make the
+      option translation fallible: validate each of delimiter/quote_char/
+      escape_char/comment with `u8::try_from`, returning
+      `Err("<option> must be a single byte (0-255), got <v>")`. `make_reader`
+      (and the writer-side equivalent) become `Result<_, String>`; all core
+      entry points (`parse`, `parse_with_headers`, `stringify`, …) already
+      return `Result<_, String>`, and both bindings propagate that — no
+      binding API change expected. Add core unit tests: delimiter 256 errors,
+      delimiter 44 still parses, quote/escape/comment 256+ error.
+      Verify: cargo test -p amigo-csv-core; pnpm --filter @amigo-labs/csv build:debug && vitest suite of crates/csv
+
+- [ ] T2: xlsx — error on >65,535 columns instead of silent u16 wraparound
+      Files: crates/_xlsx-core/src/lib.rs:165-188 (+ tests)
+      Change: `let col_u = c as u16;` wraps for c ≥ 65,536 → cells silently
+      land in wrong columns (rust_xlsxwriter only rejects 16,384–65,535).
+      Replace with `u16::try_from(c).map_err(...)` and
+      `u32::try_from(r).map_err(...)` returning a descriptive
+      `Err("row <r>: too many cells (<n>); XLSX allows at most 16384 columns")`.
+      Add a core unit test asserting `write_workbook` errors (not corrupts)
+      for an oversized row — use a row of 65,537 minimal cells.
+      Verify: cargo test -p amigo-xlsx-core
+
+- [ ] T3: template/generator — scaffold core + wasm + dual-target package.json
+      Files: crates/_template/{core/Cargo.toml.tmpl, core/src/lib.rs,
+             wasm/Cargo.toml.tmpl, wasm/src/lib.rs, wasm/tests/web.rs,
+             README.md.tmpl} (new); crates/_template/{package.json.tmpl,
+             Cargo.toml.tmpl, src/lib.rs} (modified);
+             scripts/new-package.sh; CONTRIBUTING.md §Adding a crate
+      Change: bring the generator up to the documented convention
+      (CLAUDE.md crate layout; reference impls: _slugify-core / slugify /
+      csv/package.json):
+      (a) `_template/core/` scaffold — `Cargo.toml.tmpl` (name
+          amigo-{{NAME}}-core, publish=false, edition 2024) + `src/lib.rs`
+          with a `hello()` stub + unit test; new-package.sh moves it to
+          `crates/_{{NAME}}-core`. Nested location keeps it invisible to the
+          workspace globs (`crates/*`, `crates/*/wasm`); no root Cargo.toml
+          change (prefix exclude + .tmpl manifests already cover
+          `_template/wasm`).
+      (b) `_template/wasm/` scaffold — Cargo.toml.tmpl (crate-type
+          ["cdylib","rlib"], workspace deps wasm-bindgen +
+          wasm-bindgen-test, commented serde lines, wasm-opt=false,
+          path dep on ../../_{{NAME}}-core), src/lib.rs delegating to
+          `amigo_{{NAME_UNDERSCORE}}_core::hello()`, tests/web.rs parity test.
+      (c) `package.json.tmpl` → full dual-target shape: browser field +
+          conditional exports + 5 wasm/pkg files entries (all using
+          `amigo_{{NAME_UNDERSCORE}}_wasm.*`), scripts build:wasm /
+          build:all / test:wasm / prepublishOnly, amigo block gains
+          `"targets": ["node", "browser"]` and `category`; dev-dep versions
+          aligned with csv (@napi-rs/cli ^3.6.2, fast-check ^4.8.0,
+          vitest ^4.1.7).
+      (d) `Cargo.toml.tmpl` adds `amigo-{{NAME}}-core = { path =
+          "../_{{NAME}}-core" }`; `src/lib.rs` delegates to core.
+      (e) `README.md.tmpl` minimal skeleton incl. "Install for the browser".
+      (f) `new-package.sh`: `NAME_UNDERSCORE=${NAME//-/_}`, second sed
+          expression for `{{NAME_UNDERSCORE}}`, `mv core → crates/_<name>-core`,
+          collision check for the core dir, both dirs in the find loops,
+          updated echo hints (core first, wasm wrappers, npm/ stubs,
+          build:all, test:wasm).
+      (g) CONTRIBUTING.md: reword steps 1 and 5 from "add X" to "fill in the
+          scaffolded X".
+      Verify: ./scripts/new-package.sh scratch-test-pkg; grep underscored
+      names in generated files; cargo check -p amigo-scratch-test-pkg-core
+      -p amigo-scratch-test-pkg -p amigo-scratch-test-pkg-wasm; cargo test
+      -p amigo-scratch-test-pkg-core; then rm -rf crates/scratch-test-pkg
+      crates/_scratch-test-pkg-core && git checkout -- Cargo.lock
+      (cleanup BEFORE any sync-registry/pnpm run).
+
+- [ ] T4: add "Install for the browser" README section to the 8 remaining dual-target crates
+      Files: crates/{diff,force-layout,graph-layout,pdf,pdf-parse,slugify,
+             text-splitters,xlsx}/README.md; docs/readmes/*.html (regenerated)
+      Change: closes the open status.md checkbox "README 'Install for the
+      browser' subsection per shipping crate" (25 of 33 done). Follow the
+      established patterns: bm25/README.md:64 for normal crates; check zip /
+      jimp wording for the bundle-heavy ones (pdf, pdf-parse, xlsx — mention
+      lazy import); text-splitters notes the tiktoken-on-wasm32 exclusion
+      (mirror existing wording in its README/MIGRATION if present). Then
+      regenerate the rendered fragments: pnpm install && pnpm --filter
+      @amigo-labs/commonmark build && node scripts/render-readmes.mjs.
+      Verify: node scripts/render-readmes.mjs --check; git diff shows only
+      the 8 READMEs + their 8 html fragments.
+
+- [ ] T5: rewrite stale status.md to post-expansion reality
+      Files: status.md
+      Change: last updated 2026-05-17; claims Batch 1 in progress
+      (tldts/turndown remaining), Batches 2/3 + edge cases unstarted, active
+      draft PR #134. Reality: all 33 dual-target crates shipped. Rewrite:
+      "In flight" emptied (or this fixup session), expansion moved to
+      "Recently shipped" (one summary row, not per-batch), "Next up" keeps
+      only the still-open items — pack-verify CI step (absent from
+      workflows) and dashboard targets *filter* facet (TargetsPill display
+      exists, filter doesn't) — drops the README-subsection item (done in
+      T4). Update header (date, branch), keep Q1/Q2 open questions table.
+      Verify: re-read; no claim contradicts the repo state.
+
+- [ ] T6: correct NODE_ONLY_CRATES "four places" undercount to six
+      Files: CLAUDE.md:132, docs/specs/expansion-2026.md:427, CONTRIBUTING.md:103
+      Change: the constant is duplicated in six places (audit.mjs,
+      sync-registry.mjs, build-all-wasm.mjs, scaffold-wasm-bench.mjs,
+      ci.yml, release.yml) — all values agree; only the prose count is
+      wrong. Update the three docs to list all six locations.
+      Verify: grep -rn "four places\|four spots" returns nothing relevant;
+      listed paths exist.
+
+## Not this session
+
+- pack-verify CI step (status.md backlog item — CI-only, can't validate locally)
+- dashboard "targets" filter facet in the web UI (feature, not drift)
+- full JS-side test run across all 36 packages (requires full release builds)

--- a/PLAN.md
+++ b/PLAN.md
@@ -107,7 +107,7 @@ get built and tested (full 36-crate release build is out of scope).
       Verify: node scripts/render-readmes.mjs --check; git diff shows only
       the 8 READMEs + their 8 html fragments.
 
-- [ ] T5: rewrite stale status.md to post-expansion reality
+- [x] T5: rewrite stale status.md to post-expansion reality
       Files: status.md
       Change: last updated 2026-05-17; claims Batch 1 in progress
       (tldts/turndown remaining), Batches 2/3 + edge cases unstarted, active

--- a/PLAN.md
+++ b/PLAN.md
@@ -93,7 +93,7 @@ get built and tested (full 36-crate release build is out of scope).
       crates/_scratch-test-pkg-core && git checkout -- Cargo.lock
       (cleanup BEFORE any sync-registry/pnpm run).
 
-- [ ] T4: add "Install for the browser" README section to the 8 remaining dual-target crates
+- [x] T4: add "Install for the browser" README section to the 8 remaining dual-target crates
       Files: crates/{diff,force-layout,graph-layout,pdf,pdf-parse,slugify,
              text-splitters,xlsx}/README.md; docs/readmes/*.html (regenerated)
       Change: closes the open status.md checkbox "README 'Install for the

--- a/PLAN.md
+++ b/PLAN.md
@@ -37,7 +37,7 @@ get built and tested (full 36-crate release build is out of scope).
       delimiter 44 still parses, quote/escape/comment 256+ error.
       Verify: cargo test -p amigo-csv-core; pnpm --filter @amigo-labs/csv build:debug && vitest suite of crates/csv
 
-- [ ] T2: xlsx — error on >65,535 columns instead of silent u16 wraparound
+- [x] T2: xlsx — error on >65,535 columns instead of silent u16 wraparound
       Files: crates/_xlsx-core/src/lib.rs:165-188 (+ tests)
       Change: `let col_u = c as u16;` wraps for c ≥ 65,536 → cells silently
       land in wrong columns (rust_xlsxwriter only rejects 16,384–65,535).
@@ -131,6 +131,13 @@ get built and tested (full 36-crate release build is out of scope).
 
 ## Not this session
 
+- Checked-in generated napi loaders are stale (discovered during T1): a local
+  `napi build` of csv regenerates `crates/csv/native.cjs` with the platform
+  package version check updated 0.1.0 → 0.1.1 and `native.d.ts` without doc
+  comments that no longer exist in `src/lib.rs`. The same drift likely affects
+  other crates (cf. earlier commit "Fix: index.js version drift across 26
+  crates", 69116f5). Regenerating consistently needs a full `pnpm build` of
+  all 36 packages — out of scope here; the churn was reverted.
 - pack-verify CI step (status.md backlog item — CI-only, can't validate locally)
 - dashboard "targets" filter facet in the web UI (feature, not drift)
 - full JS-side test run across all 36 packages (requires full release builds)

--- a/PLAN.md
+++ b/PLAN.md
@@ -130,6 +130,13 @@ get built and tested (full 36-crate release build is out of scope).
       Verify: grep -rn "four places\|four spots" returns nothing relevant;
       listed paths exist.
 
+## Follow-ups during PR babysitting
+
+- [x] fix(ci): the rebuild-all glob `ls -d crates/*/wasm` in the wasm-test and
+      bundle-size jobs picked up the new `crates/_template/wasm` scaffold and
+      failed (wasm-pack fell back to the workspace root manifest). Both loops
+      now skip `_`-prefixed dirs, matching the Node scripts' existing filter.
+
 ## Not this session
 
 - Checked-in generated napi loaders are stale (discovered during T1): a local

--- a/PLAN.md
+++ b/PLAN.md
@@ -120,8 +120,9 @@ get built and tested (full 36-crate release build is out of scope).
       T4). Update header (date, branch), keep Q1/Q2 open questions table.
       Verify: re-read; no claim contradicts the repo state.
 
-- [ ] T6: correct NODE_ONLY_CRATES "four places" undercount to six
-      Files: CLAUDE.md:132, docs/specs/expansion-2026.md:427, CONTRIBUTING.md:103
+- [x] T6: correct NODE_ONLY_CRATES "four places" undercount to six
+      Files: CLAUDE.md:132, docs/specs/expansion-2026.md:427, CONTRIBUTING.md:103,
+             .claude/skills/audit-crates/SKILL.md:93 (4th occurrence found during execution)
       Change: the constant is duplicated in six places (audit.mjs,
       sync-registry.mjs, build-all-wasm.mjs, scaffold-wasm-bench.mjs,
       ci.yml, release.yml) — all values agree; only the prose count is

--- a/crates/_csv-core/src/lib.rs
+++ b/crates/_csv-core/src/lib.rs
@@ -16,10 +16,22 @@ pub struct CsvOptions {
     pub trim_fields: Option<bool>,
 }
 
-pub fn make_reader(opts: &CsvOptions) -> ReaderBuilder {
+/// Validates a single-byte option coming from JS (where it arrives as a
+/// plain number). Values above 255 used to be truncated with `as u8`,
+/// silently turning e.g. `{delimiter: 256}` into a NUL byte.
+fn byte_opt(name: &str, value: Option<u32>) -> Result<Option<u8>, String> {
+    match value {
+        None => Ok(None),
+        Some(v) => u8::try_from(v)
+            .map(Some)
+            .map_err(|_| format!("{name} must be a single byte (0-255), got {v}")),
+    }
+}
+
+pub fn make_reader(opts: &CsvOptions) -> Result<ReaderBuilder, String> {
     let mut builder = ReaderBuilder::new();
     builder
-        .delimiter(opts.delimiter.unwrap_or(44) as u8)
+        .delimiter(byte_opt("delimiter", opts.delimiter)?.unwrap_or(b','))
         .has_headers(opts.has_headers.unwrap_or(true))
         .flexible(opts.flexible.unwrap_or(false))
         .trim(if opts.trim_fields.unwrap_or(false) {
@@ -27,20 +39,26 @@ pub fn make_reader(opts: &CsvOptions) -> ReaderBuilder {
         } else {
             Trim::None
         });
-    if let Some(q) = opts.quote_char {
-        builder.quote(q as u8);
+    if let Some(q) = byte_opt("quoteChar", opts.quote_char)? {
+        builder.quote(q);
     }
-    if let Some(e) = opts.escape_char {
-        builder.escape(Some(e as u8));
+    if let Some(e) = byte_opt("escapeChar", opts.escape_char)? {
+        builder.escape(Some(e));
     }
-    if let Some(c) = opts.comment {
-        builder.comment(Some(c as u8));
+    if let Some(c) = byte_opt("comment", opts.comment)? {
+        builder.comment(Some(c));
     }
-    builder
+    Ok(builder)
+}
+
+fn make_writer(opts: &CsvOptions) -> Result<WriterBuilder, String> {
+    let mut builder = WriterBuilder::new();
+    builder.delimiter(byte_opt("delimiter", opts.delimiter)?.unwrap_or(b','));
+    Ok(builder)
 }
 
 pub fn parse(input: &[u8], opts: &CsvOptions) -> Result<Vec<Vec<String>>, String> {
-    let mut reader = make_reader(opts).from_reader(input);
+    let mut reader = make_reader(opts)?.from_reader(input);
     let mut rows = Vec::new();
     for result in reader.records() {
         let record = result.map_err(|e| e.to_string())?;
@@ -53,7 +71,7 @@ pub fn parse_with_headers(
     input: &[u8],
     opts: &CsvOptions,
 ) -> Result<Vec<HashMap<String, String>>, String> {
-    let mut builder = make_reader(opts);
+    let mut builder = make_reader(opts)?;
     builder.has_headers(true);
     let mut reader = builder.from_reader(input);
 
@@ -79,9 +97,7 @@ pub fn parse_with_headers(
 }
 
 pub fn stringify(rows: Vec<Vec<String>>, opts: &CsvOptions) -> Result<String, String> {
-    let mut writer = WriterBuilder::new()
-        .delimiter(opts.delimiter.unwrap_or(44) as u8)
-        .from_writer(Vec::new());
+    let mut writer = make_writer(opts)?.from_writer(Vec::new());
     for row in rows {
         writer.write_record(&row).map_err(|e| e.to_string())?;
     }
@@ -94,9 +110,7 @@ pub fn stringify_objects(
     columns: Option<Vec<String>>,
     opts: &CsvOptions,
 ) -> Result<String, String> {
-    let mut writer = WriterBuilder::new()
-        .delimiter(opts.delimiter.unwrap_or(44) as u8)
-        .from_writer(Vec::new());
+    let mut writer = make_writer(opts)?.from_writer(Vec::new());
 
     let cols = columns.unwrap_or_else(|| {
         if let Some(first) = rows.first() {
@@ -118,7 +132,7 @@ pub fn stringify_objects(
 }
 
 pub fn count_rows(input: &[u8], opts: &CsvOptions) -> Result<u32, String> {
-    let mut reader = make_reader(opts).from_reader(input);
+    let mut reader = make_reader(opts)?.from_reader(input);
     let mut count = 0u32;
     for result in reader.records() {
         result.map_err(|e| e.to_string())?;
@@ -128,7 +142,7 @@ pub fn count_rows(input: &[u8], opts: &CsvOptions) -> Result<u32, String> {
 }
 
 pub fn parse_to_json(input: &[u8], opts: &CsvOptions) -> Result<String, String> {
-    let mut reader = make_reader(opts).from_reader(input);
+    let mut reader = make_reader(opts)?.from_reader(input);
     let mut out = String::from("[");
     let mut first_row = true;
     for result in reader.records() {
@@ -161,4 +175,62 @@ pub fn parse_to_json(input: &[u8], opts: &CsvOptions) -> Result<String, String> 
     }
     out.push(']');
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts_with(f: impl FnOnce(&mut CsvOptions)) -> CsvOptions {
+        let mut o = CsvOptions::default();
+        f(&mut o);
+        o
+    }
+
+    #[test]
+    fn parse_with_custom_delimiter() {
+        let opts = opts_with(|o| {
+            o.delimiter = Some(u32::from(b';'));
+            o.has_headers = Some(false);
+        });
+        let rows = parse(b"a;b\nc;d\n", &opts).unwrap();
+        assert_eq!(rows, vec![vec!["a", "b"], vec!["c", "d"]]);
+    }
+
+    #[test]
+    fn parse_rejects_out_of_range_delimiter() {
+        let opts = opts_with(|o| o.delimiter = Some(256));
+        let err = parse(b"a,b\n", &opts).unwrap_err();
+        assert_eq!(err, "delimiter must be a single byte (0-255), got 256");
+    }
+
+    #[test]
+    fn parse_rejects_out_of_range_quote_escape_comment() {
+        for (name, set) in [
+            (
+                "quoteChar",
+                &(|o: &mut CsvOptions| o.quote_char = Some(300)) as &dyn Fn(&mut _),
+            ),
+            ("escapeChar", &|o: &mut CsvOptions| {
+                o.escape_char = Some(1000)
+            }),
+            ("comment", &|o: &mut CsvOptions| o.comment = Some(u32::MAX)),
+        ] {
+            let opts = opts_with(|o| set(o));
+            let err = parse(b"a,b\n", &opts).unwrap_err();
+            assert!(
+                err.starts_with(&format!("{name} must be a single byte")),
+                "unexpected error for {name}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn stringify_rejects_out_of_range_delimiter() {
+        let opts = opts_with(|o| o.delimiter = Some(256));
+        let err = stringify(vec![vec!["a".to_string()]], &opts).unwrap_err();
+        assert_eq!(err, "delimiter must be a single byte (0-255), got 256");
+        let err = stringify_objects(Vec::new(), None, &opts).unwrap_err();
+        assert_eq!(err, "delimiter must be a single byte (0-255), got 256");
+    }
 }

--- a/crates/_template/Cargo.toml.tmpl
+++ b/crates/_template/Cargo.toml.tmpl
@@ -7,6 +7,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
+amigo-{{NAME}}-core = { path = "../_{{NAME}}-core" }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 

--- a/crates/_template/README.md.tmpl
+++ b/crates/_template/README.md.tmpl
@@ -1,0 +1,28 @@
+# @amigo-labs/{{NAME}}
+
+> TODO: one-sentence pitch — what does this replace and why is it faster?
+
+## Install
+
+```bash
+pnpm add @amigo-labs/{{NAME}}
+```
+
+## Usage
+
+```js
+import { hello } from '@amigo-labs/{{NAME}}'
+
+hello()
+// 'Hello from {{NAME}}!'
+```
+
+## Install for the browser
+
+The same `import` works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the `browser` conditional export:
+
+```js
+import { hello } from '@amigo-labs/{{NAME}}'
+```
+
+The `_{{NAME}}-core` crate is the same code on both sides, so behavior is identical between Node and the browser.

--- a/crates/_template/core/Cargo.toml.tmpl
+++ b/crates/_template/core/Cargo.toml.tmpl
@@ -1,0 +1,11 @@
+[package]
+name = "amigo-{{NAME}}-core"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+# Internal-only. No cdylib — consumed by @amigo-labs/{{NAME}} via
+# [dependencies]. Pattern parallels crates/_slugify-core/.
+
+[dependencies]

--- a/crates/_template/core/src/lib.rs
+++ b/crates/_template/core/src/lib.rs
@@ -1,0 +1,17 @@
+//! Shared logic for @amigo-labs/{{NAME}} — the single source of truth used
+//! by both the napi binding (`crates/{{NAME}}/`) and the WASM binding
+//! (`crates/{{NAME}}/wasm/`). No FFI types, no napi/wasm-bindgen attributes.
+
+pub fn hello() -> String {
+    "Hello from {{NAME}}!".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hello_works() {
+        assert_eq!(hello(), "Hello from {{NAME}}!");
+    }
+}

--- a/crates/_template/package.json.tmpl
+++ b/crates/_template/package.json.tmpl
@@ -4,10 +4,28 @@
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",
+  "browser": "./wasm/pkg/amigo_{{NAME_UNDERSCORE}}_wasm.js",
+  "exports": {
+    ".": {
+      "browser": {
+        "types": "./wasm/pkg/amigo_{{NAME_UNDERSCORE}}_wasm.d.ts",
+        "default": "./wasm/pkg/amigo_{{NAME_UNDERSCORE}}_wasm.js"
+      },
+      "default": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",
-    "README.md"
+    "README.md",
+    "wasm/pkg/amigo_{{NAME_UNDERSCORE}}_wasm.js",
+    "wasm/pkg/amigo_{{NAME_UNDERSCORE}}_wasm_bg.js",
+    "wasm/pkg/amigo_{{NAME_UNDERSCORE}}_wasm_bg.wasm",
+    "wasm/pkg/amigo_{{NAME_UNDERSCORE}}_wasm.d.ts",
+    "wasm/pkg/amigo_{{NAME_UNDERSCORE}}_wasm_bg.wasm.d.ts"
   ],
   "napi": {
     "binaryName": "{{NAME}}",
@@ -24,16 +42,19 @@
     "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "prepublishOnly": "napi pre-publish --skip-optional-publish --no-gh-release",
+    "build:wasm": "cd wasm && wasm-pack build --target bundler --release --out-dir pkg",
+    "build:all": "pnpm build && pnpm build:wasm",
+    "prepublishOnly": "pnpm build:wasm && napi pre-publish --skip-optional-publish --no-gh-release",
     "test": "vitest run __test__",
     "test:conformance": "vitest run __conformance__",
+    "test:wasm": "cd wasm && wasm-pack test --node",
     "test:all": "vitest run",
     "bench": "vitest bench"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3.5.0",
-    "fast-check": "^3.23.0",
-    "vitest": "^3.0.0"
+    "@napi-rs/cli": "^3.6.2",
+    "fast-check": "^4.8.0",
+    "vitest": "^4.1.7"
   },
   "license": "MIT",
   "repository": {
@@ -46,12 +67,14 @@
   },
   "amigo": {
     "title": "{{NAME}}",
+    "category": "util",
     "description": "TODO: one-sentence pitch for the dashboard.",
     "tableDescription": "TODO: short pitch for the README table.",
     "replaces": "{{NAME}}",
     "vsJs": "TBD",
     "parity": "TBD",
     "status": "Drop-in",
+    "targets": ["node", "browser"],
     "competitors": []
   }
 }

--- a/crates/_template/wasm/Cargo.toml.tmpl
+++ b/crates/_template/wasm/Cargo.toml.tmpl
@@ -1,0 +1,25 @@
+[package]
+name = "amigo-{{NAME}}-wasm"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+# rlib needed for wasm-bindgen-test to link against the crate's symbols;
+# cdylib is the actual WASM artifact emitted by wasm-pack.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+amigo-{{NAME}}-core = { path = "../../_{{NAME}}-core" }
+wasm-bindgen = { workspace = true }
+# Uncomment for option-struct / object marshalling:
+# serde-wasm-bindgen = { workspace = true }
+# serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
+[package.metadata.wasm-pack.profile.release]
+# wasm-pack tries to download a prebuilt binaryen at build time;
+# we disable it and run wasm-opt -Oz in CI as a separate step.
+wasm-opt = false

--- a/crates/_template/wasm/src/lib.rs
+++ b/crates/_template/wasm/src/lib.rs
@@ -1,6 +1,6 @@
-use napi_derive::napi;
+use wasm_bindgen::prelude::*;
 
-#[napi]
+#[wasm_bindgen]
 pub fn hello() -> String {
     amigo_{{NAME_UNDERSCORE}}_core::hello()
 }

--- a/crates/_template/wasm/tests/web.rs
+++ b/crates/_template/wasm/tests/web.rs
@@ -1,0 +1,9 @@
+use wasm_bindgen_test::*;
+
+// Default runner is Node (`pnpm test:wasm` → `wasm-pack test --node`).
+// Keep these in parity with crates/{{NAME}}/__test__/.
+
+#[wasm_bindgen_test]
+fn hello_works() {
+    assert_eq!(amigo_{{NAME_UNDERSCORE}}_wasm::hello(), "Hello from {{NAME}}!");
+}

--- a/crates/_xlsx-core/src/lib.rs
+++ b/crates/_xlsx-core/src/lib.rs
@@ -164,8 +164,21 @@ pub fn write_workbook(sheets: Vec<WriteSheet>) -> Result<Vec<u8>, String> {
             .map_err(|e| format!("sheet name: {e}"))?;
         for (r, row) in sheet_spec.rows.iter().enumerate() {
             for (c, cell) in row.iter().enumerate() {
-                let row_u = r as u32;
-                let col_u = c as u16;
+                // Checked conversions: `as` would silently wrap large indexes
+                // back into the valid range (e.g. cell 65,536 → column 0).
+                // rust_xlsxwriter enforces the actual XLSX limits (1,048,576
+                // rows × 16,384 columns) for everything below the wrap point.
+                let row_u = u32::try_from(r).map_err(|_| {
+                    format!("sheet {:?}: too many rows ({})", sheet_spec.name, r + 1)
+                })?;
+                let col_u = u16::try_from(c).map_err(|_| {
+                    format!(
+                        "sheet {:?} row {}: too many cells ({})",
+                        sheet_spec.name,
+                        r + 1,
+                        c + 1
+                    )
+                })?;
                 match cell.kind.as_str() {
                     "string" => {
                         ws.write_string(row_u, col_u, cell.text.clone().unwrap_or_default())
@@ -239,4 +252,43 @@ pub fn write_sheet_from_objects(
         name: sheet_name.to_string(),
         rows: sheet_rows,
     }])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell(kind: &str, text: Option<&str>) -> WriteCell {
+        WriteCell {
+            kind: kind.to_string(),
+            text: text.map(str::to_string),
+            number: None,
+            bool_value: None,
+        }
+    }
+
+    #[test]
+    fn write_workbook_errors_instead_of_wrapping_column_index() {
+        // 65,536 skipped cells followed by a real one: with `c as u16` the
+        // string would silently land in column 0; now the row must error.
+        let mut row: Vec<WriteCell> = vec![cell("empty", None); 65_536];
+        row.push(cell("string", Some("overflow")));
+        let err = write_workbook(vec![WriteSheet {
+            name: "Sheet1".to_string(),
+            rows: vec![row],
+        }])
+        .unwrap_err();
+        assert_eq!(err, "sheet \"Sheet1\" row 1: too many cells (65537)");
+    }
+
+    #[test]
+    fn write_workbook_small_sheet_still_works() {
+        let bytes = write_workbook(vec![WriteSheet {
+            name: "Sheet1".to_string(),
+            rows: vec![vec![cell("string", Some("hi"))]],
+        }])
+        .unwrap();
+        // XLSX is a ZIP container: PK\x03\x04 magic.
+        assert_eq!(&bytes[..4], b"PK\x03\x04");
+    }
 }

--- a/crates/diff/README.md
+++ b/crates/diff/README.md
@@ -38,6 +38,16 @@ createPatch('file.txt', oldContent, newContent)
 //  gamma
 ```
 
+## Install for the browser
+
+The same `import` works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the `browser` conditional export:
+
+```ts
+import { diffLines, diffWords, diffChars } from '@amigo-labs/diff'
+```
+
+The `_diff-core` crate is the same code on both sides, so hunks are identical between Node and the browser.
+
 ## Offset-packed hot-path
 
 For large documents or char-level diffs, the hunk-array shape spends

--- a/crates/force-layout/README.md
+++ b/crates/force-layout/README.md
@@ -28,6 +28,16 @@ const { nodes } = simulate(
 // nodes → [{ id, x, y, vx, vy }, ...]
 ```
 
+## Install for the browser
+
+The same `import` works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the `browser` conditional export:
+
+```ts
+import { simulate } from '@amigo-labs/force-layout'
+```
+
+The `_force-layout-core` simulation is the same code on both sides, so layouts are identical between Node and the browser.
+
 ## Options
 
 ```ts

--- a/crates/graph-layout/README.md
+++ b/crates/graph-layout/README.md
@@ -39,6 +39,16 @@ const result = layout({
 layoutMany([spec1, spec2, spec3])
 ```
 
+## Install for the browser
+
+The same `import` works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the `browser` conditional export:
+
+```ts
+import { layout, layoutMany } from '@amigo-labs/graph-layout'
+```
+
+The `_graph-layout-core` engine is the same code on both sides, so node positions are identical between Node and the browser.
+
 ## Options
 
 ```ts

--- a/crates/pdf-parse/README.md
+++ b/crates/pdf-parse/README.md
@@ -27,6 +27,20 @@ console.log(result.version)     // '1.7'
 const sync = parseSync(buf)
 ```
 
+## Install for the browser
+
+The same `import` works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the `browser` conditional export:
+
+```ts
+import { parse } from '@amigo-labs/pdf-parse'
+```
+
+The PDF parser makes this one of the heavier WASM bundles in the family — consider lazy-importing in code-split routes:
+
+```ts
+const { parse } = await import('@amigo-labs/pdf-parse')
+```
+
 ## Options
 
 ```ts

--- a/crates/pdf/README.md
+++ b/crates/pdf/README.md
@@ -45,6 +45,20 @@ fs.writeFileSync('invoice.pdf', buf)
 const buffers = generateMany(labelSpecs)
 ```
 
+## Install for the browser
+
+The same `import` works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the `browser` conditional export:
+
+```ts
+import { generate } from '@amigo-labs/pdf'
+```
+
+The PDF engine makes this one of the heavier WASM bundles in the family — consider lazy-importing in code-split routes:
+
+```ts
+const { generate } = await import('@amigo-labs/pdf')
+```
+
 ## Element shapes
 
 ```ts

--- a/crates/slugify/README.md
+++ b/crates/slugify/README.md
@@ -37,6 +37,16 @@ slugify("日本語テスト"); // "ri-ben-yu-tesuto"
 slugifyWithSeparator("Hello World!", "_"); // "hello_world"
 ```
 
+## Install for the browser
+
+The same `import` works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the `browser` conditional export:
+
+```ts
+import { slugify, slugifyWithSeparator } from "@amigo-labs/slugify";
+```
+
+The `_slugify-core` crate is the same code on both sides, so output is identical between Node and the browser.
+
 ## API
 
 ### `slugify(input): string`

--- a/crates/text-splitters/README.md
+++ b/crates/text-splitters/README.md
@@ -43,6 +43,16 @@ splitTextBatch([doc1, doc2, doc3], { chunkSize: 1000 })
 countTokens('hello world', 'tiktoken:cl100k_base')
 ```
 
+## Install for the browser
+
+The same `import` works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the `browser` conditional export:
+
+```ts
+import { splitText, splitMarkdown, countChars } from '@amigo-labs/text-splitters'
+```
+
+**Token metrics are Node-only.** `countTokens` and `lengthMetric: "tiktoken:*"` throw in the WASM build — the tiktoken-rs BPE tables (~1.5 MB) don't ship on wasm32. Use `countChars` / character-based metrics in the browser.
+
 ## Options
 
 ```ts

--- a/crates/xlsx/README.md
+++ b/crates/xlsx/README.md
@@ -53,6 +53,20 @@ const buf2 = writeSheetFromObjects('People', [
 ])
 ```
 
+## Install for the browser
+
+The same `import` works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the `browser` conditional export:
+
+```ts
+import { readWorkbook, writeWorkbook } from '@amigo-labs/xlsx'
+```
+
+The XLSX engine makes this one of the heavier WASM bundles in the family — consider lazy-importing in code-split routes:
+
+```ts
+const { readWorkbook } = await import('@amigo-labs/xlsx')
+```
+
 ## Cell shape
 
 ```ts

--- a/docs/readmes/diff.html
+++ b/docs/readmes/diff.html
@@ -32,6 +32,11 @@ createPatch('file.txt', oldContent, newContent)
 // +BETA
 //  gamma
 </code></pre>
+<h2 id="install-for-the-browser">Install for the browser</h2>
+<p>The same <code>import</code> works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the <code>browser</code> conditional export:</p>
+<pre><code class="language-ts">import { diffLines, diffWords, diffChars } from '@amigo-labs/diff'
+</code></pre>
+<p>The <code>_diff-core</code> crate is the same code on both sides, so hunks are identical between Node and the browser.</p>
 <h2 id="offset-packed-hot-path">Offset-packed hot-path</h2>
 <p>For large documents or char-level diffs, the hunk-array shape spends
 most of its time on <code>Vec&lt;String&gt;</code> FFI marshalling. Switch to the

--- a/docs/readmes/force-layout.html
+++ b/docs/readmes/force-layout.html
@@ -22,6 +22,11 @@ const { nodes } = simulate(
 
 // nodes → [{ id, x, y, vx, vy }, ...]
 </code></pre>
+<h2 id="install-for-the-browser">Install for the browser</h2>
+<p>The same <code>import</code> works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the <code>browser</code> conditional export:</p>
+<pre><code class="language-ts">import { simulate } from '@amigo-labs/force-layout'
+</code></pre>
+<p>The <code>_force-layout-core</code> simulation is the same code on both sides, so layouts are identical between Node and the browser.</p>
 <h2 id="options">Options</h2>
 <pre><code class="language-ts">interface SimulationOptions {
   iterations?: number      // default 300

--- a/docs/readmes/graph-layout.html
+++ b/docs/readmes/graph-layout.html
@@ -33,6 +33,11 @@ const result = layout({
 // Batch N layouts in a single FFI call (CI-time graph rendering):
 layoutMany([spec1, spec2, spec3])
 </code></pre>
+<h2 id="install-for-the-browser">Install for the browser</h2>
+<p>The same <code>import</code> works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the <code>browser</code> conditional export:</p>
+<pre><code class="language-ts">import { layout, layoutMany } from '@amigo-labs/graph-layout'
+</code></pre>
+<p>The <code>_graph-layout-core</code> engine is the same code on both sides, so node positions are identical between Node and the browser.</p>
 <h2 id="options">Options</h2>
 <pre><code class="language-ts">interface LayoutOptions {
   rankdir?: 'TB' | 'BT' | 'LR' | 'RL'    // default 'TB'

--- a/docs/readmes/pdf-parse.html
+++ b/docs/readmes/pdf-parse.html
@@ -21,6 +21,13 @@ console.log(result.version)     // '1.7'
 // Sync path for small PDFs (&lt; ~500 KB):
 const sync = parseSync(buf)
 </code></pre>
+<h2 id="install-for-the-browser">Install for the browser</h2>
+<p>The same <code>import</code> works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the <code>browser</code> conditional export:</p>
+<pre><code class="language-ts">import { parse } from '@amigo-labs/pdf-parse'
+</code></pre>
+<p>The PDF parser makes this one of the heavier WASM bundles in the family — consider lazy-importing in code-split routes:</p>
+<pre><code class="language-ts">const { parse } = await import('@amigo-labs/pdf-parse')
+</code></pre>
 <h2 id="options">Options</h2>
 <pre><code class="language-ts">interface PdfParseOptions {
   max?: number         // process at most N pages

--- a/docs/readmes/pdf.html
+++ b/docs/readmes/pdf.html
@@ -39,6 +39,13 @@ fs.writeFileSync('invoice.pdf', buf)
 // Batch — one FFI crossing for the whole label-printing job:
 const buffers = generateMany(labelSpecs)
 </code></pre>
+<h2 id="install-for-the-browser">Install for the browser</h2>
+<p>The same <code>import</code> works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the <code>browser</code> conditional export:</p>
+<pre><code class="language-ts">import { generate } from '@amigo-labs/pdf'
+</code></pre>
+<p>The PDF engine makes this one of the heavier WASM bundles in the family — consider lazy-importing in code-split routes:</p>
+<pre><code class="language-ts">const { generate } = await import('@amigo-labs/pdf')
+</code></pre>
 <h2 id="element-shapes">Element shapes</h2>
 <pre><code class="language-ts">type PdfElement =
   | { kind: 'text'; text: { x: number; y: number; text: string; fontSize?: number } }

--- a/docs/readmes/slugify.html
+++ b/docs/readmes/slugify.html
@@ -28,6 +28,11 @@ slugify("日本語テスト"); // "ri-ben-yu-tesuto"
 // With custom separator
 slugifyWithSeparator("Hello World!", "_"); // "hello_world"
 </code></pre>
+<h2 id="install-for-the-browser">Install for the browser</h2>
+<p>The same <code>import</code> works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the <code>browser</code> conditional export:</p>
+<pre><code class="language-ts">import { slugify, slugifyWithSeparator } from "@amigo-labs/slugify";
+</code></pre>
+<p>The <code>_slugify-core</code> crate is the same code on both sides, so output is identical between Node and the browser.</p>
 <h2 id="api">API</h2>
 <h3 id="slugify-input-string"><code>slugify(input): string</code></h3>
 <p>Converts a string into a URL-friendly slug using <code>-</code> as separator.</p>

--- a/docs/readmes/text-splitters.html
+++ b/docs/readmes/text-splitters.html
@@ -36,6 +36,11 @@ splitTextBatch([doc1, doc2, doc3], { chunkSize: 1000 })
 
 countTokens('hello world', 'tiktoken:cl100k_base')
 </code></pre>
+<h2 id="install-for-the-browser">Install for the browser</h2>
+<p>The same <code>import</code> works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the <code>browser</code> conditional export:</p>
+<pre><code class="language-ts">import { splitText, splitMarkdown, countChars } from '@amigo-labs/text-splitters'
+</code></pre>
+<p><strong>Token metrics are Node-only.</strong> <code>countTokens</code> and <code>lengthMetric: "tiktoken:*"</code> throw in the WASM build — the tiktoken-rs BPE tables (~1.5 MB) don’t ship on wasm32. Use <code>countChars</code> / character-based metrics in the browser.</p>
 <h2 id="options">Options</h2>
 <pre><code class="language-ts">interface SplitterOptions {
   chunkSize?: number       // default 1000

--- a/docs/readmes/xlsx.html
+++ b/docs/readmes/xlsx.html
@@ -43,6 +43,13 @@ const buf2 = writeSheetFromObjects('People', [
   { name: { kind: 'string', text: 'Alice' }, age: { kind: 'number', number: 30 } },
 ])
 </code></pre>
+<h2 id="install-for-the-browser">Install for the browser</h2>
+<p>The same <code>import</code> works in Angular, React, Vite, esbuild, and webpack ≥ 5 — the bundler picks the WASM build via the <code>browser</code> conditional export:</p>
+<pre><code class="language-ts">import { readWorkbook, writeWorkbook } from '@amigo-labs/xlsx'
+</code></pre>
+<p>The XLSX engine makes this one of the heavier WASM bundles in the family — consider lazy-importing in code-split routes:</p>
+<pre><code class="language-ts">const { readWorkbook } = await import('@amigo-labs/xlsx')
+</code></pre>
 <h2 id="cell-shape">Cell shape</h2>
 <pre><code class="language-ts">interface CellValue {
   kind: 'string' | 'number' | 'bool' | 'date' | 'empty' | 'error'

--- a/docs/specs/expansion-2026.md
+++ b/docs/specs/expansion-2026.md
@@ -424,11 +424,12 @@ Each carries `amigo.targets: ["node"]` in its `package.json` and a
 "WASM-target exclusion" section in its `docs/perf-review/<name>.md`.
 
 **Single source of truth:** the constant
-`NODE_ONLY_CRATES = {argon2, jose, jwt}` is duplicated in four spots
+`NODE_ONLY_CRATES = {argon2, jose, jwt}` is duplicated in six spots
 (`.claude/skills/audit-crates/scripts/audit.mjs`,
-`scripts/sync-registry.mjs`, `.github/workflows/ci.yml`,
+`scripts/sync-registry.mjs`, `scripts/build-all-wasm.mjs`,
+`scripts/scaffold-wasm-bench.mjs`, `.github/workflows/ci.yml`,
 `.github/workflows/release.yml`). To add or remove a crate, edit all
-four together. The `audit-crates` skill verifies the invariants:
+six together. The `audit-crates` skill verifies the invariants:
 Node-only crates must NOT have a `wasm/` directory; every other public
 crate must have one.
 

--- a/scripts/new-package.sh
+++ b/scripts/new-package.sh
@@ -14,32 +14,49 @@ if [[ ! "$NAME" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
   exit 1
 fi
 
+# wasm-pack emits underscored filenames (amigo-pdf-parse-wasm →
+# amigo_pdf_parse_wasm.js) and Rust paths underscore dashes too
+# (amigo_<name>_core::). Same character set as $NAME, so safe in sed.
+NAME_UNDERSCORE=${NAME//-/_}
+CORE_DIR="crates/_${NAME}-core"
+
 if [ -d "crates/$NAME" ]; then
   echo "Error: crates/$NAME already exists"
   exit 1
 fi
+if [ -d "$CORE_DIR" ]; then
+  echo "Error: $CORE_DIR already exists"
+  exit 1
+fi
 
 cp -r crates/_template "crates/$NAME"
+# The pure-Rust core scaffold lives nested at _template/core/ (where the
+# workspace globs can't see it) but ships as a sibling crate.
+mv "crates/$NAME/core" "$CORE_DIR"
 
 # Rename template files (recursively across all sub-dirs)
 while IFS= read -r -d '' f; do
   mv "$f" "${f%.tmpl}"
-done < <(find "crates/$NAME" -type f -name "*.tmpl" -print0)
+done < <(find "crates/$NAME" "$CORE_DIR" -type f -name "*.tmpl" -print0)
 
 # Replace template variables in every non-binary file. The validation
 # above ensures `$NAME` contains no sed metacharacters (`/`, `&`, `\`).
 while IFS= read -r -d '' f; do
-  sed -i "s/{{NAME}}/$NAME/g" "$f"
-done < <(find "crates/$NAME" -type f \( -name "*.toml" -o -name "*.json" -o -name "*.rs" -o -name "*.ts" -o -name "*.md" \) -print0)
+  sed -i -e "s/{{NAME}}/$NAME/g" -e "s/{{NAME_UNDERSCORE}}/$NAME_UNDERSCORE/g" "$f"
+done < <(find "crates/$NAME" "$CORE_DIR" -type f \( -name "*.toml" -o -name "*.json" -o -name "*.rs" -o -name "*.ts" -o -name "*.md" \) -print0)
 
-echo "Created crates/$NAME"
-echo "  -> Edit crates/$NAME/src/lib.rs"
-echo "  -> Edit crates/$NAME/Cargo.toml (add dependencies)"
-echo "  -> Edit crates/$NAME/package.json \"amigo\" block (title, description, replaces, competitors)"
+echo "Created crates/$NAME, $CORE_DIR and crates/$NAME/wasm"
+echo "  -> Implement the algorithm in $CORE_DIR/src/lib.rs (single source of truth)"
+echo "  -> Wrap it in crates/$NAME/src/lib.rs (#[napi]) and crates/$NAME/wasm/src/lib.rs (#[wasm_bindgen])"
+echo "  -> Extend crates/$NAME/wasm/tests/web.rs (wasm-bindgen-test parity tests)"
+echo "  -> Edit crates/$NAME/package.json \"amigo\" block (title, category, description, replaces, competitors)"
+echo "  -> Edit crates/$NAME/README.md"
 echo "  -> Edit crates/$NAME/__conformance__/parity.spec.ts (handcrafted invariants)"
 echo "  -> Edit crates/$NAME/__conformance__/upstream.spec.ts (clone upstream tests)"
 echo "  -> Edit crates/$NAME/__conformance__/fuzz.spec.ts (fast-check properties)"
 echo "  -> Edit crates/$NAME/__bench__/index.bench.ts (add benchmarks)"
 echo "  -> Delete crates/$NAME/MIGRATION.md if fully drop-in"
-echo "  -> Run: pnpm install && cd crates/$NAME && pnpm run build"
+echo "  -> Add crates/$NAME/npm/ platform-stub dirs (6 targets — copy from an existing crate; audit-crates checks them)"
+echo "  -> Run: pnpm install && cd crates/$NAME && pnpm run build:all"
+echo "  -> Run: cd crates/$NAME && pnpm run test && pnpm run test:wasm"
 echo "  -> Run: node scripts/sync-registry.mjs  # regenerate docs/packages.json + README table"

--- a/status.md
+++ b/status.md
@@ -38,10 +38,7 @@ cleanup (this file, NODE_ONLY_CRATES place count).
    crate and grep the file list for the expected `wasm/pkg/*` entries.
    Catches the case where `prepublishOnly` doesn't run (e.g. local
    `npm pack`) and the tarball ships without the WASM artifact.
-2. **Dashboard `targets` filter facet** in the web UI: the per-package
-   `TargetsPill` badge exists; add a "browser-compatible" vs. "node-only"
-   filter so consumers see the boundary at a glance.
-3. **Regenerate stale checked-in napi loaders**: a local `napi build` of
+2. **Regenerate stale checked-in napi loaders**: a local `napi build` of
    csv/xlsx shows the committed `native.cjs` / `.d.ts` files lag the
    current source (version-check strings, removed doc comments). Needs a
    full `pnpm build` across all 36 packages and one sweeping commit

--- a/status.md
+++ b/status.md
@@ -3,55 +3,20 @@
 Working dashboard. Source of truth for "what is in flight, what was just shipped,
 what to pick up next." Updated as work moves.
 
-> **Last updated:** 2026-05-17
-> **Active branch:** `claude/convert-packages-wasm-RZd3b`
-> **Active PR:** [#134 — feat: ship WASM bindings for all eligible crates (draft)](https://github.com/amigo-labs/amigo-native/pull/134)
+> **Last updated:** 2026-06-10
+> **Active branch:** `claude/deep-fixup-v7j8ey` (deep-fixup session)
 
 ---
 
 ## In flight
 
-### Dual-target (Node + Browser) expansion — scope widened to all eligible crates
+### Deep-fixup session (2026-06-10)
 
-Take the napi-only crate family to dual-target by shipping
-`wasm-bindgen` companions in the same npm packages via conditional
-exports. Scope: **33 of 36 public crates**; the remaining 3 form a
-formal **Node.js server-only tier** (`argon2`, `jose`, `jwt`) that
-intentionally stays napi-only. Full plan in
-[`docs/specs/expansion-2026.md`](docs/specs/expansion-2026.md)
-(updated 2026-05-17).
-
-- [x] Spec drafted and revised against the real 36-crate workspace
-- [x] Architecture decisions D1–D6 locked in (see spec § Decisions)
-- [x] **Pilot: slugify** — Phase 1 (core/napi split) and Phase 2
-      (WASM binding inside the same npm package) end-to-end. All
-      acceptance gates green. Bench: WASM 2–3× faster than JS
-      `slugify`, 246 KB gzipped unoptimized (~80–120 KB after
-      `wasm-opt -Oz`).
-- [x] **Foundation landed on PR #134**: workspace `[workspace.dependencies]`
-      for wasm-bindgen / wasm-bindgen-test / serde-wasm-bindgen / js-sys;
-      `ci.yml` gains `wasm-test` (per-crate `wasm-pack test --node`) +
-      `bundle-size` (warn-only per D2) jobs; `release.yml` builds the
-      in-tarball wasm/pkg/ artifact via `wasm-pack` + `wasm-opt -Oz`
-      before `npm publish`; `scripts/sync-registry.mjs` propagates
-      `amigo.targets` into `docs/packages.json`; audit-crates skill
-      enforces the dual-target / Node-only invariants via a single
-      `NODE_ONLY_CRATES = {argon2, jose, jwt}` constant.
-- [x] **Node.js server-only tier landed**: argon2 / jose / jwt carry
-      `targets: ["node"]` and have WASM-target exclusion sections in
-      their perf-review docs.
-- [x] **Batch 1 — pure-string crates (in progress)**: deepmerge,
-      language-detect, stemmer, sentences, linkify-it, diff shipped
-      core split + wasm sub-crate. Remaining: tldts, turndown.
-- [ ] **Batch 2 — buffer crates** (xxhash, csv, encoding, file-type,
-      inflate, pixelmatch, pngjs, jpeg-js, svgo)
-- [ ] **Batch 3 — option-heavy + classes** (commonmark, minisearch,
-      bm25, fuse, sanitize-html, force-layout, graph-layout)
-- [ ] **Edge cases** (zstd via ruzstd fallback, text-splitters minus
-      tiktoken on wasm32, zip, jimp, pdf, pdf-parse, xlsx, typst)
-- [ ] README "Install for the browser" subsection per shipping crate
-- [ ] Dashboard surface: `targets` facet in the docs/packages.json
-      consumer-facing dashboard
+Repo-wide analyze → fix pass; session record in `PLAN.md` on the branch.
+Bug fixes (csv option truncation, xlsx column wraparound), the
+`new-package.sh` template brought up to the dual-target convention,
+the last 8 "Install for the browser" README sections, and doc-drift
+cleanup (this file, NODE_ONLY_CRATES place count).
 
 ---
 
@@ -59,40 +24,28 @@ intentionally stays napi-only. Full plan in
 
 | Date       | What                                                                      |
 | :--------- | :------------------------------------------------------------------------ |
-| 2026-05-17 | Batch 1 in-progress: WASM bindings for `deepmerge`, `language-detect`, `stemmer`, `sentences`, `linkify-it`, `diff` (PR #134) |
+| 2026-05-28 | WASM benchmark coverage completed across crates; benchmarks regenerated (PR #151) |
+| 2026-05-17 | **Dual-target expansion complete**: WASM bindings shipped for all 33 eligible crates — Batches 1–3 and all edge cases (zstd decompress-only via ruzstd, text-splitters minus tiktoken, zip, jimp, pdf, pdf-parse, xlsx, typst) (PR #134) |
 | 2026-05-17 | Foundation: workspace deps, CI wasm-test + bundle-size jobs, release.yml WASM build step, audit-crates WASM checks (PR #134) |
 | 2026-05-17 | Node.js server-only tier formalized: `argon2`, `jose`, `jwt` carry `targets: ["node"]` (PR #134) |
 | 2026-05-17 | `expansion-2026.md` updated: scope widened from 9-crate shortlist to 33-crate dual-target tier + 3-crate Node-only tier |
-| 2026-05-15 | `status.md` introduced as the working dashboard                           |
-| 2026-05-15 | Fix: `index.js` version drift across 26 crates (`69116f5`)                |
-| 2026-05-15 | Pilot: slugify dual-target — core/napi split + WASM binding (`53a582c`)   |
 
 ---
 
 ## Next up — pick from the top
 
-1. **Finish Batch 1**: `tldts`, `turndown` (last two pure-string crates).
-2. **Batch 2 — buffer crates**: start with `xxhash` (smallest API, closes
-   Q1 SIMD question once benched) and `inflate` (validates the
-   `flate2`/`zlib-rs` wasm32-portable backend). Then `csv`, `encoding`,
-   `file-type`, `pixelmatch`, `pngjs`, `jpeg-js`, `svgo`.
-3. **Batch 3 — option-heavy + classes**: `commonmark`, `minisearch`,
-   `bm25`, `fuse`, `sanitize-html` (first real bundle-budget stress test
-   — `ammonia` + `html5ever` ~200–400 KB gz), `force-layout`,
-   `graph-layout`.
-4. **Edge cases** — `zstd` needs a `ruzstd` fallback for the WASM build
-   because `zstd-sys` doesn't build for `wasm32-unknown-unknown`;
-   compress / `trainDictionary` throw "not available in WASM build".
-   `text-splitters` excludes tiktoken-rs on wasm32 (BPE tables ~1.5 MB).
-   The bundle-heavy crates (`zip`, `jimp`, `pdf`, `pdf-parse`, `xlsx`,
-   `typst`) ship with a "consider lazy import" README note.
-5. **`pack-verify` CI step**: run `pnpm pack --dry-run` per dual-target
+1. **`pack-verify` CI step**: run `pnpm pack --dry-run` per dual-target
    crate and grep the file list for the expected `wasm/pkg/*` entries.
    Catches the case where `prepublishOnly` doesn't run (e.g. local
    `npm pack`) and the tarball ships without the WASM artifact.
-6. **Dashboard `targets` facet** in `docs/packages.json` UI: filter
-   for "browser-compatible" vs. "node-only" so consumers see the
-   boundary at a glance.
+2. **Dashboard `targets` filter facet** in the web UI: the per-package
+   `TargetsPill` badge exists; add a "browser-compatible" vs. "node-only"
+   filter so consumers see the boundary at a glance.
+3. **Regenerate stale checked-in napi loaders**: a local `napi build` of
+   csv/xlsx shows the committed `native.cjs` / `.d.ts` files lag the
+   current source (version-check strings, removed doc comments). Needs a
+   full `pnpm build` across all 36 packages and one sweeping commit
+   (cf. `69116f5`, the earlier index.js version-drift fix).
 
 ---
 
@@ -102,19 +55,11 @@ Non-blocking — defer until the relevant implementation PR.
 
 | ID   | Question                                                                       | Resolve in                          |
 | :--- | :----------------------------------------------------------------------------- | :---------------------------------- |
-| Q1   | `xxhash` WASM: target `+simd128` by default, ship two variants, or skip SIMD?  | `xxhash` Phase 2 PR (with benchmarks) |
-| Q2   | `commonmark` WASM README: exact XSS-warning wording, dashboard surface?        | `commonmark` Phase 2 PR             |
+| Q1   | `xxhash` WASM: target `+simd128` by default, ship two variants, or skip SIMD?  | A future `xxhash` perf PR (shipped without SIMD for now) |
 
 Resolved decisions are in [`docs/specs/expansion-2026.md`](docs/specs/expansion-2026.md) § Decisions.
-
----
-
-## Things deliberately not touched yet
-
-- `CLAUDE.md` — conventions live in the spec; CLAUDE.md stays minimal
-- `README.md` tagline — keep "Rust-powered npm packages" until WASM
-  ships in a non-pilot crate
-- `BACKLOG.md` — open items tracked here, not duplicated
+Q2 (commonmark XSS-warning wording) was resolved in the shipped
+`crates/commonmark/README.md` § Safety section.
 
 ---
 


### PR DESCRIPTION
Single-session analyze → plan → execute pass over the repo. The session record (baseline, verified findings, task list with verification steps) is in `PLAN.md`.

## Bug fixes

- **T1 (csv)**: `delimiter` / `quoteChar` / `escapeChar` / `comment` arrived from JS as `u32` and were cast `as u8`, silently wrapping values > 255 (`{delimiter: 256}` became a NUL-byte delimiter). The core now validates with `u8::try_from` and returns a descriptive error from every parse/stringify entry point. Core unit tests added; csv vitest (12) + conformance (40) suites pass.
- **T2 (xlsx)**: `write_workbook` cast cell indexes with `as u16`/`as u32`; a row with > 65,535 cells wrapped the column index back into the valid range (reachable below rust_xlsxwriter's own 16,384-column check via skipped-kind cells), silently writing data into the wrong columns. Checked conversions + descriptive error; core unit tests added.

## DX

- **T3**: `crates/_template` + `scripts/new-package.sh` predated the core-split / dual-target conventions — new packages scaffolded without the pure-Rust core, the `wasm/` sub-crate, or the browser `package.json` fields. The generator now scaffolds all three crates (verified end-to-end with a scratch package: all three compile, core test passes). CONTRIBUTING reworded accordingly.

## Docs

- **T4**: "Install for the browser" README section added to the last 8 of 33 dual-target crates (open `status.md` checkbox); `docs/readmes/*.html` regenerated, `--check` passes.
- **T5**: `status.md` rewritten — it still described PR #134 mid-flight although the WASM expansion fully shipped on 2026-05-17.
- **T6**: `NODE_ONLY_CRATES` duplication count corrected from four to six places in four docs.

## Verification

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, oxlint, `render-readmes.mjs --check`, and `sync-registry.mjs` idempotency — all green (also green at baseline before changes, except the items fixed here).

Noted but deliberately parked (see `PLAN.md` § Not this session): stale checked-in generated napi loaders across crates, pack-verify CI step, dashboard targets filter facet.

https://claude.ai/code/session_01WsmniE8Qat7VoJp4bGYnrY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsmniE8Qat7VoJp4bGYnrY)_